### PR TITLE
Fix Weather Now current UV metric

### DIFF
--- a/plugins/weather_now/server.py
+++ b/plugins/weather_now/server.py
@@ -86,7 +86,8 @@ def fetch(
         f"?latitude={lat}&longitude={lon}"
         "&current=temperature_2m,weather_code,apparent_temperature,"
         "wind_speed_10m,wind_direction_10m,relative_humidity_2m,is_day,"
-        "dew_point_2m,wind_gusts_10m,cloud_cover,pressure_msl,visibility"
+        "dew_point_2m,wind_gusts_10m,cloud_cover,pressure_msl,visibility,"
+        "uv_index"
         "&daily=temperature_2m_max,temperature_2m_min,"
         "uv_index_max,sunrise,sunset,precipitation_probability_max"
         f"&temperature_unit={temp_unit}"
@@ -122,6 +123,7 @@ def fetch(
 
     speed_unit = "mph" if units == "imperial" else "km/h"
     rain_chance = _first(daily.get("precipitation_probability_max"))
+    uv_index = current.get("uv_index")
 
     # The 8-metric grid the Refined / Geometric / Swiss variants paint.
     # Order is hand-tuned: most-useful first so a 4-cell variant
@@ -129,8 +131,8 @@ def fetch(
     metrics = [
         _metric("Humidity", current.get("relative_humidity_2m"), "%", "humidity", "blue"),
         _metric("Wind", current.get("wind_speed_10m"), speed_unit, "wind", "ink"),
-        _metric("Rain", rain_chance, "%", "rainprob", "blue"),
-        _metric("UV Index", _first(daily.get("uv_index_max")), "", "uv", "yellow"),
+        _metric("Rain (today)", rain_chance, "%", "rainprob", "blue"),
+        _metric("UV Index", uv_index, "", "uv", "yellow"),
         _metric("Pressure", current.get("pressure_msl"), "hPa", "pressure", "ink"),
         _metric("Dew", current.get("dew_point_2m"), "°", "dew", "blue"),
         _metric(
@@ -150,7 +152,7 @@ def fetch(
         "wind_dir": current.get("wind_direction_10m"),
         "code": code,
         "is_day": is_day,
-        "uv": _first(daily.get("uv_index_max")),
+        "uv": uv_index,
         "sunrise": sunrise_iso,
         "sunset": sunset_iso,
         "today_max": _first(daily.get("temperature_2m_max")),

--- a/plugins/weather_now/tests/test_smoke.py
+++ b/plugins/weather_now/tests/test_smoke.py
@@ -9,6 +9,8 @@ from unittest.mock import patch
 import pytest
 from flask.testing import FlaskClient
 
+from plugins.weather_now import server as weather_now_server
+
 _FAKE_PAYLOAD = json.dumps(
     {
         "current": {
@@ -19,6 +21,7 @@ _FAKE_PAYLOAD = json.dumps(
             "wind_direction_10m": 180,
             "relative_humidity_2m": 58,
             "is_day": 1,
+            "uv_index": 2.1,
         },
         "daily": {
             "time": ["2026-06-01"],
@@ -78,3 +81,50 @@ def test_weather_now_location_search_promotes_to_label(client: FlaskClient, size
     body = resp.get_data(as_text=True)
     assert "Berlin" in body
     assert "Melbourne" not in body
+
+
+def test_weather_now_uses_current_uv_and_labels_daily_rain(tmp_path) -> None:
+    """UV is a current condition; rain probability remains today's chance."""
+    payload = {
+        "current": {
+            "temperature_2m": 26.1,
+            "weather_code": 2,
+            "apparent_temperature": 31.2,
+            "wind_speed_10m": 8.8,
+            "wind_direction_10m": 90,
+            "relative_humidity_2m": 91,
+            "is_day": 0,
+            "uv_index": 0.0,
+        },
+        "daily": {
+            "time": ["2026-07-09"],
+            "temperature_2m_max": [31],
+            "temperature_2m_min": [25],
+            "uv_index_max": [9.05],
+            "sunrise": ["2026-07-09T05:45"],
+            "sunset": ["2026-07-09T19:12"],
+            "precipitation_probability_max": [99],
+        },
+    }
+    urls: list[str] = []
+
+    def fake_fetch_json(url: str, **kwargs) -> dict:
+        del kwargs
+        urls.append(url)
+        return payload
+
+    opts = {
+        "latitude": 22.5455,
+        "longitude": 114.0683,
+        "units": "metric",
+        "label": "Home",
+    }
+    with patch.object(weather_now_server, "fetch_json", side_effect=fake_fetch_json):
+        result = weather_now_server.fetch(opts, {}, ctx={"data_dir": tmp_path})
+
+    assert urls and "uv_index" in urls[0].split("&daily=", 1)[0]
+    assert result["uv"] == 0.0
+    metrics = {metric["icon"]: metric for metric in result["metrics"]}
+    assert metrics["uv"]["value"] == 0.0
+    assert metrics["rainprob"]["label"] == "Rain (today)"
+    assert metrics["rainprob"]["value"] == 99


### PR DESCRIPTION
## Summary

- Request `uv_index` in the Open-Meteo `current=` block for `weather_now`.
- Display `UV Index` from `current.uv_index` instead of `daily.uv_index_max`, so night-time UV correctly renders as 0.
- Keep rain probability as the daily max forecast, but relabel it to `Rain (today)` so it no longer reads like a current condition.

Fixes #85.

## Root cause

The Weather Now metric row mixed current conditions (`Humidity`, `Wind`) with daily maximum forecast fields (`Rain`, `UV Index`) under labels that looked current. `UV Index` was especially visible at night because Open-Meteo returned `current.is_day = 0` and `current.uv_index = 0.0`, while the widget displayed `daily.uv_index_max`.

## Tests

- `./.venv/bin/python -m pytest plugins/weather_now/tests/test_smoke.py -q`
- `./.venv/bin/python -m pytest -q`
- `./.venv/bin/ruff check .`
- `./.venv/bin/ruff format --check .`
- `./.venv/bin/python -m mypy app` did not reach project code locally: mypy exited while parsing the installed numpy stub because the repo config targets Python 3.11 and the local numpy stub uses Python 3.12 `type` statement syntax.
