### PR TITLE
chore: bring the tesserae-mcp bridge into the monorepo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,28 @@ jobs:
         # Only the contract modules are checked under --strict per the
         # pyproject overrides; plugin code passes default mypy.
         run: mypy app
+
+  mcp-bridge:
+    name: mcp bridge
+    runs-on: ubuntu-latest
+    # The stdio bridge (packages/tesserae-mcp) is a self-contained sub-project
+    # with its own pyproject + deps. Linting + testing it here keeps its tool
+    # list / doc-shape in lockstep with the /api/mcp surface it wraps.
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+      - name: Install the bridge
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e "packages/tesserae-mcp[dev]"
+      - name: ruff
+        working-directory: packages/tesserae-mcp
+        run: |
+          ruff check .
+          ruff format --check .
+      - name: pytest
+        working-directory: packages/tesserae-mcp
+        run: pytest -q

--- a/.github/workflows/publish-tesserae-mcp.yml
+++ b/.github/workflows/publish-tesserae-mcp.yml
@@ -1,0 +1,37 @@
+# Publish the tesserae-mcp bridge (packages/tesserae-mcp) to PyPI.
+#
+# Fires on a tag like ``mcp-v0.5.0`` (kept distinct from the app's own version
+# tags) or a manual dispatch. Uses PyPI Trusted Publishing (OIDC), so no API
+# token secret is needed, but it requires one-time setup on PyPI: add a pending
+# publisher for the ``tesserae-mcp`` project pointing at this repo, this workflow
+# file, and the ``pypi`` environment. Until that's configured the job is inert.
+
+name: publish tesserae-mcp
+
+on:
+  push:
+    tags:
+      - "mcp-v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: build + publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # OIDC token for PyPI trusted publishing
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Build sdist + wheel
+        working-directory: packages/tesserae-mcp
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/tesserae-mcp/dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+### Changed
+
+- **The `tesserae-mcp` bridge now lives in this repo** (`packages/tesserae-mcp`) as a
+  self-contained sub-project with its own `pyproject`, so its tool list / doc-shape stay
+  in lockstep with the `/api/mcp` surface it wraps and are tested in the same CI run. It
+  still ships a thin, stdlib-plus-`mcp` wheel published to PyPI as `tesserae-mcp`, so an
+  agent-machine install stays light. Install becomes `pip install tesserae-mcp`.
+
 ### Docs
+
+- MCP client-config snippets for Codex CLI, Cursor, Windsurf, Cline, VS Code, and the
+  OpenAI Agents SDK, alongside the existing Claude config.
 
 - Two new docs-site pages: **Build widgets with Studio** (the Tesserae Studio authoring
   loop, linter rules, and the new-widget restart gate) and **MCP servers: install & use**

--- a/docs/dev/mcp-servers.md
+++ b/docs/dev/mcp-servers.md
@@ -117,6 +117,95 @@ lint it, register it, and show me the faithful render at every size."* Key tools
 
 ---
 
+## Client configuration
+
+Both servers are standard stdio MCP servers with nothing Claude-specific in them, so any
+MCP-capable client works, Claude Desktop / Code, Cursor, Windsurf, Cline, VS Code (Copilot
+agent mode), Codex CLI, Zed, or a custom client on the MCP SDK. Only the config **file
+format** differs; the command and environment variables are the same everywhere.
+
+What every client needs:
+
+| | tesserae-mcp | tesserae-studio-mcp |
+| --- | --- | --- |
+| command | `tesserae-mcp` | `tesserae-studio-mcp` |
+| env | `TESSERAE_URL` (+ `TESSERAE_MCP_TOKEN` for a remote target) | `STUDIO_URL` |
+
+If the console scripts aren't on your `PATH`, use `command: "python"` with
+`args: ["-m", "tesserae_mcp"]` (or `["-m", "studio_server.mcp_server"]`).
+
+**Claude Desktop / Code, Cursor, Windsurf, Cline** share the `mcpServers` JSON shape.
+The same block works in each; only the file it goes in differs:
+
+```json
+{
+  "mcpServers": {
+    "tesserae": {
+      "command": "tesserae-mcp",
+      "env": { "TESSERAE_URL": "http://127.0.0.1:8765", "TESSERAE_MCP_TOKEN": "<token>" }
+    },
+    "tesserae-studio": {
+      "command": "tesserae-studio-mcp",
+      "env": { "STUDIO_URL": "http://localhost:8770" }
+    }
+  }
+}
+```
+
+- **Claude Desktop** → `claude_desktop_config.json`; **Claude Code** → `claude mcp add …`
+  (see above) or a project `.mcp.json`.
+- **Cursor** → `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project).
+- **Windsurf** → `~/.codeium/windsurf/mcp_config.json`.
+- **Cline** → the extension's `cline_mcp_settings.json`.
+
+**Codex CLI** (`~/.codex/config.toml`):
+
+```toml
+[mcp_servers.tesserae]
+command = "tesserae-mcp"
+env = { TESSERAE_URL = "http://127.0.0.1:8765", TESSERAE_MCP_TOKEN = "<token>" }
+
+[mcp_servers.tesserae-studio]
+command = "tesserae-studio-mcp"
+env = { STUDIO_URL = "http://localhost:8770" }
+```
+
+**VS Code (Copilot agent mode)** (`.vscode/mcp.json`):
+
+```json
+{
+  "servers": {
+    "tesserae": {
+      "type": "stdio",
+      "command": "tesserae-mcp",
+      "env": { "TESSERAE_URL": "http://127.0.0.1:8765", "TESSERAE_MCP_TOKEN": "<token>" }
+    }
+  }
+}
+```
+
+**OpenAI Agents SDK / custom clients** point an stdio MCP transport at the command:
+
+```python
+from agents.mcp import MCPServerStdio
+
+tesserae = MCPServerStdio(params={
+    "command": "tesserae-mcp",
+    "env": {"TESSERAE_URL": "http://127.0.0.1:8765"},
+})
+```
+
+Other clients (Zed, Continue, …) take the same command + env in their own MCP /
+context-server config; see the client's MCP docs for the file location and key names.
+
+Two behaviours depend on how rich the client's MCP support is, not on the servers: whether
+it surfaces the server's handshake **instructions** (Claude clients do; if not, paste the
+loop from the pages above), and whether it renders **image** tool results (`render_preview`
+/ `faithful_render`), a text-only client still gets every other tool, use `render_report`
+for structured verification instead.
+
+---
+
 ## Using both together
 
 The two servers compose. A typical end-to-end session connects **both** and moves between

--- a/docs/dev/mcp-servers.md
+++ b/docs/dev/mcp-servers.md
@@ -29,10 +29,12 @@ agent runs on a *different* machine from Tesserae, also **Regenerate token** and
 **2. Install the bridge** on the machine where your *agent* runs:
 
 ```bash
-pip install git+https://github.com/dmellok/tesserae-mcp
+pip install tesserae-mcp
 ```
 
-That gives you the `tesserae-mcp` command.
+That gives you the `tesserae-mcp` command. (The bridge lives in the Tesserae repo under
+`packages/tesserae-mcp`; to install straight from source use
+`pip install "git+https://github.com/dmellok/tesserae#subdirectory=packages/tesserae-mcp"`.)
 
 **3. Configure your agent.** Claude Desktop / Claude Code `mcpServers` config:
 

--- a/docs/dev/mcp.md
+++ b/docs/dev/mcp.md
@@ -66,7 +66,7 @@ it to your `PATH`, which is exactly what an MCP client needs.
     Then install the bridge:
 
     ```bash
-    pipx install git+https://github.com/dmellok/tesserae-mcp
+    pipx install tesserae-mcp
     ```
 
     Confirm it's on your `PATH`:
@@ -81,19 +81,18 @@ it to your `PATH`, which is exactly what an MCP client needs.
 
     ```bash
     python3 -m venv ~/.tesserae-mcp
-    ~/.tesserae-mcp/bin/python -m pip install git+https://github.com/dmellok/tesserae-mcp
+    ~/.tesserae-mcp/bin/python -m pip install tesserae-mcp
     ```
 
     The command is then `~/.tesserae-mcp/bin/tesserae-mcp` (use that full path in
     the config below).
 
-=== "from a clone"
+=== "from source"
 
     ```bash
-    git clone https://github.com/dmellok/tesserae-mcp
-    cd tesserae-mcp
-    python3 -m pip install mcp
-    # run with:  python -m tesserae_mcp
+    # the bridge lives in the Tesserae repo under packages/tesserae-mcp
+    pip install "git+https://github.com/dmellok/tesserae#subdirectory=packages/tesserae-mcp"
+    # or from a clone:  pip install -e tesserae/packages/tesserae-mcp
     ```
 
 !!! warning "`error: externally-managed-environment`"

--- a/packages/tesserae-mcp/.gitignore
+++ b/packages/tesserae-mcp/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.egg-info/
+build/
+dist/
+.venv/
+.pytest_cache/
+.ruff_cache/

--- a/packages/tesserae-mcp/LICENSE
+++ b/packages/tesserae-mcp/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/packages/tesserae-mcp/README.md
+++ b/packages/tesserae-mcp/README.md
@@ -1,0 +1,105 @@
+# tesserae-mcp
+
+> Part of the [Tesserae](https://github.com/dmellok/tesserae) monorepo
+> (`packages/tesserae-mcp`), so the bridge stays in lockstep with the `/api/mcp`
+> surface it wraps. Published to PyPI as `tesserae-mcp`.
+
+The [MCP](https://modelcontextprotocol.io) bridge for
+[Tesserae](https://github.com/dmellok/tesserae). It lets an AI agent (Claude
+Desktop, Claude Code, or any MCP client) build **freeform (canvas) dashboards**
+for your e-ink panels: it lists your widgets and devices, lays out a canvas,
+**renders a preview to check its own work**, and pushes to a panel.
+
+This is a thin stdio client. It talks to a running Tesserae over its `/api/mcp`
+HTTP surface, so the rendering, widgets, and devices all come from your own
+Tesserae instance.
+
+```
+create_canvas_page → set_canvas → render_preview → (look) → set_canvas → …
+```
+
+## Prerequisites
+
+A running Tesserae with the MCP API enabled: **Settings → System → MCP → Enable
+MCP API**. If this bridge runs on a *different* machine from Tesserae, also
+**Regenerate token** there and copy it.
+
+## Install
+
+Run this on the machine where your **agent** runs (your laptop/desktop), which
+may be different from where Tesserae runs.
+
+```bash
+pip install git+https://github.com/dmellok/tesserae-mcp
+```
+
+That gives you the `tesserae-mcp` command.
+
+## Configure your agent
+
+Point your MCP client at `tesserae-mcp`. Example (Claude Desktop / Claude Code
+`mcpServers` config):
+
+```json
+{
+  "mcpServers": {
+    "tesserae": {
+      "command": "tesserae-mcp",
+      "env": {
+        "TESSERAE_URL": "http://127.0.0.1:8765",
+        "TESSERAE_MCP_TOKEN": "<your-token>"
+      }
+    }
+  }
+}
+```
+
+- `TESSERAE_URL` — where your Tesserae is reachable (default
+  `http://127.0.0.1:8765`). For a Docker/Home Assistant install, use its LAN
+  address, e.g. `http://192.168.1.50:8765` (the port must be reachable; HA
+  ingress-only setups won't work).
+- `TESSERAE_MCP_TOKEN` — the token from Settings. **Omit it** when the agent and
+  Tesserae share a machine (loopback is trusted).
+
+Then just ask: *"Build me an 800×480 dashboard with the time, today's weather for
+Melbourne, and my next calendar event, then show me a preview."*
+
+## Tools
+
+| Tool | What it does |
+| --- | --- |
+| `list_widgets` | Every placeable widget (with fragments) + theme/style/font options |
+| `get_widget_options` | A widget's options + format hints (big choice lists omitted by default) |
+| `get_widget_choices` | Page through one option's choice rows (HA entity pickers etc.) |
+| `probe_widget_data` | A widget's data + `data_source` (live/sample/error) + bindable field paths |
+| `list_devices` | Registered panels: dimensions + colour capability (palette, mono flag) |
+| `list_pages` | Existing canvas dashboards |
+| `create_canvas_page` | Create an empty canvas (size it to your panel) |
+| `get_canvas` | Read a canvas document (returns a `rev` for concurrency-safe writes) |
+| `set_canvas` | Replace a canvas document (422 with field errors if invalid) |
+| `add_element` | Append one element (live-updates an open editor) |
+| `update_element` | Change one element in place (no full re-send) |
+| `delete_element` | Remove one element |
+| `patch_canvas` | Change document-level fields (size, theme, bg) without touching elements |
+| `arrange` | Compute aligned grid/row/column boxes so you lay out by intent, not pixels |
+| `measure_text` | Measure rendered text width/height so a box fits its content |
+| `render_report` | Read back what rendered (values, overflow, live-vs-sample, colours) as JSON |
+| `render_preview` | Render the canvas to a PNG the agent can see |
+| `push_to_device` | Push the canvas to explicit device(s) |
+
+Writes (`set_canvas`, `add_element`, `update_element`, `delete_element`, `patch_canvas`)
+accept an optional `base_rev` (from `get_canvas`); if the page changed since, the
+write returns HTTP 409 so you re-read instead of clobbering a concurrent edit.
+
+## Run without installing
+
+From a clone:
+
+```bash
+pip install mcp
+TESSERAE_URL=http://127.0.0.1:8765 python -m tesserae_mcp
+```
+
+## License
+
+AGPL-3.0-or-later, matching Tesserae.

--- a/packages/tesserae-mcp/pyproject.toml
+++ b/packages/tesserae-mcp/pyproject.toml
@@ -38,3 +38,10 @@ line-length = 100
 
 [tool.ruff.format]
 quote-style = "double"
+
+# Anchor pytest's rootdir here so it does NOT climb to the repo-root config /
+# conftest.py (which imports the Flask app). Without this, running the bridge's
+# tests inside the monorepo pulls in the app's conftest and fails on a missing
+# ``flask`` in the bridge's stdlib-only environment.
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/packages/tesserae-mcp/pyproject.toml
+++ b/packages/tesserae-mcp/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "tesserae-mcp"
+version = "0.5.0"
+description = "MCP bridge for Tesserae: build e-ink canvas dashboards with an AI agent."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "AGPL-3.0-or-later" }
+authors = [{ name = "Kayden D'Mello" }]
+keywords = ["mcp", "tesserae", "e-ink", "dashboard", "ai"]
+dependencies = [
+    # The Model Context Protocol SDK (FastMCP). Everything else is stdlib.
+    "mcp>=1.2,<2",
+]
+
+[project.urls]
+Homepage = "https://github.com/dmellok/tesserae/tree/main/packages/tesserae-mcp"
+Tesserae = "https://github.com/dmellok/tesserae"
+Docs = "https://docs.tesserae.ink/dev/mcp-servers/"
+
+[project.scripts]
+tesserae-mcp = "tesserae_mcp:main"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.15,<0.16",
+]
+
+[tool.setuptools.packages.find]
+include = ["tesserae_mcp*"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.format]
+quote-style = "double"

--- a/packages/tesserae-mcp/tesserae_mcp/__init__.py
+++ b/packages/tesserae-mcp/tesserae_mcp/__init__.py
@@ -1,0 +1,398 @@
+"""tesserae-mcp — the stdio MCP bridge an AI agent connects to.
+
+A thin client over a running Tesserae's ``/api/mcp`` HTTP surface. It exposes
+tools an agent uses to build **freeform (canvas) dashboards**: discover widgets
+and devices, create + edit a canvas, **render a preview image** to check its own
+work, and push to a panel.
+
+Tesserae side: enable the ``mcp`` experiment under Settings → System → MCP.
+
+Config via environment:
+- ``TESSERAE_URL``        base URL of a running Tesserae (default http://127.0.0.1:8765)
+- ``TESSERAE_MCP_TOKEN``  the MCP token (optional when the agent runs on the same
+                          machine as Tesserae, since loopback is trusted)
+
+Run it as ``tesserae-mcp`` (console script) or ``python -m tesserae_mcp``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+__version__ = "0.5.0"
+
+_BASE = os.environ.get("TESSERAE_URL", "http://127.0.0.1:8765").rstrip("/")
+_TOKEN = os.environ.get("TESSERAE_MCP_TOKEN", "").strip()
+
+# The canvas-document shape, embedded in the set_canvas tool description so the
+# agent knows exactly what to write.
+_DOC_SHAPE = """A canvas document is JSON:
+{
+  "w": int, "h": int,                 # artboard size in px (match the target panel)
+  "theme": str, "style": str,         # appearance ids from list_widgets().appearance
+  "font": str, "bg": str,             # optional font id and background colour override
+  "els": [ <element>, ... ]           # painted in list order: first = back, last = front
+}
+Elements may sit partly off the panel (it clips at the edge). Each element has a
+unique "id" and a box "x","y","w","h" (px, top-left origin; x/y may be negative),
+plus optional "opacity" (0-100) and "rotate" (degrees). By "kind":
+- widget:  {"kind":"widget","widget":"<key>","fragment":"full","options":{...}}
+           <key> from list_widgets(); "fragment" from that widget's fragments (or "full");
+           "options" per get_widget_options(<key>).
+- text:    {"kind":"text","text":"...","color":"<css or var(--accent-1)>","size":<px, 0=auto>,"align":"left|center|right"}
+- rect:    {"kind":"rect","color":"...","fill":true,"stroke":<px>,"radius":<px>}
+- ellipse: {"kind":"ellipse","color":"...","fill":true,"stroke":<px>}
+- line:    {"kind":"line","color":"...","stroke":<px>}
+- icon:    {"kind":"icon","icon":"<name or ph-name>","color":"...","weight":"thin|light|regular|bold|fill|duotone"}
+- data:    {"kind":"data","source":"<widget key>","options":{...},"field":"<path>",
+            "display":"text|number|line|bar|sparkline","format":"","unit":"","precision":0,
+            "label":"","color":"...","size":<px, 0=auto>,"align":"..."}
+           Binds a widget's data field to a scalable value or graph. "source" is a widget key from
+           list_widgets(); configure it via "options" (get_widget_options). Use probe_widget_data(source,
+           options) to see the real data shape before choosing "field". "format" (text/number only) is a
+           date pattern ("HH:mm","MMM d","ddd HH:mm"), "relative", or a number pattern ("0.0").
+- html:    {"kind":"html","html":"<div>…</div>","css":"div{…}"}
+           A mini widget from static HTML + CSS in a sandboxed iframe (no scripts, no network).
+- svg:     {"kind":"svg","html":"<svg …>…</svg>","css":""}   -- raw SVG, scaled to fill the box.
+
+LIVE BINDINGS ("bind" on ANY element -- makes a SHAPE reflect data):
+  Data elements auto-update, but shapes (rect/ellipse/icon/line/text) are static geometry.
+  Add "bind": [ <binding>, ... ] to drive a shape's props from data each render (in lockstep
+  with data elements, no polling). A binding is:
+    {"source":"<widget key>","options":{...},"field":"<path>","transform":"<t>","params":{...}}
+  transforms:
+    position -- scalar to a coordinate: {"axis":"x"|"y","in":[lo,hi],"out":[p0,p1],"center":<elemSize>}
+                lo/hi may be numbers OR other field paths (e.g. "sun.riseMin").
+    length   -- scalar to a size: {"dim":"w"|"h","in":[lo,hi],"out":[minPx,maxPx],"anchorMax":<px>?}
+    pick     -- integer field indexes arrays: {"set":{"x":[...],"color":[...],...},"center":<elemSize>?}
+    color    -- scalar to a colour by ascending thresholds: {"stops":[[max,"#hex"],...],"else":"#hex"}
+    gradient -- scalar interpolated smoothly along colour stops: {"stops":[[value,"#hex"],...]}
+                (quantised to the panel palette on e-ink; a value-driven gradient, not animation)
+    icon     -- code/string to a Phosphor glyph: {"table":{"<code>":"ph-name"},"default":"ph-name"}
+  Several bindings combine (e.g. bind x by position AND colour by threshold). A binding that
+  can't resolve its value is skipped, so the element keeps its authored props.
+
+FIELD PATHS ("field" on data elements):
+  dotted -- "current.temp"
+  array index -- "hourly.0.temp"  (or "hourly[0].temp")
+  pluck (for charts) -- "series.*.total"  (or "series[].total")  maps .total over every item of
+     the array "series", yielding an array of numbers. Charts (line/bar/sparkline) need a field that
+     resolves to an array of numbers -- use pluck to get one from an array-of-objects.
+  probe_widget_data() returns a "fields" list of the bindable paths (with sample values), so you
+  don't have to reverse-engineer the shape.
+
+EDITING WITHOUT RESENDING EVERYTHING:
+  update_element / delete_element / patch_canvas change one thing without re-sending the whole
+  document (cheaper, fewer errors on a big canvas). add_element appends one.
+
+AVOID CLOBBERING A CONCURRENT EDIT:
+  get_canvas() returns a "rev". Pass it as base_rev to a write; if the page changed since (someone
+  edited it in the UI, or another agent), the write returns HTTP 409 with the current rev, so you
+  re-read instead of overwriting.
+
+LAY OUT BY INTENT, NOT PIXELS:
+  arrange(box, layout, count) returns aligned child boxes (grid/row/column) to spread across your
+  elements -- no hand-computed x/y. measure_text() tells you how wide text renders so a box fits
+  its content (prevents clipping). render_report() reads back what actually rendered (per-element
+  value, overflow flags, live-vs-sample, colours) so you verify without eyeballing the PNG.
+
+MATCH THE HARDWARE:
+  list_devices() reports each panel's colour capability (color_mode, the renderable palette as hex,
+  and a "mono" flag). Design within that palette so colours don't quantise away on the panel.
+"""
+
+
+def _request(method: str, path: str, body: dict[str, Any] | None = None) -> tuple[int, bytes, str]:
+    """Call the Tesserae MCP API. Returns (status, raw_bytes, content_type)."""
+    url = f"{_BASE}/api/mcp{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    if body is not None:
+        req.add_header("Content-Type", "application/json")
+    if _TOKEN:
+        req.add_header("Authorization", f"Bearer {_TOKEN}")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return resp.status, resp.read(), resp.headers.get("Content-Type", "")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read(), exc.headers.get("Content-Type", "") if exc.headers else ""
+    except urllib.error.URLError as exc:
+        detail = getattr(exc, "reason", exc)
+        raise RuntimeError(
+            f"Cannot reach Tesserae at {_BASE} ({detail}). Is it running, and is the "
+            f"'mcp' experiment enabled in Settings → System → MCP?"
+        ) from exc
+
+
+def _json(method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+    """Call the API expecting JSON. Non-2xx bodies are returned as-is (so the agent
+    sees 422 validation details) rather than raised."""
+    status, raw, _ = _request(method, path, body)
+    try:
+        parsed = json.loads(raw) if raw else {}
+    except ValueError:
+        parsed = {"error": raw.decode("utf-8", "replace")}
+    if status >= 400 and isinstance(parsed, dict):
+        parsed.setdefault("_status", status)
+    return parsed
+
+
+# Sent to the connecting agent at handshake (FastMCP ``instructions``) so it drives
+# the compose loop the way the canvas surface expects, the operator prompt lives with
+# the tools instead of being pasted in by hand.
+_INSTRUCTIONS = """\
+You compose Tesserae canvases through these tools (mcp__tesserae__*). Work this loop.
+
+LOOP: probe -> place -> render_preview -> render_report -> adjust -> (push).
+- get_widget_options(key) before placing, so you fill "options" correctly.
+- probe_widget_data(key, options) to get real field dot-paths BEFORE binding any data
+  primitive or shape. It reports data_source: live | sample | error, never treat
+  sample/error as real.
+- create_canvas_page then set_canvas (whole layout) or add_element (one at a time).
+  Elements paint back-to-front in list order (first = back, last = front).
+- render_preview(page_id) = the image; render_report(page_id) = machine-readable
+  (resolved box, rendered text, overflow_x/y, data_source, colours). Use render_report to
+  catch clipping and confirm live data without eyeballing pixels.
+- If a just-pushed widget shows "Failed to fetch dynamically imported module .../client.js",
+  the widget isn't loaded yet (not a canvas problem): it adds an admin blueprint() (a
+  restart is pending, poll /healthz then retry), the reload hasn't completed, or client.js
+  errored. Reload/restart Tesserae (or wait for the restart) and re-render.
+
+VERIFY EVERY SIZE (this is where layouts break)
+- Size token comes from the cell's LONGER side: xs <=200, sm <=400, md <=700, lg >700 px.
+- To review a widget across sizes on live data, build one contact-sheet canvas with the same
+  widget at lg (~760px), md (~550px), sm (~380px), xs (~180px) boxes plus each fragment
+  (e.g. a 430x72 "bar"), all with the same options, and render_preview once. sm/xs are where
+  things overflow, check them, not just md.
+
+BINDING & DECORATION
+- data element (live NUMBER / TEXT / graph): {kind:"data", source:<key>, options:{...},
+  field:"<dot.path from probe>", display:"text|number|line|bar|sparkline", ...}. A wrong
+  field simply isn't in probe's list.
+- Live SHAPE binding: a data element makes a value live; a "bind" on a shape makes the shape
+  itself move / grow / recolour from a field. Add "bind":[{source, options, field, transform,
+  params}] to any rect / ellipse / icon / line / text. Transforms: position, length, pick,
+  color, gradient (a value interpolated smoothly along colour stops, quantised to the panel
+  palette on e-ink), icon. Several combine. Reach for this instead of a static shape whenever
+  the shape should track data. Full shape is in the set_canvas tool description.
+- Paint from var(--accent-N) / semantic tokens or documented data-identity colours; avoid
+  arbitrary hex.
+
+PUSH: list_devices, then push_to_device once the render looks right. Confirm before pushing
+to a real panel.
+"""
+
+
+def build_server() -> Any:
+    """Construct the FastMCP server with all tools registered.
+
+    Tools are registered via ``add_tool`` (not the ``@tool`` decorator) so the
+    optional, untyped ``mcp`` SDK doesn't strip the type info off our functions.
+    """
+    from mcp.server.fastmcp import FastMCP, Image
+
+    def list_widgets() -> Any:
+        """List every widget that can be placed on a canvas (with its fragments) and
+        the available theme/style/font appearance options."""
+        return _json("GET", "/catalog")
+
+    def get_widget_options(widget: str, include_choices: bool = False) -> Any:
+        """Get the configurable options for one widget, so you can fill an element's
+        "options" correctly (e.g. a weather widget's location). Each option carries a
+        "format" hint for its type. Big choice lists (HA entity pickers) are omitted
+        by default (the option shows "choices_count" + a "choices_endpoint"); pass
+        include_choices=True to inline them, or call get_widget_choices() to page."""
+        suffix = "?include_choices=true" if include_choices else ""
+        return _json("GET", f"/widgets/{widget}/options{suffix}")
+
+    def get_widget_choices(
+        widget: str, option: str, q: str = "", limit: int = 100, offset: int = 0
+    ) -> Any:
+        """Page through the choice rows for one of a widget's options (kept out of
+        get_widget_options so a picker with hundreds of entries doesn't bloat the
+        schema). "q" filters by case-insensitive substring on value/label."""
+        path = f"/widgets/{widget}/choices?option={option}&limit={limit}&offset={offset}"
+        if q:
+            path += f"&q={q}"
+        return _json("GET", path)
+
+    def probe_widget_data(widget: str, options: dict[str, Any] | None = None) -> Any:
+        """Return a widget's data as JSON to pick "field" paths before binding a data
+        primitive. Returns {data, data_source, reason, fields}: "data_source" is
+        "live" (real fetch), "sample" (demo fallback because nothing was configured),
+        or "error" (fetch failed) so you never mistake a placeholder for a real
+        result; "fields" lists the bindable dot-paths with sample values (a wrong key
+        simply isn't in the list; an empty payload has fields with null values)."""
+        return _json("POST", f"/widgets/{widget}/data", {"options": options or {}})
+
+    def list_devices() -> Any:
+        """List registered display devices with panel dims AND colour capability:
+        "color_mode" (e.g. "6-colour (Spectra 6)"), "colors" (the renderable palette
+        as hex), "gamut", "orientation", and a "mono" flag. Match a canvas's w/h to
+        the target panel, and design within its palette so colours don't quantise
+        away on the hardware."""
+        return _json("GET", "/devices")
+
+    def list_pages() -> Any:
+        """List existing canvas (freeform) dashboards."""
+        return _json("GET", "/pages")
+
+    def create_canvas_page(name: str, w: int = 800, h: int = 480) -> Any:
+        """Create a new, empty canvas dashboard and return its id. Then set_canvas()
+        to lay it out. Size it to your target panel (see list_devices)."""
+        return _json("POST", "/pages", {"name": name, "w": w, "h": h})
+
+    def get_canvas(page_id: str) -> Any:
+        """Get the full canvas document (size, appearance, and every element) for a
+        page, plus "rev" / "updated_at" / "updated_by". Keep the "rev" and pass it as
+        base_rev on your next write to be warned (HTTP 409) if the page drifted."""
+        return _json("GET", f"/pages/{page_id}/canvas")
+
+    def _rev_suffix(base_rev: str) -> str:
+        return f"?base_rev={base_rev}" if base_rev else ""
+
+    def set_canvas(page_id: str, canvas: dict[str, Any], base_rev: str = "") -> Any:
+        return _json("PUT", f"/pages/{page_id}/canvas{_rev_suffix(base_rev)}", canvas)
+
+    def add_element(page_id: str, element: dict[str, Any], base_rev: str = "") -> Any:
+        """Append ONE element to a canvas and save. Each call is a separate save, so
+        an editor open on the page updates live as you build. "element" is a single
+        element object (same shapes as set_canvas's "els"). Returns the compact ack
+        plus the new "element_id". Prefer this when building incrementally; use
+        set_canvas to replace the whole layout at once."""
+        return _json("POST", f"/pages/{page_id}/elements{_rev_suffix(base_rev)}", element)
+
+    def update_element(
+        page_id: str, element_id: str, patch: dict[str, Any], base_rev: str = ""
+    ) -> Any:
+        """Change ONE element in place without re-sending the whole document. "patch"
+        is a partial element ({field: value, ...}) merged over the existing one (a
+        provided "options"/"parts" replaces wholesale). The cheap edit path for a big
+        canvas: change a precision, a colour, a location, one box. Returns the ack."""
+        return _json(
+            "PATCH", f"/pages/{page_id}/elements/{element_id}{_rev_suffix(base_rev)}", patch
+        )
+
+    def delete_element(page_id: str, element_id: str, base_rev: str = "") -> Any:
+        """Remove ONE element from a canvas by id. Returns the compact ack."""
+        return _json("DELETE", f"/pages/{page_id}/elements/{element_id}{_rev_suffix(base_rev)}")
+
+    def patch_canvas(page_id: str, patch: dict[str, Any], base_rev: str = "") -> Any:
+        """Change document-level fields (any of name, w, h, theme, style, font, bg,
+        bg_image, bg_fit) without touching the elements. Use update_element / set_canvas
+        for elements. Returns the ack."""
+        return _json("PATCH", f"/pages/{page_id}/canvas{_rev_suffix(base_rev)}", patch)
+
+    def arrange(
+        box: dict[str, int],
+        count: int,
+        layout: str = "grid",
+        gap: int = 0,
+        pad: int = 0,
+        cols: int = 0,
+    ) -> Any:
+        """Compute "count" aligned child boxes inside "box" ({x,y,w,h}) for a
+        "grid" / "row" / "column" layout, so you place cells by intent instead of
+        hand-computing pixels. "gap" is the space between cells, "pad" the inset from
+        the box edge, "cols" forces a grid column count (default ~sqrt). Returns
+        {boxes:[{x,y,w,h}, ...]}; spread them across your elements' geometry (bake
+        them in as normal elements — they stay individually editable)."""
+        return _json(
+            "POST",
+            "/layout",
+            {"box": box, "count": count, "layout": layout, "gap": gap, "pad": pad, "cols": cols},
+        )
+
+    def measure_text(items: list[dict[str, Any]]) -> Any:
+        """Measure how wide/tall text renders in a widget font, so a box fits its
+        content (prevents clipping). "items" is a list of {text, font?, size?, weight?,
+        max_width?}. Returns {items:[{text,width,height,fits}]} where "fits" is whether
+        the text is within max_width. Font names come from list_widgets().appearance."""
+        return _json("POST", "/measure-text", {"items": items})
+
+    def render_report(page_id: str) -> Any:
+        """Read back what a canvas actually rendered, as JSON (a companion to
+        render_preview's image). Per element: the resolved box, the text that
+        rendered, overflow/clip flags (overflow_x when content is wider than its box),
+        "data_source" (live | sample | error | static), and computed colours; plus the
+        board's resolved background / theme. Use it to verify a render — catch
+        clipping, confirm live data, read the real colours — without parsing a PNG.
+        (Widget cells render into shadow DOM, so their "text" may be empty; data
+        primitives and decorations report their text.)"""
+        return _json("GET", f"/pages/{page_id}/render_report")
+
+    def render_preview(page_id: str) -> Any:
+        """Render the canvas to a PNG at its authored size and return the image, so you
+        can visually check the layout and iterate. This is your feedback loop: place →
+        render_preview → adjust → set_canvas → render_preview again. For a
+        machine-readable check (values, overflow, colours), use render_report()."""
+        status, raw, ctype = _request("GET", f"/pages/{page_id}/preview.png")
+        if status >= 400 or not ctype.startswith("image/"):
+            raise RuntimeError(
+                f"preview failed (HTTP {status}): {raw.decode('utf-8', 'replace')[:300]}"
+            )
+        return Image(data=raw, format="png")
+
+    def push_to_device(page_id: str, device_ids: list[str]) -> Any:
+        """Render the canvas and push it to the given devices (ids from list_devices).
+        device_ids is required — pushing is always explicit."""
+        return _json("POST", f"/pages/{page_id}/push", {"device_ids": device_ids})
+
+    mcp = FastMCP("tesserae", instructions=_INSTRUCTIONS)
+    for fn in (
+        list_widgets,
+        get_widget_options,
+        get_widget_choices,
+        probe_widget_data,
+        list_devices,
+        list_pages,
+        create_canvas_page,
+        get_canvas,
+        update_element,
+        delete_element,
+        patch_canvas,
+        arrange,
+        measure_text,
+        render_report,
+        render_preview,
+        push_to_device,
+    ):
+        mcp.add_tool(fn)
+    mcp.add_tool(
+        set_canvas,
+        description=(
+            "Replace a canvas dashboard's document. Returns a compact {ok,id,rev,elements} "
+            'ack (not the full document), or an error with field-level "details" (HTTP 422) '
+            "if the document is invalid, so you can correct it and retry. Pass base_rev (the rev "
+            "from get_canvas) to be warned with HTTP 409 if the page changed under you. For a "
+            "one-field change prefer update_element / patch_canvas. After setting, call "
+            "render_preview() (or render_report()) to check the result.\n\n" + _DOC_SHAPE
+        ),
+    )
+    mcp.add_tool(
+        add_element,
+        description=(
+            "Append ONE element to a canvas and save (each call is a separate save, so an "
+            "open editor updates live as you build). 'element' is a single element object; "
+            "returns {ok,id,rev,elements,element_id}. Use set_canvas to replace the whole "
+            "layout at once.\n\n" + _DOC_SHAPE
+        ),
+    )
+    return mcp
+
+
+def main() -> None:
+    try:
+        server = build_server()
+    except ModuleNotFoundError as exc:
+        if exc.name and exc.name.split(".")[0] == "mcp":
+            raise SystemExit(
+                "The MCP SDK isn't installed. Reinstall the bridge with its dependency:\n\n"
+                "    pip install git+https://github.com/dmellok/tesserae-mcp\n"
+            ) from exc
+        raise
+    server.run()

--- a/packages/tesserae-mcp/tesserae_mcp/__main__.py
+++ b/packages/tesserae-mcp/tesserae_mcp/__main__.py
@@ -1,0 +1,4 @@
+from tesserae_mcp import main
+
+if __name__ == "__main__":
+    main()

--- a/packages/tesserae-mcp/tests/test_bridge.py
+++ b/packages/tesserae-mcp/tests/test_bridge.py
@@ -1,0 +1,62 @@
+"""Smoke tests for the tesserae-mcp bridge.
+
+These don't need a running Tesserae; they exercise the local plumbing (JSON
+handling) and, when the mcp SDK is present, that all tools register.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import tesserae_mcp as bridge
+
+
+def test_tools_register() -> None:
+    """build_server() wires up every tool with the set_canvas doc spec."""
+    import asyncio
+
+    server = bridge.build_server()
+    tools = asyncio.run(server.list_tools())
+    names = {t.name for t in tools}
+    assert names == {
+        "list_widgets",
+        "get_widget_options",
+        "get_widget_choices",
+        "probe_widget_data",
+        "list_devices",
+        "list_pages",
+        "create_canvas_page",
+        "get_canvas",
+        "set_canvas",
+        "add_element",
+        "update_element",
+        "delete_element",
+        "patch_canvas",
+        "arrange",
+        "measure_text",
+        "render_report",
+        "render_preview",
+        "push_to_device",
+    }
+    set_canvas = next(t for t in tools if t.name == "set_canvas")
+    assert "canvas document is JSON" in (set_canvas.description or "")
+
+
+def test_server_ships_compose_instructions() -> None:
+    """The compose-agent operator loop is sent at handshake via FastMCP
+    instructions, so it lives with the tools instead of being pasted in."""
+    server = bridge.build_server()
+    text = server.instructions or ""
+    assert "LOOP:" in text and "render_report" in text and "bind" in text
+
+
+def test_json_wraps_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-2xx response is returned as data (with _status), not raised, so the
+    agent can read 422 validation details."""
+    monkeypatch.setattr(
+        bridge,
+        "_request",
+        lambda *a, **k: (422, b'{"error":"bad","details":[]}', "application/json"),
+    )
+    out = bridge._json("PUT", "/pages/x/canvas", {"w": 0})
+    assert out["error"] == "bad" and out["_status"] == 422

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.110.2"
+version = "0.110.3"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }
@@ -96,7 +96,10 @@ exclude = ["data*", "plugins*", "renderers*", "devices*", "tests*"]
 [tool.ruff]
 line-length = 100
 target-version = "py311"
-extend-exclude = ["data", "static/dist", "node_modules"]
+# ``packages/`` holds self-contained sub-projects (the tesserae-mcp bridge)
+# with their own pyproject + ruff config and their own CI job; the app's ruff
+# run skips them so the two rule sets don't fight.
+extend-exclude = ["data", "static/dist", "node_modules", "packages"]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Why
The `tesserae-mcp` stdio bridge is a thin client over the app's `/api/mcp` surface, but it lived in a separate repo, so every change to that surface (a new tool, a doc-shape field, the handshake instructions) meant editing and version-bumping two repos in lockstep, and they could drift.

## What
Move the bridge into **`packages/tesserae-mcp`** as a self-contained sub-project:

- Its own `pyproject.toml` + deps (stdlib + the `mcp` SDK only), so it still builds a **thin wheel** and an agent-machine `pip install tesserae-mcp` stays light (no Flask/Playwright/numpy).
- A new **`mcp-bridge` CI job** lints + tests it in the same run, so its tool list / doc-shape are kept in lockstep with the endpoints it wraps.
- A **tag-gated PyPI publish** workflow (`mcp-v*`) via trusted publishing (needs one-time PyPI-side setup; inert until then).

Isolation: the app's `ruff` run excludes `packages/` (the sub-project carries its own config); the app wheel is unaffected (`packages.find` is `app*`-only) and app `pytest` doesn't collect the sub-project (verified: 0 collected). Docs install lines move to `pip install tesserae-mcp` with a from-source fallback.

Also folds in the earlier commit adding **MCP client-config snippets** (Codex, Cursor, Windsurf, Cline, VS Code, Agents SDK).

## Follow-ups (not in this PR, your call)
- Configure PyPI trusted publishing for `tesserae-mcp`, then tag `mcp-v0.5.0` to publish.
- Archive the old `dmellok/tesserae-mcp` repo with a README pointing here (keep it so existing `git+` pins don't break).

## Verify
Subpackage: `ruff` clean, 3 tests pass. App: `ruff` clean (skips `packages/`), `mypy app` clean, docs build `--strict`. No app code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)