### PR TITLE
Fix calendar timezone and all-day date handling

### DIFF
--- a/app/calendar_time.py
+++ b/app/calendar_time.py
@@ -4,40 +4,6 @@ from __future__ import annotations
 
 from datetime import UTC, date, datetime, time, timedelta, tzinfo
 from typing import Any
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
-
-from flask import current_app
-
-from app.tz_resolve import _resolve_iana_timezone
-
-
-def calendar_timezone() -> tzinfo:
-    """Return the timezone calendar widgets should use for date boundaries.
-
-    Rendering already forwards ``settings.app.timezone`` to Chromium so
-    client-side ``new Date()`` uses the configured zone. Calendar server-side
-    fetchers also need the same zone for "today", visible week/month windows,
-    and event date buckets.
-    """
-    raw = "system"
-    try:
-        store = current_app.config.get("SETTINGS_STORE")
-        if store is not None:
-            raw = str((store.get_section("app") or {}).get("timezone") or "system").strip()
-    except Exception:
-        raw = "system"
-
-    if raw and raw.lower() != "system":
-        try:
-            return ZoneInfo(raw)
-        except ZoneInfoNotFoundError:
-            pass
-
-    resolved = _resolve_iana_timezone("system")
-    if resolved:
-        return ZoneInfo(resolved)
-
-    return datetime.now().astimezone().tzinfo or UTC
 
 
 def local_midnight_utc(day: date, zone: tzinfo) -> datetime:

--- a/app/calendar_time.py
+++ b/app/calendar_time.py
@@ -1,0 +1,61 @@
+"""Timezone helpers shared by the calendar widgets."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime, time, tzinfo
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from flask import current_app
+
+from app.tz_resolve import _resolve_iana_timezone
+
+
+def calendar_timezone() -> tzinfo:
+    """Return the timezone calendar widgets should use for date boundaries.
+
+    Rendering already forwards ``settings.app.timezone`` to Chromium so
+    client-side ``new Date()`` uses the configured zone. Calendar server-side
+    fetchers also need the same zone for "today", visible week/month windows,
+    and event date buckets.
+    """
+    raw = "system"
+    try:
+        store = current_app.config.get("SETTINGS_STORE")
+        if store is not None:
+            raw = str((store.get_section("app") or {}).get("timezone") or "system").strip()
+    except Exception:
+        raw = "system"
+
+    if raw and raw.lower() != "system":
+        try:
+            return ZoneInfo(raw)
+        except ZoneInfoNotFoundError:
+            pass
+
+    resolved = _resolve_iana_timezone("system")
+    if resolved:
+        return ZoneInfo(resolved)
+
+    return datetime.now().astimezone().tzinfo or UTC
+
+
+def local_midnight_utc(day: date, zone: tzinfo) -> datetime:
+    """Return local midnight for ``day`` converted to UTC."""
+    return datetime.combine(day, time.min, tzinfo=zone).astimezone(UTC)
+
+
+def event_local_date_key(event: dict[str, Any], zone: tzinfo) -> str:
+    """Bucket a calendar event by the date a user sees in ``zone``."""
+    start = str(event.get("start") or "")
+    if not start:
+        return ""
+    if event.get("all_day") or "T" not in start:
+        return start.split("T")[0]
+    try:
+        parsed = datetime.fromisoformat(start)
+    except ValueError:
+        return start.split("T")[0]
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(zone).date().isoformat()

--- a/app/calendar_time.py
+++ b/app/calendar_time.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime, time, tzinfo
+from datetime import UTC, date, datetime, time, timedelta, tzinfo
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -59,3 +59,56 @@ def event_local_date_key(event: dict[str, Any], zone: tzinfo) -> str:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=UTC)
     return parsed.astimezone(zone).date().isoformat()
+
+
+def _all_day_bounds(event: dict[str, Any]) -> tuple[date, date] | None:
+    start_raw = str(event.get("start") or "")
+    if not start_raw:
+        return None
+    try:
+        start = date.fromisoformat(start_raw.split("T")[0])
+    except ValueError:
+        return None
+
+    end_raw = str(event.get("end") or "")
+    if end_raw:
+        try:
+            end = date.fromisoformat(end_raw.split("T")[0])
+        except ValueError:
+            end = start + timedelta(days=1)
+    else:
+        end = start + timedelta(days=1)
+
+    if end <= start:
+        end = start + timedelta(days=1)
+    return start, end
+
+
+def all_day_event_overlaps_date(event: dict[str, Any], target: date) -> bool:
+    """Return whether an all-day event covers ``target``.
+
+    iCalendar date-only ``DTEND`` values are exclusive, so an event with
+    start=2026-07-04 and end=2026-07-05 belongs only to July 4.
+    """
+    bounds = _all_day_bounds(event)
+    if bounds is None:
+        return False
+    start, end = bounds
+    return start <= target < end
+
+
+def all_day_event_date_keys(
+    event: dict[str, Any], window_start: date, window_end: date
+) -> list[str]:
+    """Return local date keys an all-day event occupies inside ``[start, end)``."""
+    bounds = _all_day_bounds(event)
+    if bounds is None:
+        return []
+    start, end = bounds
+    cur = max(start, window_start)
+    stop = min(end, window_end)
+    keys: list[str] = []
+    while cur < stop:
+        keys.append(cur.isoformat())
+        cur += timedelta(days=1)
+    return keys

--- a/plugins/calendar_day/server.py
+++ b/plugins/calendar_day/server.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from flask import current_app
 
-from app.calendar_time import calendar_timezone
+from app.calendar_time import all_day_event_overlaps_date, calendar_timezone
 
 
 def _parse_feeds_filter(s: str) -> list[str] | None:
@@ -45,6 +45,10 @@ def fetch(
     except Exception as err:
         return {"error": f"{type(err).__name__}: {err}", "events": []}
 
+    target_date = now_local.date()
+    visible_events = [
+        e for e in events if not e.get("all_day") or all_day_event_overlaps_date(e, target_date)
+    ]
     slim = [
         {
             "summary": e["summary"],
@@ -55,7 +59,7 @@ def fetch(
             "colour": e.get("feed_colour"),
             "feed": e.get("feed_name"),
         }
-        for e in events
+        for e in visible_events
     ]
     if max_events > 0:
         slim = slim[:max_events]

--- a/plugins/calendar_day/server.py
+++ b/plugins/calendar_day/server.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from flask import current_app
 
+from app.calendar_time import calendar_timezone
+
 
 def _parse_feeds_filter(s: str) -> list[str] | None:
     s = (s or "").strip()
@@ -29,7 +31,9 @@ def fetch(
     max_events = int(options.get("max_events") or 0)
     feeds_filter = _parse_feeds_filter(options.get("feeds_filter") or "")
 
-    now = datetime.now(UTC)
+    zone = calendar_timezone()
+    now_local = datetime.now(zone)
+    now = now_local.astimezone(UTC)
     end = now + timedelta(hours=hours_ahead)
     try:
         events = core.server_module.load_events(
@@ -56,8 +60,8 @@ def fetch(
     if max_events > 0:
         slim = slim[:max_events]
     return {
-        "now": now.isoformat(),
-        "date": now.date().isoformat(),
+        "now": now_local.isoformat(),
+        "date": now_local.date().isoformat(),
         "events": slim,
         "count": len(slim),
     }

--- a/plugins/calendar_day/server.py
+++ b/plugins/calendar_day/server.py
@@ -8,7 +8,8 @@ from typing import Any
 
 from flask import current_app
 
-from app.calendar_time import all_day_event_overlaps_date, calendar_timezone
+from app.calendar_time import all_day_event_overlaps_date
+from app.tz_resolve import app_timezone
 
 
 def _parse_feeds_filter(s: str) -> list[str] | None:
@@ -31,7 +32,7 @@ def fetch(
     max_events = int(options.get("max_events") or 0)
     feeds_filter = _parse_feeds_filter(options.get("feeds_filter") or "")
 
-    zone = calendar_timezone()
+    zone = app_timezone()
     now_local = datetime.now(zone)
     now = now_local.astimezone(UTC)
     end = now + timedelta(hours=hours_ahead)

--- a/plugins/calendar_month/server.py
+++ b/plugins/calendar_month/server.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import calendar as cal_mod
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 from flask import current_app
+
+from app.calendar_time import calendar_timezone, event_local_date_key, local_midnight_utc
 
 
 def _parse_feeds_filter(s: str) -> list[str] | None:
@@ -26,7 +28,8 @@ def fetch(
     if core is None or core.server_module is None:
         return {"error": "calendar_core plugin not installed.", "days": []}
 
-    today = datetime.now(UTC).date()
+    zone = calendar_timezone()
+    today = datetime.now(zone).date()
     week_start = options.get("week_start", "monday")
     feeds_filter = _parse_feeds_filter(options.get("feeds_filter") or "")
     max_per_day = int(options.get("max_events_per_day") or 3)
@@ -39,8 +42,8 @@ def fetch(
     grid_start = first_of_month - timedelta(days=offset)
     grid_end = grid_start + timedelta(days=42)
 
-    start_dt = datetime.combine(grid_start, datetime.min.time(), tzinfo=UTC)
-    end_dt = datetime.combine(grid_end, datetime.min.time(), tzinfo=UTC)
+    start_dt = local_midnight_utc(grid_start, zone)
+    end_dt = local_midnight_utc(grid_end, zone)
     try:
         events = core.server_module.load_events(
             feeds_filter,
@@ -54,12 +57,7 @@ def fetch(
     # Bucket events by local date (event start date)
     buckets: dict[str, list[dict[str, Any]]] = {}
     for ev in events:
-        # Derive a date key from the start ISO. All-day events have a
-        # plain YYYY-MM-DD; timed events have a UTC ISO, we'll let
-        # the client localise the time; for date-bucketing we use the
-        # UTC date as a stable key.
-        s = ev["start"]
-        day_key = s.split("T")[0] if "T" in s else s
+        day_key = event_local_date_key(ev, zone)
         buckets.setdefault(day_key, []).append(ev)
 
     days = []

--- a/plugins/calendar_month/server.py
+++ b/plugins/calendar_month/server.py
@@ -11,10 +11,10 @@ from flask import current_app
 
 from app.calendar_time import (
     all_day_event_date_keys,
-    calendar_timezone,
     event_local_date_key,
     local_midnight_utc,
 )
+from app.tz_resolve import app_timezone
 
 
 def _parse_feeds_filter(s: str) -> list[str] | None:
@@ -33,7 +33,7 @@ def fetch(
     if core is None or core.server_module is None:
         return {"error": "calendar_core plugin not installed.", "days": []}
 
-    zone = calendar_timezone()
+    zone = app_timezone()
     today = datetime.now(zone).date()
     week_start = options.get("week_start", "monday")
     feeds_filter = _parse_feeds_filter(options.get("feeds_filter") or "")

--- a/plugins/calendar_month/server.py
+++ b/plugins/calendar_month/server.py
@@ -9,7 +9,12 @@ from typing import Any
 
 from flask import current_app
 
-from app.calendar_time import calendar_timezone, event_local_date_key, local_midnight_utc
+from app.calendar_time import (
+    all_day_event_date_keys,
+    calendar_timezone,
+    event_local_date_key,
+    local_midnight_utc,
+)
 
 
 def _parse_feeds_filter(s: str) -> list[str] | None:
@@ -54,11 +59,16 @@ def fetch(
     except Exception as err:
         return {"error": f"{type(err).__name__}: {err}", "days": []}
 
-    # Bucket events by local date (event start date)
+    # Bucket timed events by their local start date. All-day event DTEND values
+    # are exclusive, so expand them across each covered visible date.
     buckets: dict[str, list[dict[str, Any]]] = {}
     for ev in events:
-        day_key = event_local_date_key(ev, zone)
-        buckets.setdefault(day_key, []).append(ev)
+        if ev.get("all_day"):
+            day_keys = all_day_event_date_keys(ev, grid_start, grid_end)
+        else:
+            day_keys = [event_local_date_key(ev, zone)]
+        for day_key in day_keys:
+            buckets.setdefault(day_key, []).append(ev)
 
     days = []
     cur = grid_start

--- a/plugins/calendar_week/server.py
+++ b/plugins/calendar_week/server.py
@@ -8,7 +8,8 @@ from typing import Any
 
 from flask import current_app
 
-from app.calendar_time import calendar_timezone, event_local_date_key, local_midnight_utc
+from app.calendar_time import event_local_date_key, local_midnight_utc
+from app.tz_resolve import app_timezone
 
 
 def _parse_feeds_filter(s: str) -> list[str] | None:
@@ -27,7 +28,7 @@ def fetch(
     if core is None or core.server_module is None:
         return {"error": "calendar_core plugin not installed.", "days": []}
 
-    zone = calendar_timezone()
+    zone = app_timezone()
     today = datetime.now(zone).date()
     week_start = options.get("week_start", "monday")
     first_weekday = 6 if week_start == "sunday" else 0

--- a/plugins/calendar_week/server.py
+++ b/plugins/calendar_week/server.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 from flask import current_app
+
+from app.calendar_time import calendar_timezone, event_local_date_key, local_midnight_utc
 
 
 def _parse_feeds_filter(s: str) -> list[str] | None:
@@ -25,7 +27,8 @@ def fetch(
     if core is None or core.server_module is None:
         return {"error": "calendar_core plugin not installed.", "days": []}
 
-    today = datetime.now(UTC).date()
+    zone = calendar_timezone()
+    today = datetime.now(zone).date()
     week_start = options.get("week_start", "monday")
     first_weekday = 6 if week_start == "sunday" else 0
     # Start the week on the chosen weekday at-or-before today.
@@ -33,8 +36,8 @@ def fetch(
     start_date = today - timedelta(days=offset)
     end_date = start_date + timedelta(days=7)
 
-    start_dt = datetime.combine(start_date, datetime.min.time(), tzinfo=UTC)
-    end_dt = datetime.combine(end_date, datetime.min.time(), tzinfo=UTC)
+    start_dt = local_midnight_utc(start_date, zone)
+    end_dt = local_midnight_utc(end_date, zone)
 
     feeds_filter = _parse_feeds_filter(options.get("feeds_filter") or "")
     try:
@@ -49,8 +52,7 @@ def fetch(
 
     buckets: dict[str, list[dict[str, Any]]] = {}
     for ev in events:
-        s = ev["start"]
-        day_key = s.split("T")[0] if "T" in s else s
+        day_key = event_local_date_key(ev, zone)
         buckets.setdefault(day_key, []).append(ev)
 
     days = []

--- a/tests/test_calendar_widget_timezone.py
+++ b/tests/test_calendar_widget_timezone.py
@@ -1,0 +1,140 @@
+"""Calendar widgets should calculate visible dates in the configured app timezone."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from flask import Flask
+
+
+def _freeze_datetime(instant: datetime) -> type[datetime]:
+    class FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz: Any = None) -> datetime:
+            if tz is None:
+                return instant.replace(tzinfo=None)
+            return instant.astimezone(tz)
+
+    return FrozenDateTime
+
+
+def _plugin(app: Flask, plugin_id: str) -> Any:
+    plugin = app.config["PLUGIN_REGISTRY"].get(plugin_id)
+    assert plugin is not None and plugin.server_module is not None
+    return plugin.server_module
+
+
+def _core_plugin(app: Flask) -> Any:
+    core = app.config["PLUGIN_REGISTRY"].get("calendar_core")
+    assert core is not None and core.server_module is not None
+    return core
+
+
+def test_calendar_day_uses_app_timezone_for_display_date(
+    app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    day = _plugin(app, "calendar_day")
+    core = _core_plugin(app)
+    app.config["SETTINGS_STORE"].update_section("app", {"timezone": "Asia/Hong_Kong"})
+    frozen = datetime(2026, 7, 4, 18, 30, tzinfo=UTC)
+    captured: dict[str, datetime] = {}
+
+    def load_events(
+        _feeds_filter: list[str] | None,
+        start: datetime,
+        end: datetime,
+        *,
+        data_dir: Any,
+    ) -> list[dict[str, Any]]:
+        del data_dir
+        captured["start"] = start
+        captured["end"] = end
+        return []
+
+    monkeypatch.setattr(day, "datetime", _freeze_datetime(frozen))
+    monkeypatch.setattr(core.server_module, "load_events", load_events)
+
+    with app.app_context():
+        out = day.fetch({"hours_ahead": 24}, {}, ctx={})
+
+    assert out["date"] == "2026-07-05"
+    assert captured["start"] == frozen
+    assert captured["end"] == datetime(2026, 7, 5, 18, 30, tzinfo=UTC)
+
+
+def test_calendar_week_uses_local_week_and_buckets_timed_events_by_local_date(
+    app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    week = _plugin(app, "calendar_week")
+    core = _core_plugin(app)
+    app.config["SETTINGS_STORE"].update_section("app", {"timezone": "Asia/Hong_Kong"})
+    frozen = datetime(2026, 7, 4, 18, 30, tzinfo=UTC)
+    captured: dict[str, datetime] = {}
+
+    def load_events(
+        _feeds_filter: list[str] | None,
+        start: datetime,
+        end: datetime,
+        *,
+        data_dir: Any,
+    ) -> list[dict[str, Any]]:
+        del data_dir
+        captured["start"] = start
+        captured["end"] = end
+        return [
+            {
+                "summary": "Late event",
+                "start": "2026-07-04T17:30:00+00:00",
+                "end": "2026-07-04T18:30:00+00:00",
+                "all_day": False,
+                "feed_colour": "#0d8c7e",
+            }
+        ]
+
+    monkeypatch.setattr(week, "datetime", _freeze_datetime(frozen))
+    monkeypatch.setattr(core.server_module, "load_events", load_events)
+
+    with app.app_context():
+        out = week.fetch({"week_start": "sunday"}, {}, ctx={})
+
+    assert out["start"] == "2026-07-05"
+    assert out["end"] == "2026-07-11"
+    assert captured["start"] == datetime(2026, 7, 4, 16, 0, tzinfo=UTC)
+    assert captured["end"] == datetime(2026, 7, 11, 16, 0, tzinfo=UTC)
+    assert out["days"][0]["date"] == "2026-07-05"
+    assert out["days"][0]["is_today"] is True
+    assert out["days"][0]["events"][0]["summary"] == "Late event"
+
+
+def test_calendar_month_uses_local_month(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    month = _plugin(app, "calendar_month")
+    core = _core_plugin(app)
+    app.config["SETTINGS_STORE"].update_section("app", {"timezone": "Asia/Hong_Kong"})
+    frozen = datetime(2026, 6, 30, 17, 0, tzinfo=UTC)
+    captured: dict[str, datetime] = {}
+
+    def load_events(
+        _feeds_filter: list[str] | None,
+        start: datetime,
+        end: datetime,
+        *,
+        data_dir: Any,
+    ) -> list[dict[str, Any]]:
+        del data_dir
+        captured["start"] = start
+        captured["end"] = end
+        return []
+
+    monkeypatch.setattr(month, "datetime", _freeze_datetime(frozen))
+    monkeypatch.setattr(core.server_module, "load_events", load_events)
+
+    with app.app_context():
+        out = month.fetch({}, {}, ctx={})
+
+    assert out["month"] == 7
+    assert out["year"] == 2026
+    assert out["month_name"] == "July"
+    assert captured["start"] == datetime(2026, 6, 28, 16, 0, tzinfo=UTC)
+    assert captured["end"] == datetime(2026, 8, 9, 16, 0, tzinfo=UTC)

--- a/tests/test_calendar_widget_timezone.py
+++ b/tests/test_calendar_widget_timezone.py
@@ -64,6 +64,56 @@ def test_calendar_day_uses_app_timezone_for_display_date(
     assert captured["end"] == datetime(2026, 7, 5, 18, 30, tzinfo=UTC)
 
 
+def test_calendar_day_filters_all_day_events_to_the_local_date(
+    app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    day = _plugin(app, "calendar_day")
+    core = _core_plugin(app)
+    app.config["SETTINGS_STORE"].update_section("app", {"timezone": "Asia/Hong_Kong"})
+    frozen = datetime(2026, 7, 4, 19, 10, tzinfo=UTC)
+
+    def load_events(
+        _feeds_filter: list[str] | None,
+        _start: datetime,
+        _end: datetime,
+        *,
+        data_dir: Any,
+    ) -> list[dict[str, Any]]:
+        del data_dir
+        return [
+            {
+                "summary": "Yesterday",
+                "start": "2026-07-04",
+                "end": "2026-07-05",
+                "all_day": True,
+                "feed_colour": "#0d8c7e",
+            },
+            {
+                "summary": "Today",
+                "start": "2026-07-05",
+                "end": "2026-07-06",
+                "all_day": True,
+                "feed_colour": "#0d8c7e",
+            },
+            {
+                "summary": "Spanning",
+                "start": "2026-07-04",
+                "end": "2026-07-06",
+                "all_day": True,
+                "feed_colour": "#0d8c7e",
+            },
+        ]
+
+    monkeypatch.setattr(day, "datetime", _freeze_datetime(frozen))
+    monkeypatch.setattr(core.server_module, "load_events", load_events)
+
+    with app.app_context():
+        out = day.fetch({"hours_ahead": 24}, {}, ctx={})
+
+    assert out["date"] == "2026-07-05"
+    assert [event["summary"] for event in out["events"]] == ["Today", "Spanning"]
+
+
 def test_calendar_week_uses_local_week_and_buckets_timed_events_by_local_date(
     app: Flask, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -138,3 +188,44 @@ def test_calendar_month_uses_local_month(app: Flask, monkeypatch: pytest.MonkeyP
     assert out["month_name"] == "July"
     assert captured["start"] == datetime(2026, 6, 28, 16, 0, tzinfo=UTC)
     assert captured["end"] == datetime(2026, 8, 9, 16, 0, tzinfo=UTC)
+
+
+def test_calendar_month_expands_all_day_events_across_visible_dates(
+    app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    month = _plugin(app, "calendar_month")
+    core = _core_plugin(app)
+    app.config["SETTINGS_STORE"].update_section("app", {"timezone": "Asia/Hong_Kong"})
+    frozen = datetime(2026, 7, 5, 10, 0, tzinfo=UTC)
+
+    def load_events(
+        _feeds_filter: list[str] | None,
+        _start: datetime,
+        _end: datetime,
+        *,
+        data_dir: Any,
+    ) -> list[dict[str, Any]]:
+        del data_dir
+        return [
+            {
+                "summary": "Long weekend",
+                "start": "2026-07-04",
+                "end": "2026-07-07",
+                "all_day": True,
+                "feed_colour": "#0d8c7e",
+            }
+        ]
+
+    monkeypatch.setattr(month, "datetime", _freeze_datetime(frozen))
+    monkeypatch.setattr(core.server_module, "load_events", load_events)
+
+    with app.app_context():
+        out = month.fetch({}, {}, ctx={})
+
+    events_by_date = {
+        day["date"]: [event["summary"] for event in day["events"]] for day in out["days"]
+    }
+    assert events_by_date["2026-07-04"] == ["Long weekend"]
+    assert events_by_date["2026-07-05"] == ["Long weekend"]
+    assert events_by_date["2026-07-06"] == ["Long weekend"]
+    assert events_by_date["2026-07-07"] == []


### PR DESCRIPTION
## Summary
- rebase onto current main and reuse the shared `app.tz_resolve.app_timezone()` helper for calendar server-side date calculations
- make calendar day/week/month compute visible dates from settings.app.timezone instead of UTC
- convert local day/week/month boundaries back to UTC before loading iCal events
- bucket timed events by the configured local date so events near midnight appear on the expected day
- filter calendar_day all-day events using iCalendar exclusive DTEND semantics so a previous-day all-day event does not remain visible the next day
- expand calendar_month all-day events across each covered visible date, again treating date-only DTEND as exclusive

## Not addressed
- calendar_week all-day rendering is intentionally left unchanged in this PR. The week client currently skips all_day events in the timetable body; it is unclear whether that is intentional or an omission, and a proper display likely needs a separate all-day row/strip design for the maintainer to weigh in on.

## Tests
- .venv/bin/python -m pytest tests/test_calendar_widget_timezone.py tests/test_renderer_timezone.py tests/test_app_timezone.py -q
- .venv/bin/python -m ruff check app/calendar_time.py plugins/calendar_day/server.py plugins/calendar_week/server.py plugins/calendar_month/server.py tests/test_calendar_widget_timezone.py tests/test_app_timezone.py
- .venv/bin/python -m ruff format --check app/calendar_time.py plugins/calendar_day/server.py plugins/calendar_week/server.py plugins/calendar_month/server.py tests/test_calendar_widget_timezone.py tests/test_app_timezone.py