### PR TITLE
fix: newly-pushed widgets 404'd their static assets until restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,15 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Fixed
 
+- **Pushed widgets served their assets only after a restart.** A widget installed
+  over the MCP push path went live for data on the in-process reload but its
+  `client.js` / static assets kept 404ing until a full restart, so a freshly pushed
+  widget rendered blank. The per-plugin asset routes closed over the registry captured
+  at startup; they now read `app.config["PLUGIN_REGISTRY"]` fresh per request (matching
+  the composer / condition routes), so a newly-pushed non-blueprint widget serves its
+  assets immediately on reload. Widgets that declare an admin `blueprint()` still take
+  one restart (Flask registers blueprints once at startup).
+
 - **MCP `render.png` returned a login screenshot on password-protected instances.**
   The single-widget render endpoint screenshots `/_test/render` over loopback with no
   session; that path was not in the auth gate's loopback-exempt list, so a

--- a/app/plugin_loader.py
+++ b/app/plugin_loader.py
@@ -33,7 +33,7 @@ from types import ModuleType
 from typing import Any
 
 import jsonschema
-from flask import Blueprint, Flask, abort, render_template, send_from_directory
+from flask import Blueprint, Flask, abort, current_app, render_template, send_from_directory
 from werkzeug.wrappers import Response
 
 from app.capabilities import Capabilities
@@ -325,18 +325,29 @@ def register_routes(app: Flask, registry: PluginRegistry) -> None:
     """Register per-plugin static asset routes and any plugin-provided blueprints."""
     bp = Blueprint("plugins", __name__)
 
+    # The route closures capture ``registry`` at startup, but an in-process
+    # reload (the MCP widget-push path) swaps a fresh registry into
+    # ``app.config["PLUGIN_REGISTRY"]``. Read that per request (falling back to
+    # the closed-over one if the key is ever absent) so a newly-pushed widget's
+    # assets are found without a restart, matching how composer.py /
+    # condition_routes.py already resolve the registry.
+    def _live_registry() -> PluginRegistry:
+        live: PluginRegistry = current_app.config.get("PLUGIN_REGISTRY", registry)
+        return live
+
     @bp.get("/")
     def plugins_index() -> str:
         """Top-level page listing every loaded plugin + loader errors."""
+        reg = _live_registry()
         return render_template(
             "plugins_index.html",
-            plugins=sorted(registry.plugins.values(), key=lambda p: (p.kind, p.name.lower())),
-            errors=registry.errors,
+            plugins=sorted(reg.plugins.values(), key=lambda p: (p.kind, p.name.lower())),
+            errors=reg.errors,
         )
 
     @bp.get("/<plugin_id>/<path:asset>")
     def plugin_asset(plugin_id: str, asset: str) -> Response:
-        plugin = registry.plugins.get(plugin_id)
+        plugin = _live_registry().plugins.get(plugin_id)
         if plugin is None:
             abort(404)
         if asset not in _ALLOWED_ASSETS and not asset.startswith(_ALLOWED_ASSET_PREFIXES):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.110.1"
+version = "0.110.2"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/tests/test_widget_push.py
+++ b/tests/test_widget_push.py
@@ -111,6 +111,22 @@ def test_install_reloads_in_process_and_goes_live(app: Flask) -> None:
     assert data["data_source"] == "live" and data["data"]["value"] == 42
 
 
+def test_pushed_widget_serves_client_js_after_in_process_reload(app: Flask) -> None:
+    """A brand-new widget's client.js is served over /plugins/<id>/ right after the
+    in-process reload, no restart. The asset routes read the registry fresh per
+    request, so the swapped-in registry's new plugin id resolves (regression: the
+    closed-over startup registry 404'd it)."""
+    _enable(app)
+    client = app.test_client()
+    _install(client, _make_tar(_widget_files(), top="air_quality"))
+    resp = client.get("/plugins/air_quality/client.js")
+    try:
+        assert resp.status_code == 200
+        assert b"export default" in resp.get_data()
+    finally:
+        resp.close()  # release the send_from_directory file handle
+
+
 def test_install_upserts_new_version(app: Flask) -> None:
     _enable(app)
     client = app.test_client()


### PR DESCRIPTION
## Problem
A widget installed over the MCP push path (`/api/mcp/widgets/install` + in-process reload) went live for **data** immediately, but its `client.js` / static assets kept **404ing until a full restart**, so a freshly pushed widget rendered blank ("Failed to fetch dynamically imported module .../client.js").

## Root cause
`app/plugin_loader.py` `register_routes(app, registry)` defines its `plugins_index()` / `plugin_asset()` closures over the `registry` captured at startup. The in-process reload (`app/mcp_api.py` `_reload_registry`) swaps a **new** registry into `app.config["PLUGIN_REGISTRY"]`, but the closed-over `registry` still points at the old one, so a newly-added `plugin_id` isn't found and `send_from_directory` 404s. `composer.py` and `condition_routes.py` already read the registry fresh per request; these two routes just missed it.

## Change
The asset routes now resolve the registry via a small `_live_registry()` helper that reads `app.config["PLUGIN_REGISTRY"]` per request (falling back to the closed-over one if the key is ever absent). Minimal, no change to normal post-startup behaviour.

## Scope
Fixes **static-asset serving** for newly-pushed **non-blueprint** widgets on in-process reload. Widgets that declare an admin `blueprint()` still take one restart (Flask registers blueprints once at startup); the reload path already returns `restart` for those, which is unchanged.

## Verify
New regression test: push a brand-new non-blueprint widget via `/api/mcp`, then `GET /plugins/<id>/client.js` returns **200** (was 404). Full suite green (1641), mypy `--strict` on `plugin_loader` clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)