### PR TITLE
add tesserae to 'i2c' group as well

### DIFF
--- a/scripts/pi-client-cloud-init.yaml
+++ b/scripts/pi-client-cloud-init.yaml
@@ -70,6 +70,7 @@ users:
     groups:
       - sudo
       - gpio
+      - i2c
       - spi
     sudo:
       - "ALL=(ALL) NOPASSWD:ALL"


### PR DESCRIPTION
## What this changes

As the title says. I had to add the tesserae user to `i2c`, otherwise reading of the EEPROM on the Inky-4 failed.