### PR TITLE
Surface environmental telemetry in device status

### DIFF
--- a/app/settings/index_routes.py
+++ b/app/settings/index_routes.py
@@ -10,6 +10,7 @@ shape regardless of source. Helpers below (``_values_for_core``,
 from __future__ import annotations
 
 import json
+import math
 import os
 import time
 from pathlib import Path
@@ -1362,13 +1363,35 @@ def _humanize_firmware(parsed: dict[str, Any]) -> dict[str, Any] | None:
     return {"value": str(fw) if fw is not None else "Unknown", "sub": str(ip) if ip else None}
 
 
+def _humanize_environment(parsed: dict[str, Any]) -> dict[str, str | None] | None:
+    """Format optional environmental telemetry for one compact status tile."""
+
+    def finite_float(value: Any) -> float | None:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return None
+        return number if math.isfinite(number) else None
+
+    temperature = finite_float(parsed.get("temperature_c"))
+    humidity = finite_float(parsed.get("humidity_pct"))
+    if temperature is None and humidity is None:
+        return None
+    if temperature is not None:
+        return {
+            "value": f"{temperature:.1f} °C",
+            "sub": f"{humidity:.0f}% RH" if humidity is not None else None,
+        }
+    return {"value": f"{humidity:.0f}% RH", "sub": None}
+
+
 def _status_tiles(parsed: dict[str, Any]) -> dict[str, Any]:
-    """Three-tile humanized summary used on the Status tab of the
-    device card (Signal / Power / Firmware)."""
+    """Humanized summary used on the Status tab of the device card."""
     return {
         "signal": _humanize_signal(parsed.get("rssi")),
         "power": _humanize_power(parsed),
         "firmware": _humanize_firmware(parsed),
+        "environment": _humanize_environment(parsed),
     }
 
 

--- a/app/transport_wiring.py
+++ b/app/transport_wiring.py
@@ -42,11 +42,22 @@ from app.transport import BrokerConfig, MqttTransport
 logger = logging.getLogger(__name__)
 
 
-# Heartbeat fields that drift every beat (battery, signal, uptime). They
+# Heartbeat fields that drift every beat (battery, signal, environment,
+# uptime). They
 # update the live status cache + HA sensors, but a change in one of these
 # alone shouldn't write an event-log row, otherwise every heartbeat logs.
 _VOLATILE_STATUS_KEYS: frozenset[str] = frozenset(
-    {"battery_mv", "battery_pct", "rssi", "voltage", "uptime", "uptime_s", "last_paint"}
+    {
+        "battery_mv",
+        "battery_pct",
+        "rssi",
+        "voltage",
+        "temperature_c",
+        "humidity_pct",
+        "uptime",
+        "uptime_s",
+        "last_paint",
+    }
 )
 
 

--- a/devices/esp32_client/device.py
+++ b/devices/esp32_client/device.py
@@ -1,13 +1,17 @@
 """esp32_client device contract.
 
-The firmware wakes on its sleep interval, fetches the retained .bin frame,
-paints, then publishes a heartbeat before going back to sleep. The
+The firmware wakes on its sleep interval, fetches the current .bin frame,
+publishes a heartbeat, paints any changed frame, then goes back to sleep. The
 heartbeat carries the bits useful for surfacing battery + signal health
 in the admin UI.
 
 Expected status payload:
 
-    {"battery_mv": int, "battery_pct": int, "rssi": int, "ip": "..."}
+    {"battery_mv": int, "battery_pct": int, "rssi": int, "ip": "...",
+     "temperature_c": float, "humidity_pct": float}
+
+Environmental fields are optional. Temperature stays canonical in Celsius;
+renderers with a unit preference can convert it at presentation time.
 
 Config payload (published from Tesserae, subscribed by the firmware):
 
@@ -39,6 +43,8 @@ def parse_status(payload: bytes) -> dict[str, Any]:
         "battery_pct": None,
         "rssi": None,
         "ip": None,
+        "temperature_c": None,
+        "humidity_pct": None,
         # Optional smart-sync fields (issue #10). Firmware that publishes
         # either of these gives the server a more accurate wake-time
         # prediction than the configured ``sleep_interval_s`` fallback.
@@ -64,6 +70,8 @@ def parse_status(payload: bytes) -> dict[str, Any]:
         ("battery_pct", int),
         ("rssi", int),
         ("ip", str),
+        ("temperature_c", float),
+        ("humidity_pct", float),
         ("sleep_until", float),
         ("next_sleep_s", int),
     ):

--- a/devices/esp32_client/tests/test_smoke.py
+++ b/devices/esp32_client/tests/test_smoke.py
@@ -34,13 +34,22 @@ def test_manifest_fields(esp) -> None:
 
 def test_parse_status_normalises_known_fields(esp) -> None:
     payload = json.dumps(
-        {"battery_mv": 3850, "battery_pct": 72, "rssi": -64, "ip": "10.0.0.42"}
+        {
+            "battery_mv": 3850,
+            "battery_pct": 72,
+            "rssi": -64,
+            "ip": "10.0.0.42",
+            "temperature_c": "25.4",
+            "humidity_pct": "58.2",
+        }
     ).encode()
     parsed = esp.parse_status(payload)
     assert parsed["battery_mv"] == 3850
     assert parsed["battery_pct"] == 72
     assert parsed["rssi"] == -64
     assert parsed["ip"] == "10.0.0.42"
+    assert parsed["temperature_c"] == 25.4
+    assert parsed["humidity_pct"] == 58.2
 
 
 def test_parse_status_empty_payload_returns_none_fields(esp) -> None:
@@ -50,6 +59,8 @@ def test_parse_status_empty_payload_returns_none_fields(esp) -> None:
         "battery_pct": None,
         "rssi": None,
         "ip": None,
+        "temperature_c": None,
+        "humidity_pct": None,
         # Smart-sync optional fields (issue #10).
         "sleep_until": None,
         "next_sleep_s": None,

--- a/static/style/settings.css
+++ b/static/style/settings.css
@@ -949,6 +949,9 @@
   grid-template-columns: repeat(3, 1fr);
   gap: 10px;
 }
+.dx-stat-grid--device {
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+}
 .dx-stat-tile {
   background: var(--dx-inset);
   border: 1px solid #ecebe6;

--- a/templates/_device_card.html
+++ b/templates/_device_card.html
@@ -192,7 +192,7 @@
                class="dx-panel{% if active_tab == 'status' %} is-active{% endif %}"
                aria-hidden="{% if active_tab == 'status' %}false{% else %}true{% endif %}">
         {% set tiles = section.status.tiles %}
-        <div class="dx-stat-grid">
+        <div class="dx-stat-grid dx-stat-grid--device">
           {# SIGNAL #}
           <div class="dx-stat-tile">
             <div class="dx-stat-label">Signal</div>
@@ -226,6 +226,14 @@
               {% if tiles.firmware and tiles.firmware.sub %}<code>{{ tiles.firmware.sub }}</code>{% else %}-{% endif %}
             </div>
           </div>
+          {# ENVIRONMENT -- only sensor-equipped devices report this. #}
+          {% if tiles.environment %}
+          <div class="dx-stat-tile">
+            <div class="dx-stat-label">Environment</div>
+            <div class="dx-stat-value">{{ tiles.environment.value }}</div>
+            <div class="dx-stat-sub">{{ tiles.environment.sub or '-' }}</div>
+          </div>
+          {% endif %}
         </div>
 
         {# SMART SYNC PANEL #}

--- a/tests/test_device_routes.py
+++ b/tests/test_device_routes.py
@@ -103,13 +103,30 @@ def test_status_cache_renders_after_heartbeat(app: Flask) -> None:
 def test_merge_keeps_prev_values_when_new_is_none() -> None:
     """An LWT typically carries only state=offline; merge must preserve
     the last known battery / rssi / ip rather than blanking them."""
-    prev = {"battery_mv": 3820, "battery_pct": 67, "rssi": -58, "ip": "10.0.0.42"}
-    lwt = {"battery_mv": None, "battery_pct": None, "rssi": None, "ip": None, "state": "offline"}
+    prev = {
+        "battery_mv": 3820,
+        "battery_pct": 67,
+        "rssi": -58,
+        "ip": "10.0.0.42",
+        "temperature_c": 25.4,
+        "humidity_pct": 58.2,
+    }
+    lwt = {
+        "battery_mv": None,
+        "battery_pct": None,
+        "rssi": None,
+        "ip": None,
+        "temperature_c": None,
+        "humidity_pct": None,
+        "state": "offline",
+    }
     merged = merge_status_parsed(prev, lwt)
     assert merged["battery_mv"] == 3820
     assert merged["battery_pct"] == 67
     assert merged["rssi"] == -58
     assert merged["ip"] == "10.0.0.42"
+    assert merged["temperature_c"] == 25.4
+    assert merged["humidity_pct"] == 58.2
     assert merged["state"] == "offline"
 
 

--- a/tests/test_event_log.py
+++ b/tests/test_event_log.py
@@ -98,9 +98,21 @@ def test_status_changed_meaningfully() -> None:
 
     # First sighting always counts.
     assert status_changed_meaningfully({}, {"state": "idle"}) is True
-    # Volatile-only drift (battery / rssi) does not.
-    prev = {"state": "idle", "battery_pct": 80, "rssi": -60}
-    same = {"state": "idle", "battery_pct": 74, "rssi": -71}
+    # Volatile-only drift (battery / rssi / environment) does not.
+    prev = {
+        "state": "idle",
+        "battery_pct": 80,
+        "rssi": -60,
+        "temperature_c": 25.4,
+        "humidity_pct": 58.2,
+    }
+    same = {
+        "state": "idle",
+        "battery_pct": 74,
+        "rssi": -71,
+        "temperature_c": 25.5,
+        "humidity_pct": 58.1,
+    }
     assert status_changed_meaningfully(prev, same) is False
     # A real field change does.
     assert status_changed_meaningfully(prev, {"state": "rendering", "battery_pct": 80}) is True

--- a/tests/test_settings_routes.py
+++ b/tests/test_settings_routes.py
@@ -1070,6 +1070,21 @@ def test_humanize_power_calls_zero_zero_mains_not_dead() -> None:
     }
 
 
+def test_humanize_environment_formats_available_readings() -> None:
+    from app.settings.index_routes import _humanize_environment
+
+    assert _humanize_environment({}) is None
+    assert _humanize_environment({"temperature_c": 25.4, "humidity_pct": 58.2}) == {
+        "value": "25.4 °C",
+        "sub": "58% RH",
+    }
+    assert _humanize_environment({"humidity_pct": "61.6"}) == {
+        "value": "62% RH",
+        "sub": None,
+    }
+    assert _humanize_environment({"temperature_c": "invalid", "humidity_pct": None}) is None
+
+
 def test_device_card_renders_humanized_status_tiles(app_with_gate: Flask) -> None:
     """The Status tab shows Signal / Power / Firmware tiles instead of
     raw key/value pairs. Smoke-checks the tile labels are present after
@@ -1084,13 +1099,21 @@ def test_device_card_renders_humanized_status_tiles(app_with_gate: Flask) -> Non
     )
     app_with_gate.config["DEVICE_STATUS"]["esp32_lab"] = {
         "received_at": time.time(),
-        "parsed": {"battery_mv": 3820, "battery_pct": 67, "rssi": -64, "ip": "10.0.0.42"},
+        "parsed": {
+            "battery_mv": 3820,
+            "battery_pct": 67,
+            "rssi": -64,
+            "ip": "10.0.0.42",
+            "temperature_c": 25.4,
+            "humidity_pct": 58.2,
+        },
     }
     body = client.get("/settings/devices").get_data(as_text=True)
-    # All three tile labels render.
+    # Core tiles plus optional environmental telemetry render.
     assert "Signal" in body
     assert "Power" in body
     assert "Firmware" in body
+    assert "Environment" in body
     # Humanized signal label + dBm sub-line.
     assert "Good" in body
     assert "-64 dBm" in body
@@ -1098,6 +1121,8 @@ def test_device_card_renders_humanized_status_tiles(app_with_gate: Flask) -> Non
     assert "67%" in body
     # Firmware IP sub-line.
     assert "10.0.0.42" in body
+    assert "25.4 °C" in body
+    assert "58% RH" in body
 
 
 def test_device_card_rest_hides_dormant_mqtt_topics(app_with_gate: Flask) -> None:


### PR DESCRIPTION
## Summary

- promote `temperature_c` and `humidity_pct` to well-known ESP32 heartbeat fields with float coercion
- preserve both values across partial/offline heartbeats using the existing status merge behavior
- treat environmental drift as volatile so temperature and humidity changes alone do not create event-log noise
- show available readings in an optional Environment tile in the existing device Status area
- keep Celsius as the canonical telemetry unit; widgets can convert units at presentation time

This implements the server half of the approach agreed in [Discussion #89](https://github.com/dmellok/tesserae/discussions/89). The matching firmware change is https://github.com/dmellok/tesserae-device-firmware/pull/1.

## Validation

- `pytest -q`: 1516 passed
- `ruff check .`: passed
- `ruff format --check .`: passed
- GitHub Actions `ruff`, `mypy (strict modules)`, and `pytest`: passed
- desktop and 390px mobile browser checks passed with no tile overflow or overlap
- temporarily hot-patched a Tesserae 0.74.0 container and received a real E1004 heartbeat containing `temperature_c: 32.1031` and `humidity_pct: 77.7625`
- the device remained registered and continued its normal frame/status/300-second sleep cycle
