### PR TITLE
Make device binding the delivery model; retire unbound-broadcast

### DIFF
--- a/app/device_timetable.py
+++ b/app/device_timetable.py
@@ -48,6 +48,7 @@ class TimetableEntry:
     days_of_week: list[int]  # 0=Mon..6=Sun
     days_label: str  # human-readable: "Mon-Fri", "Weekends", or "Mon, Wed, Fri"
     enabled: bool
+    wont_send: bool  # page is unbound and the unbound-broadcast opt-in is off: fires nothing
 
 
 def _days_label(dows: list[int]) -> str:
@@ -90,14 +91,16 @@ def timetable_for_device(
     devices: DeviceRegistry,
     pages: PageStore,
     schedules: ScheduleStore,
+    unbound_broadcast: bool = False,
 ) -> list[TimetableEntry]:
     """Compute the rotation timetable for one device.
 
     The join is: pages whose ``device_ids`` include this device →
     schedules whose ``page_id`` matches one of those pages → one
-    TimetableEntry per schedule. Pages bound to no device at all (the
-    virtual-panel fan-out path) are also included on every device -
-    they fire everywhere, so they belong on every device's timetable.
+    TimetableEntry per schedule. Pages bound to no device at all are
+    still listed on every device's timetable, but unless
+    ``unbound_broadcast`` is on they no longer deliver anywhere (#84);
+    such entries are flagged ``wont_send`` so the card can warn.
 
     Returns entries sorted by window start so a glance at the card
     reads as a daily timetable."""
@@ -119,6 +122,7 @@ def timetable_for_device(
             continue
         bound_page = pages_by_id.get(schedule.page_id)
         page_name = bound_page.name if bound_page else schedule.page_id
+        page_unbound = bool(bound_page) and not bound_page.device_ids
         entries.append(
             TimetableEntry(
                 schedule_id=schedule.id,
@@ -132,6 +136,7 @@ def timetable_for_device(
                 days_of_week=list(schedule.days_of_week),
                 days_label=_days_label(list(schedule.days_of_week)),
                 enabled=schedule.enabled,
+                wont_send=page_unbound and not unbound_broadcast,
             )
         )
 

--- a/app/push.py
+++ b/app/push.py
@@ -168,8 +168,22 @@ def _page_needs_per_device_render(page: Any) -> bool:
 
 logger = logging.getLogger(__name__)
 
+
+def _unbound_broadcast_enabled(settings: Any) -> bool:
+    """True when the legacy 'an unbound Send broadcasts to every base
+    renderer' path is explicitly opted into (single-head MQTT setups
+    that never bind a device). Off by default: binding is the delivery
+    model, so an unbound Send no-ops instead of broadcasting."""
+    value = (settings.get_section("app") or {}).get("unbound_broadcast", False)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes", "on")
+    return bool(value)
+
+
 PushStatus = Literal[
-    "sent", "busy", "failed", "not_found", "quiet", "held", "superseded", "no_change"
+    "sent", "busy", "failed", "not_found", "quiet", "held", "superseded", "no_change", "unbound"
 ]
 
 # Max bytes we'll pull from a remote image URL (Send-page Image URL tab).
@@ -802,6 +816,18 @@ class PushManager:
                     status="failed",
                     error="dashboard targets none of the requested device(s)",
                 )
+        # Binding is the delivery model (#84). A dashboard is delivered
+        # only to devices it's explicitly bound to. The legacy path where
+        # an unbound Send fans out to every base renderer over the retained
+        # MQTT topics (a single-head leftover) is gated behind an explicit
+        # opt-in. By default, drop empty-dids virtual groups: bound groups
+        # still deliver, a wholly-unbound Send no-ops with a clear message.
+        if not _unbound_broadcast_enabled(self._settings):
+            bound_groups = [(panel, dids) for panel, dids in groups if dids]
+            if len(bound_groups) != len(groups):
+                if not bound_groups:
+                    return self._log_unbound_skip(page_id, source=source)
+                groups = bound_groups
         if respect_quiet_hours:
             groups = self._filter_quiet_devices(groups)
             if not groups:
@@ -1658,5 +1684,26 @@ class PushManager:
             status="quiet",
             page_id=page_id,
             error="all bound devices in quiet hours",
+            event_id=event_id,
+        )
+
+    def _log_unbound_skip(self, page_id: str, *, source: str = "page") -> PushResult:
+        """Record a soft skip when a Send targets a dashboard bound to no
+        device and the legacy unbound-broadcast opt-in is off. Not a
+        failure: binding is the delivery model, so the fix is to bind the
+        dashboard to a device. Surfaced in Events so 'why didn't it send?'
+        is a one-look answer."""
+        msg = "dashboard isn't bound to any device"
+        event_id = self._event_log.record(
+            type="push",
+            source=source,
+            target=page_id,
+            status="unbound",
+            error=msg,
+        )
+        return PushResult(
+            status="unbound",
+            page_id=page_id,
+            error=msg,
             event_id=event_id,
         )

--- a/app/settings/field_defs.py
+++ b/app/settings/field_defs.py
@@ -165,6 +165,21 @@ APP_FIELDS: list[dict[str, Any]] = [
         ),
     },
     {
+        "name": "unbound_broadcast",
+        "type": "switch",
+        "label": "Broadcast unbound dashboards (legacy single-head MQTT)",
+        "default": False,
+        "group": "network",
+        "help": (
+            "Legacy behaviour. When a dashboard bound to no device is sent, fan "
+            "its frame out to every base renderer over the retained MQTT topics, "
+            "the single-head default from before device binding existed. Off by "
+            "default: unbound Sends no-op with a message and dashboards reach only "
+            "the devices they're bound to. Turn on only if you drive a single "
+            "panel over MQTT and never bind it."
+        ),
+    },
+    {
         "name": "quiet_hours_enabled",
         "type": "switch",
         "label": "Quiet hours",

--- a/app/settings/index_routes.py
+++ b/app/settings/index_routes.py
@@ -1077,6 +1077,9 @@ def _build_sections() -> list[dict[str, Any]]:
                         devices=devices(),
                         pages=current_app.config["PAGE_STORE"],
                         schedules=current_app.config["SCHEDULE_STORE"],
+                        unbound_broadcast=bool(
+                            settings_store().get_section("app").get("unbound_broadcast", False)
+                        ),
                     )
                     if is_instance
                     else []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.72.1"
+version = "0.73.0"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/templates/_device_card.html
+++ b/templates/_device_card.html
@@ -603,6 +603,7 @@
               <i class="ph ph-squares-four" aria-hidden="true"></i>
               <span>{{ entry.page_name }}</span>
               {% if not entry.enabled %}<span class="pill">disabled</span>{% endif %}
+              {% if entry.wont_send %}<span class="pill" title="This dashboard isn't bound to any device, so it won't send. Bind it to a device, or enable legacy unbound broadcast in Settings.">unbound · won't send</span>{% endif %}
             </div>
             <div class="timetable-edit">
               <a class="button ghost" href="{{ url_for('schedules.index') }}#schedule-{{ entry.schedule_id }}">

--- a/tests/test_device_timetable.py
+++ b/tests/test_device_timetable.py
@@ -153,3 +153,36 @@ def test_days_label_groups() -> None:
     assert _days_label([0, 1, 4, 5, 6]) == "Mon-Tue, Fri-Sun"
     assert _days_label([3]) == "Thu"
     assert _days_label([]) == "(no days)"
+
+
+def test_unbound_page_flagged_wont_send_unless_broadcast_on(wiring) -> None:
+    """#84: an unbound page still lists on the timetable, but is flagged
+    wont_send unless the legacy unbound-broadcast opt-in is on."""
+    devices, pages, schedules = wiring
+    pages.save(Page(id="floating", name="Floating", device_ids=[], cells=[]))
+    pages.save(Page(id="pinned", name="Pinned", device_ids=["hallway"], cells=[]))
+    for sid, pid in (("floating_sched", "floating"), ("pinned_sched", "pinned")):
+        schedules.upsert(
+            Schedule(
+                id=sid,
+                name=sid,
+                page_id=pid,
+                type="interval",
+                interval_minutes=30,
+                time_of_day_start="08:00",
+                time_of_day_end="18:00",
+                days_of_week=[0, 1, 2, 3, 4],
+            )
+        )
+
+    # Default: the unbound page won't send, the bound page will.
+    hall = timetable_for_device("hallway", devices=devices, pages=pages, schedules=schedules)
+    by_page = {e.page_id: e for e in hall}
+    assert by_page["floating"].wont_send is True
+    assert by_page["pinned"].wont_send is False
+
+    # Legacy opt-in on: the unbound page delivers again, so no warning.
+    hall_legacy = timetable_for_device(
+        "hallway", devices=devices, pages=pages, schedules=schedules, unbound_broadcast=True
+    )
+    assert {e.page_id: e.wont_send for e in hall_legacy}["floating"] is False

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -101,6 +101,17 @@ class _FakeMqttClient:
         return (0, 1)
 
 
+def _legacy_settings(tmp_path: Path) -> SettingsStore:
+    """Settings with the legacy unbound-broadcast opt-in on, so tests that
+    Send an unbound 'virtual panel' page still fan out to base renderers
+    (the pre-#84 behaviour these fan-out / skip / clone tests target).
+    The new default (opt-in off, unbound Send no-ops) is covered by the
+    binding-gate tests below."""
+    s = SettingsStore(tmp_path / "settings.json")
+    s.update_section("app", {"unbound_broadcast": True})
+    return s
+
+
 def _wired(tmp_path: Path, composition_png: bytes, renderers: list[Renderer]):
     page_store = PageStore(tmp_path / "pages.json")
     page = Page(
@@ -126,7 +137,7 @@ def _wired(tmp_path: Path, composition_png: bytes, renderers: list[Renderer]):
         registry=registry,
         page_store=page_store,
         transport=transport,
-        settings=SettingsStore(tmp_path / "settings.json"),
+        settings=_legacy_settings(tmp_path),
         event_log=EventLog(tmp_path / "events.db"),
         renders_dir=tmp_path / "renders",
         base_url_fn=lambda: "http://broker.local:8000",
@@ -333,7 +344,7 @@ def test_unbound_push_over_base_renderers_is_clean_on_brokerless_install(
         registry=registry,
         page_store=page_store,
         transport=transport,
-        settings=SettingsStore(tmp_path / "settings.json"),
+        settings=_legacy_settings(tmp_path),
         event_log=EventLog(tmp_path / "events.db"),
         renders_dir=tmp_path / "renders",
         base_url_fn=lambda: "http://broker.local:8000",
@@ -585,7 +596,7 @@ def test_multi_device_page_renders_once_per_panel_and_routes(
         registry=renderers,
         page_store=page_store,
         transport=transport,
-        settings=SettingsStore(tmp_path / "settings.json"),
+        settings=_legacy_settings(tmp_path),
         event_log=EventLog(tmp_path / "events.db"),
         renders_dir=tmp_path / "renders",
         base_url_fn=lambda: "http://broker.local:8000",
@@ -663,7 +674,7 @@ def test_push_device_filter_targets_single_display(tmp_path: Path, composition_p
         registry=renderers,
         page_store=page_store,
         transport=transport,
-        settings=SettingsStore(tmp_path / "settings.json"),
+        settings=_legacy_settings(tmp_path),
         event_log=EventLog(tmp_path / "events.db"),
         renders_dir=tmp_path / "renders",
         base_url_fn=lambda: "http://broker.local:8000",
@@ -736,7 +747,7 @@ def test_unbound_push_does_not_overwrite_a_bound_devices_frame(
         registry=renderers,
         page_store=page_store,
         transport=transport,
-        settings=SettingsStore(tmp_path / "settings.json"),
+        settings=_legacy_settings(tmp_path),
         event_log=EventLog(tmp_path / "events.db"),
         renders_dir=tmp_path / "renders",
         base_url_fn=lambda: "http://broker.local:8000",
@@ -819,7 +830,7 @@ def test_http_polled_device_skips_mqtt_publish(tmp_path: Path, composition_png: 
         registry=renderers,
         page_store=page_store,
         transport=transport,
-        settings=SettingsStore(tmp_path / "settings.json"),
+        settings=_legacy_settings(tmp_path),
         event_log=EventLog(tmp_path / "events.db"),
         renders_dir=tmp_path / "renders",
         base_url_fn=lambda: "http://broker.local:8000",
@@ -890,7 +901,7 @@ def test_http_polled_push_succeeds_without_broker_connection(
         registry=renderers,
         page_store=page_store,
         transport=transport,
-        settings=SettingsStore(tmp_path / "settings.json"),
+        settings=_legacy_settings(tmp_path),
         event_log=EventLog(tmp_path / "events.db"),
         renders_dir=tmp_path / "renders",
         base_url_fn=lambda: "http://broker.local:8000",
@@ -902,3 +913,56 @@ def test_http_polled_push_succeeds_without_broker_connection(
 
     assert result.status == "sent"
     assert all(r.error is None for r in result.renderers)
+
+
+def _wired_default(tmp_path: Path, composition_png: bytes, renderers: list[Renderer]):
+    """Like _wired but with default settings (unbound broadcast OFF), for
+    exercising the #84 binding gate."""
+    page_store = PageStore(tmp_path / "pages.json")
+    page_store.save(Page(id="home", name="Home", panel=Panel(w=100, h=100), cells=[]))
+    registry = RendererRegistry(renderers={r.id: r for r in renderers})
+    fakes = {}
+
+    def factory(client_id: str):
+        fakes["client"] = _FakeMqttClient(client_id)
+        return fakes["client"]
+
+    transport = MqttTransport(BrokerConfig(host="x"), client_factory=factory)
+    transport.connect()
+    event_log = EventLog(tmp_path / "events.db")
+    manager = PushManager(
+        registry=registry,
+        page_store=page_store,
+        transport=transport,
+        settings=SettingsStore(tmp_path / "settings.json"),
+        event_log=event_log,
+        renders_dir=tmp_path / "renders",
+        base_url_fn=lambda: "http://broker.local:8000",
+    )
+    return manager, fakes["client"], event_log
+
+
+def test_unbound_send_noops_by_default(tmp_path: Path, composition_png: bytes) -> None:
+    """#84: an unbound dashboard Send no-ops (status 'unbound') instead of
+    broadcasting to base renderers, and nothing is published."""
+    renderers = [_make_renderer(tmp_path, "pi_png", "png", retain=False)]
+    manager, client, event_log = _wired_default(tmp_path, composition_png, renderers)
+    with patch("app.push.render_to_png", return_value=composition_png):
+        result = manager.push("home")
+    assert result.status == "unbound"
+    assert "isn't bound" in (result.error or "")
+    assert client.published == []
+    # Surfaced in the event log as a soft skip, not a failure.
+    rows = event_log.list(type="push")
+    assert rows[0].status == "unbound"
+
+
+def test_unbound_send_broadcasts_when_opted_in(tmp_path: Path, composition_png: bytes) -> None:
+    """With the legacy opt-in on, an unbound Send still fans out to base
+    renderers (back-compat for single-head MQTT setups)."""
+    renderers = [_make_renderer(tmp_path, "pi_png", "png", retain=False)]
+    manager, client, _ = _wired(tmp_path, composition_png, renderers)
+    with patch("app.push.render_to_png", return_value=composition_png):
+        result = manager.push("home")
+    assert result.status == "sent"
+    assert len(client.published) == 1


### PR DESCRIPTION
Follow-up to the #83 leak fix. Makes explicit device binding the delivery model instead of the legacy single-head MQTT broadcast.

## What changed
- An unbound dashboard Send (a page bound to no device) no longer fans out to every base renderer over the retained MQTT topics. It now no-ops with a soft `unbound` status and an event-log row.
- Delivery is restricted to the devices a dashboard is explicitly bound to. Bound and targeted (HA / webhook / button) pushes are unchanged.
- The legacy broadcast stays available behind a new `unbound_broadcast` opt-in (Settings, off by default), for single-head MQTT setups that never bind.
- The per-device timetable flags unbound scheduled pages with an "unbound · won't send" pill.

## Migration (behaviour change)
Two cases relied on the old broadcast: unbound scheduled pages, and the Home Assistant per-dashboard push button. Both are fixed by the same step:

- **Bind the dashboard to the device(s) it should appear on.** Scheduled fires deliver via the binding, and the HA button (`push(page_id)` with no device_ids) still delivers because the gate only drops the empty virtual group, not bound groups. Bind to several devices to fan out to all of them.
- **Or** enable `unbound_broadcast` in Settings to restore the old single-head behaviour.

## Testing
- New tests: unbound Send no-ops by default; broadcasts when opted in; timetable `wont_send` flag on/off.
- Existing fan-out / skip / #83 clone-skip tests updated to run under the opt-in (they target the broadcast mechanics).
- Full suite: 1482 passed. Ruff format + check clean. Version bumped to 0.73.0.

Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)