### PR TITLE
docs: tesserae-studio-mcp installs from PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Docs
 
+- The `tesserae-studio-mcp` bridge install now reads `pip install tesserae-studio-mcp`
+  (it's on PyPI), matching the `tesserae-mcp` section, with a from-source fallback.
+
 - MCP client-config snippets for Codex CLI, Cursor, Windsurf, Cline, VS Code, and the
   OpenAI Agents SDK, alongside the existing Claude config.
 

--- a/docs/dev/mcp-servers.md
+++ b/docs/dev/mcp-servers.md
@@ -86,8 +86,16 @@ Tesserae, faithfully render, mine a data schema, and prepare a catalog PR. Full 
 serves on `http://localhost:8770` and should point at your Tesserae via
 `STUDIO_TESSERAE_URL` for live data + faithful render.
 
-**2. Install the bridge.** It ships with the Studio server package (`pip install -e server`
-gives you the `tesserae-studio-mcp` command), or run it as a module.
+**2. Install the bridge** on the machine where your *agent* runs:
+
+```bash
+pip install tesserae-studio-mcp
+```
+
+That gives you the `tesserae-studio-mcp` command. (The bridge lives in the Tesserae Studio repo
+under `packages/tesserae-studio-mcp`; to install straight from source use
+`pip install "git+https://github.com/dmellok/tesserae-studio#subdirectory=packages/tesserae-studio-mcp"`.
+It also still ships with the Studio server package for source installs.)
 
 **3. Configure your agent.** Claude Desktop / Claude Code `mcpServers` config:
 
@@ -95,8 +103,7 @@ gives you the `tesserae-studio-mcp` command), or run it as a module.
 {
   "mcpServers": {
     "tesserae-studio": {
-      "command": "python",
-      "args": ["-m", "studio_server.mcp_server"],
+      "command": "tesserae-studio-mcp",
       "env": { "STUDIO_URL": "http://localhost:8770" }
     }
   }
@@ -134,7 +141,7 @@ What every client needs:
 | env | `TESSERAE_URL` (+ `TESSERAE_MCP_TOKEN` for a remote target) | `STUDIO_URL` |
 
 If the console scripts aren't on your `PATH`, use `command: "python"` with
-`args: ["-m", "tesserae_mcp"]` (or `["-m", "studio_server.mcp_server"]`).
+`args: ["-m", "tesserae_mcp"]` (or `["-m", "tesserae_studio_mcp"]`).
 
 **Claude Desktop / Code, Cursor, Windsurf, Cline** share the `mcpServers` JSON shape.
 The same block works in each; only the file it goes in differs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.110.3"
+version = "0.110.4"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }


### PR DESCRIPTION
`tesserae-studio-mcp` is now on PyPI (https://pypi.org/project/tesserae-studio-mcp/), split out under `packages/tesserae-studio-mcp` in the `dmellok/tesserae-studio` repo. This updates the Studio bridge's docs so its install matches the `tesserae-mcp` section.

In `docs/dev/mcp-servers.md` (Studio section only; the tesserae-mcp/dashboards section is untouched):

- **Step 2 (install):** `pip install -e server` → `pip install tesserae-studio-mcp`, with a from-source fallback and a note that it still ships with the Studio server package for source installs.
- **Step 3 (agent config):** the `mcpServers` command switches from `python` + `["-m","studio_server.mcp_server"]` to the `tesserae-studio-mcp` console script (consistent with the one-liner below it and the client-config table).
- **Client-config fallback:** `["-m","studio_server.mcp_server"]` → `["-m","tesserae_studio_mcp"]` (the PyPI package's module).

Docs build passes `mkdocs build --strict`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)