### PR TITLE
feat(ha): ha_automation_history widget (#80)

### DIFF
--- a/plugins/ha_automation_history/client.js
+++ b/plugins/ha_automation_history/client.js
@@ -1,0 +1,218 @@
+// ha_automation_history — HA automation firing history.
+//
+// Fragment-first, ha_* family house style: paints on the shared
+// spectra-widgets.css structural classes (.w-title / .w-body / list-body /
+// list-lead / list-title / list-meta / u-muted) + design tokens, never raw
+// pixels. `full` = ranking + totals + recently-active board; `bar` = a
+// fired-count chip. No images, no dither, no animation, idempotent innerHTML.
+
+export default function render(shadow, ctx) {
+  const data = (ctx && ctx.data) || {};
+  const o = (ctx.cell && ctx.cell.options) || {};
+  const fragment = (ctx.cell && ctx.cell.fragment) || ctx.fragment || "full";
+  const title = (o.title && o.title.trim()) || data.title || "Automations";
+
+  // ---- helpers ------------------------------------------------------------
+  const num = (n) => typeof n === "number" && isFinite(n);
+  const esc = (s) =>
+    String(s == null ? "" : s).replace(/[&<>"']/g, (c) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c])
+    );
+  function ago(sec) {
+    if (!num(sec)) return "—";
+    if (sec < 45) return "now";
+    if (sec < 3600) return Math.round(sec / 60) + "m";
+    if (sec < 86400) return Math.round(sec / 3600) + "h";
+    return Math.round(sec / 86400) + "d";
+  }
+  const count = (n) => (num(n) ? String(n) : "0");
+
+  const css = `<link rel="stylesheet" href="/static/style/spectra-widgets.css">`;
+  const layout = `
+    .ah-stack { display: flex; flex-direction: column; gap: var(--space-1);
+                height: 100%; min-height: 0; }
+
+    .ah-rank { display: flex; gap: var(--space-2); flex: 0 0 auto; }
+    .ah-rank .tile { flex: 1 1 0; min-width: 0; background: var(--surface-sunken);
+                     border-radius: var(--radius-1); padding: var(--space-2);
+                     display: flex; flex-direction: column; gap: 1px; }
+    .ah-rank .lab { display: flex; align-items: center; gap: var(--space-1);
+                    font-size: var(--fs-caption); font-weight: var(--fw-bold);
+                    letter-spacing: var(--ls-label); text-transform: uppercase;
+                    color: var(--text-muted); white-space: nowrap; overflow: hidden; }
+    .ah-rank .most .lab i { color: var(--accent-2); }
+    .ah-rank .least .lab i { color: var(--text-muted); }
+    .ah-rank .nm { font-weight: var(--fw-bold); white-space: nowrap;
+                   overflow: hidden; text-overflow: ellipsis; }
+    .ah-rank .ct { font-size: var(--fs-caption); color: var(--text-secondary);
+                   font-variant-numeric: tabular-nums; }
+
+    .ah-totals { display: flex; gap: var(--space-2); flex: 0 0 auto; }
+    .ah-totals .cell { flex: 1 1 0; text-align: center; background: var(--surface-sunken);
+                       border-radius: var(--radius-1); padding: var(--space-1); }
+    .ah-totals .n { font-weight: var(--fw-black); font-size: 1.4em; line-height: 1.05;
+                    font-variant-numeric: tabular-nums; }
+    .ah-totals .l { font-size: var(--fs-caption); color: var(--text-muted);
+                    letter-spacing: var(--ls-label); text-transform: uppercase; }
+
+    .ah-recent { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column;
+                 gap: 1px; overflow: hidden; }
+    .ah-recent .subhead { font-size: var(--fs-caption); font-weight: var(--fw-bold);
+                          letter-spacing: var(--ls-label); text-transform: uppercase;
+                          color: var(--text-muted); flex: 0 0 auto; margin-bottom: 1px; }
+    .arow { display: flex; align-items: center; justify-content: space-between;
+            gap: var(--space-2); padding: 2px var(--space-2);
+            border-radius: var(--radius-1); min-width: 0; }
+    .arow.is-zebra { background: color-mix(in oklab, var(--text-primary) 3%, transparent); }
+    .arow.is-stale { background: color-mix(in oklab, var(--accent-1) 8%, var(--surface));
+                     box-shadow: inset 3px 0 0 var(--accent-1); }
+    .arow .list-lead { flex: 1 1 auto; min-width: 0; display: flex; align-items: center;
+                       gap: var(--space-2); }
+    .arow .dot { flex: 0 0 auto; width: .5em; height: .5em; border-radius: 50%;
+                 background: var(--accent-3); }
+    .arow.is-off .dot { background: var(--text-muted); }
+    .arow .list-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .arow.is-off .list-title { color: var(--text-muted); }
+    .arow .flag { flex: 0 0 auto; color: var(--accent-1); }
+    .arow .list-meta { flex: 0 0 auto; font-variant-numeric: tabular-nums;
+                       color: var(--text-secondary); }
+    .arow .list-meta .x { color: var(--text-muted); margin-right: .4em; }
+
+    .w-title-meta .stale { color: var(--accent-1); font-weight: var(--fw-bold);
+                           margin-right: var(--space-1); }
+
+    /* responsive trimming — the .w is a size container in spectra-widgets.css */
+    @container (max-width: 460px) { .ah-totals { display: none; } }
+    @container (max-width: 210px) {
+      .ah-recent, .w-title-meta .win { display: none; }
+      .ah-rank { flex-direction: column; }
+    }
+
+    /* bar fragment */
+    .ah-bar { display: flex; align-items: center; gap: var(--space-2); height: 100%;
+              padding: 0 var(--space-2); box-sizing: border-box; }
+    .ah-bar i.logo { color: var(--accent-3); font-size: clamp(1.3em, 44cqmin, 2.8em); flex: 0 0 auto; }
+    .ah-bar .stat { display: flex; align-items: baseline; gap: .25em; min-width: 0; }
+    .ah-bar .stat b { font-size: clamp(1.3em, 44cqmin, 2.8em); font-weight: var(--fw-black);
+                      font-variant-numeric: tabular-nums; }
+    .ah-bar .stat small { color: var(--text-secondary); font-size: clamp(.55em, 16cqmin, 1em); }
+    .ah-bar .sep { color: var(--text-muted); flex: 0 0 auto; }
+    .ah-bar .barstale { margin-left: auto; display: inline-flex; align-items: center;
+                        gap: .2em; color: var(--accent-1); font-weight: var(--fw-bold);
+                        font-size: clamp(.55em, 16cqmin, .95em); flex: 0 0 auto; }
+  `;
+
+  // ---- error state --------------------------------------------------------
+  if (data.error) {
+    shadow.innerHTML = `${css}
+      <div class="w" data-widget="ha_automation_history">
+        <div class="w-title"><i class="ph-bold ph-warning-circle"></i><h3>${esc(title)}</h3></div>
+        <div class="w-body"><p class="u-muted">${esc(data.error)}</p></div>
+      </div>`;
+    return;
+  }
+
+  // ---- empty state --------------------------------------------------------
+  if (data.empty || !Array.isArray(data.automations) || data.automations.length === 0) {
+    shadow.innerHTML = `${css}
+      <div class="w" data-widget="ha_automation_history">
+        <div class="w-title"><i class="ph-bold ph-lightning-slash"></i><h3>${esc(title)}</h3></div>
+        <div class="w-body"><p class="u-muted">No automations found${
+          data.tracked_all === false ? " for your selection" : ""
+        }.</p></div>
+      </div>`;
+    return;
+  }
+
+  // ---- bar fragment -------------------------------------------------------
+  if (fragment === "bar") {
+    const stale = num(data.stale_count) && data.stale_count > 0
+      ? `<span class="barstale"><i class="ph-bold ph-warning"></i>${data.stale_count}</span>` : "";
+    shadow.innerHTML = `${css}<style>${layout}</style>
+      <div class="w" data-widget="ha_automation_history">
+        <div class="ah-bar">
+          <i class="ph-bold ph-lightning logo"></i>
+          <span class="stat"><b>${count(data.total_24h)}</b><small>fired · 24h</small></span>
+          <span class="sep">·</span>
+          <span class="stat"><b>${count(data.total_1h)}</b><small>1h</small></span>
+          ${stale}
+        </div>
+      </div>`;
+    return;
+  }
+
+  // ---- full board ---------------------------------------------------------
+  const most = data.most_fired;
+  const least = data.least_fired;
+  const rankTiles =
+    (most
+      ? `<div class="tile most">
+           <div class="lab"><i class="ph-bold ph-trophy"></i>Most fired · 7d</div>
+           <div class="nm">${esc(most.name)}</div>
+           <div class="ct">${count(most.c7)} triggers</div>
+         </div>`
+      : `<div class="tile most">
+           <div class="lab"><i class="ph-bold ph-moon"></i>This week</div>
+           <div class="nm">No triggers</div>
+           <div class="ct">quiet week</div>
+         </div>`) +
+    (least
+      ? `<div class="tile least">
+           <div class="lab"><i class="ph-bold ph-arrow-down"></i>Least fired · 7d</div>
+           <div class="nm">${esc(least.name)}</div>
+           <div class="ct">${count(least.c7)} triggers</div>
+         </div>`
+      : "");
+
+  const totals = `
+    <div class="ah-totals">
+      <div class="cell"><div class="n">${count(data.total_1h)}</div><div class="l">1 hour</div></div>
+      <div class="cell"><div class="n">${count(data.total_24h)}</div><div class="l">24 hours</div></div>
+      <div class="cell"><div class="n">${count(data.total_7d)}</div><div class="l">7 days</div></div>
+    </div>`;
+
+  const feed = Array.isArray(data.recent) ? data.recent : [];
+  const byId = {};
+  (data.automations || []).forEach((a) => { byId[a.eid] = a; });
+  const rows = feed
+    .map((r, i) => {
+      const a = byId[r.eid] || {};
+      const cls =
+        (i % 2 ? " is-zebra" : "") + (a.stale ? " is-stale" : "") + (a.on === false ? " is-off" : "");
+      const flag = a.stale ? `<i class="ph-bold ph-warning flag"></i>` : "";
+      const n7 = num(a.c7) ? `<span class="x">${a.c7}×</span>` : "";
+      return `<div class="arow${cls}">
+        <div class="list-lead"><span class="dot"></span>
+          <span class="list-title">${esc(r.name)}</span>${flag}</div>
+        <span class="list-meta">${n7}${ago(r.ago_s)}</span>
+      </div>`;
+    })
+    .join("");
+  const recent = `
+    <div class="ah-recent">
+      <div class="subhead">Recently active</div>
+      <div class="list-body">${
+        rows || `<p class="u-muted">Nothing in the last ${esc(data.window_days || 7)} days.</p>`
+      }</div>
+    </div>`;
+
+  const stale = num(data.stale_count) && data.stale_count > 0
+    ? `<span class="stale"><i class="ph-bold ph-warning"></i> ${data.stale_count} stale</span>` : "";
+  const meta = `<span class="w-title-meta">${stale}<span class="win">${esc(data.window_days || 7)}d</span></span>`;
+
+  shadow.innerHTML = `${css}<style>${layout}</style>
+    <div class="w" data-widget="ha_automation_history">
+      <div class="w-title">
+        <i class="ph-bold ph-lightning" style="color:var(--accent-3)"></i>
+        <h3>${esc(title)}</h3>
+        ${meta}
+      </div>
+      <div class="w-body">
+        <div class="ah-stack">
+          <div class="ah-rank">${rankTiles}</div>
+          ${totals}
+          ${recent}
+        </div>
+      </div>
+    </div>`;
+}

--- a/plugins/ha_automation_history/plugin.json
+++ b/plugins/ha_automation_history/plugin.json
@@ -1,0 +1,170 @@
+{
+  "tesserae_compat": "1.x",
+  "name": "Home Assistant, Automation History",
+  "version": "0.1.0",
+  "kind": "widget",
+  "description": "Which Home Assistant automations fired, when, and how often. Ranks the most- vs least-fired automation this week, streams a most-recent-first trigger feed, tallies 1h / 24h / 7d trigger counts, and flags any tracked automation that hasn't fired within an expected cadence. Reads automation.* logbook history via the Home Assistant Core plugin.",
+  "icon": "ph-lightning",
+  "supports": {
+    "sizes": [
+      "xs",
+      "sm",
+      "md",
+      "lg"
+    ]
+  },
+  "cell_options": [
+    {
+      "name": "title",
+      "type": "string",
+      "label": "Title (blank = \"Automations\")",
+      "default": ""
+    },
+    {
+      "name": "automations",
+      "type": "multiselect",
+      "label": "Automations (blank = all)",
+      "default": [],
+      "choices_from": "entity",
+      "help": "Leave blank to track every automation; the busiest ~12 are read in detail each refresh."
+    },
+    {
+      "name": "stale_hours",
+      "type": "number",
+      "label": "Stale alert after (hours, blank = off)",
+      "default": "",
+      "help": "Flag a tracked automation that hasn't fired within this many hours. Leave blank to disable."
+    },
+    {
+      "name": "refresh",
+      "type": "select",
+      "label": "Refresh",
+      "default": "60",
+      "choices": [
+        { "value": "60", "label": "Every minute" },
+        { "value": "300", "label": "Every 5 min" },
+        { "value": "900", "label": "Every 15 min" }
+      ]
+    }
+  ],
+  "fragments": [
+    { "id": "full", "label": "Ranking + recent", "w": 320, "h": 220, "icon": "ph-lightning" },
+    { "id": "bar", "label": "Fired count", "w": 240, "h": 64, "icon": "ph-lightning-a" }
+  ],
+  "render": {
+    "dither": "none",
+    "needs_network": true
+  },
+  "data_schema": {
+    "fields": [
+      { "name": "automations[].c1", "label": "Triggers (1h)", "type": "arr" },
+      { "name": "automations[].c24", "label": "Triggers (24h)", "type": "arr" },
+      { "name": "automations[].c7", "label": "Triggers (7d)", "type": "arr" },
+      { "name": "automations[].eid", "label": "Entity id", "type": "arr" },
+      { "name": "automations[].last_ago_s", "label": "Last fired (s ago)", "type": "arr" },
+      { "name": "automations[].last_triggered", "label": "Last triggered", "type": "arr" },
+      { "name": "automations[].name", "label": "Name", "type": "arr" },
+      { "name": "automations[].on", "label": "Enabled", "type": "arr" },
+      { "name": "automations[].stale", "label": "Stale", "type": "arr" },
+      { "name": "capped", "label": "Capped", "type": "str" },
+      { "name": "count", "label": "Automation count", "type": "num" },
+      { "name": "fetched_at", "label": "Fetched at", "type": "num" },
+      { "name": "least_fired.c7", "label": "Least fired triggers (7d)", "type": "num" },
+      { "name": "least_fired.eid", "label": "Least fired entity id", "type": "str" },
+      { "name": "least_fired.name", "label": "Least fired name", "type": "str" },
+      { "name": "most_fired.c7", "label": "Most fired triggers (7d)", "type": "num" },
+      { "name": "most_fired.eid", "label": "Most fired entity id", "type": "str" },
+      { "name": "most_fired.name", "label": "Most fired name", "type": "str" },
+      { "name": "recent[].ago_s", "label": "Fired (s ago)", "type": "arr" },
+      { "name": "recent[].eid", "label": "Entity id", "type": "arr" },
+      { "name": "recent[].name", "label": "Name", "type": "arr" },
+      { "name": "recent[].when", "label": "When", "type": "arr" },
+      { "name": "stale_count", "label": "Stale count", "type": "num" },
+      { "name": "stale_hours", "label": "Stale threshold (h)", "type": "num" },
+      { "name": "title", "label": "Title", "type": "str" },
+      { "name": "total_1h", "label": "Total fired (1h)", "type": "num" },
+      { "name": "total_24h", "label": "Total fired (24h)", "type": "num" },
+      { "name": "total_7d", "label": "Total fired (7d)", "type": "num" },
+      { "name": "tracked_all", "label": "Tracking all", "type": "str" },
+      { "name": "window_days", "label": "Window (days)", "type": "num" }
+    ],
+    "sample": {
+      "automations": [
+        {
+          "c1": 66,
+          "c24": 747,
+          "c7": 4228,
+          "eid": "automation.vfd_auto_brightness_from_lux",
+          "last_ago_s": 103,
+          "last_triggered": "2026-07-13T05:50:28.826142+00:00",
+          "name": "VFD - Auto brightness from lux",
+          "on": true,
+          "stale": false
+        },
+        {
+          "c1": 0,
+          "c24": 39,
+          "c7": 341,
+          "eid": "automation.vfd_presence_on_off",
+          "last_ago_s": 5713,
+          "last_triggered": "2026-07-13T04:16:58.443311+00:00",
+          "name": "VFD - Presence on/off",
+          "on": true,
+          "stale": false
+        },
+        {
+          "c1": 0,
+          "c24": 7,
+          "c7": 138,
+          "eid": "automation.desk_light_dim_at_desk_boost_when_away",
+          "last_ago_s": 61625,
+          "last_triggered": "2026-07-12T12:45:06.692932+00:00",
+          "name": "Desk Light - Dim at desk / Boost when away",
+          "on": true,
+          "stale": false
+        }
+      ],
+      "capped": false,
+      "count": 15,
+      "fetched_at": 1783921932,
+      "least_fired": {
+        "c7": 4,
+        "eid": "automation.closet_light_door_auto",
+        "name": "Closet Light - Door Auto"
+      },
+      "most_fired": {
+        "c7": 4228,
+        "eid": "automation.vfd_auto_brightness_from_lux",
+        "name": "VFD - Auto brightness from lux"
+      },
+      "recent": [
+        {
+          "ago_s": 103,
+          "eid": "automation.vfd_auto_brightness_from_lux",
+          "name": "VFD - Auto brightness from lux",
+          "when": "2026-07-13T05:50:28.826139+00:00"
+        },
+        {
+          "ago_s": 5713,
+          "eid": "automation.vfd_presence_on_off",
+          "name": "VFD - Presence on/off",
+          "when": "2026-07-13T04:16:58.443309+00:00"
+        },
+        {
+          "ago_s": 31931,
+          "eid": "automation.blinds_up",
+          "name": "Blinds Up",
+          "when": "2026-07-12T21:00:00.494053+00:00"
+        }
+      ],
+      "stale_count": 0,
+      "stale_hours": 0.0,
+      "title": "",
+      "total_1h": 66,
+      "total_24h": 797,
+      "total_7d": 4744,
+      "tracked_all": true,
+      "window_days": 7
+    }
+  }
+}

--- a/plugins/ha_automation_history/server.py
+++ b/plugins/ha_automation_history/server.py
@@ -288,9 +288,7 @@ def _build(
         "total_24h": sum(a["c24"] for a in autos),
         "total_7d": sum(a["c7"] for a in autos),
         "most_fired": _rank(most),
-        "least_fired": (
-            _rank(least) if least and most and least["eid"] != most["eid"] else None
-        ),
+        "least_fired": (_rank(least) if least and most and least["eid"] != most["eid"] else None),
         "stale_count": sum(1 for a in autos if a["stale"]),
         "stale_hours": stale_h,
         "fetched_at": now,

--- a/plugins/ha_automation_history/server.py
+++ b/plugins/ha_automation_history/server.py
@@ -69,9 +69,7 @@ def _is_trigger(entry: dict[str, Any]) -> bool:
     if entry.get("state") in ("on", "off"):
         return False
     msg = str(entry.get("message") or "").lower()
-    if msg and "trigger" not in msg:
-        return False
-    return True
+    return not (msg and "trigger" not in msg)
 
 
 def _refresh_s(raw: Any) -> int:
@@ -122,7 +120,7 @@ def _logbook(
     )
     try:
         data = core.request_json(path, timeout=12)
-    except Exception as err:  # noqa: BLE001 — surfaced via coerce_error
+    except Exception as err:
         return [], core.coerce_error(err)
     return ([e for e in data if isinstance(e, dict)] if isinstance(data, list) else []), None
 
@@ -173,7 +171,7 @@ def _build(
 ) -> tuple[dict[str, Any] | None, str | None]:
     try:
         states = core.get_states()
-    except Exception as err:  # noqa: BLE001 — surfaced via coerce_error
+    except Exception as err:
         return None, core.coerce_error(err)
 
     now_dt = datetime.now(UTC)

--- a/plugins/ha_automation_history/server.py
+++ b/plugins/ha_automation_history/server.py
@@ -1,0 +1,299 @@
+"""ha_automation_history — which Home Assistant automations fired, when, how often.
+
+Thin widget over ha_core. ``get_states`` gives every ``automation.*`` entity
+with its ``last_triggered`` attribute in one call; a per-automation logbook
+fetch over a rolling 7-day window gives the trigger history we bucket into
+1h / 24h / 7d counts, a most-/least-fired weekly ranking, and a most-recent-
+first "recently active" feed (one row per automation). An automation whose
+last trigger is older than the configured cadence is flagged stale.
+
+Cost control: we only hit the logbook for automations that actually fired in
+the last 7 days (per ``last_triggered``), capped at ``MAX_LOGBOOK`` of them, so
+a big install with hundreds of dormant automations stays a couple of REST
+calls. Results are cached in ctx["data_dir"] for the refresh window so composer
+re-renders don't re-poll.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import re
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from flask import current_app
+
+WINDOW_DAYS = 7
+MAX_LOGBOOK = 12  # cap per-automation logbook fetches per render
+RECENT_LIMIT = 8  # rows in the recently-active feed
+HOUR_S = 3600
+DAY_S = 86400
+
+
+def _core() -> Any:
+    plugin = current_app.config["PLUGIN_REGISTRY"].get("ha_core")
+    return plugin.server_module if plugin is not None else None
+
+
+def choices(name: str) -> list[dict[str, str]]:
+    """Automation entity multi-select for the editor."""
+    core = _core()
+    if name == "entity" and core is not None:
+        return core.entity_choices(domains=("automation",))
+    return []
+
+
+def _entity_list(raw: Any) -> list[str]:
+    """Accept the multiselect's list, or a legacy comma/newline string."""
+    if isinstance(raw, list):
+        return [str(x).strip() for x in raw if str(x).strip()]
+    return [tok for tok in re.split(r"[\s,]+", str(raw or "").strip()) if tok]
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_trigger(entry: dict[str, Any]) -> bool:
+    """A logbook entry for the automation actually firing, not it being
+    enabled/disabled (those carry an on/off state) or an unrelated note."""
+    if entry.get("state") in ("on", "off"):
+        return False
+    msg = str(entry.get("message") or "").lower()
+    if msg and "trigger" not in msg:
+        return False
+    return True
+
+
+def _refresh_s(raw: Any) -> int:
+    try:
+        return max(30, int(float(raw)))
+    except (TypeError, ValueError):
+        return 60
+
+
+def _stale_hours(raw: Any) -> float:
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _cache_slug(eids: list[str], stale_h: float) -> str:
+    basis = ",".join(sorted(eids)) + f"|{stale_h}"
+    return re.sub(r"[^A-Za-z0-9]", "_", basis)[:80] or "all"
+
+
+def _cache_path(data_dir: Any, eids: list[str], stale_h: float) -> Path | None:
+    """Cache file for this option set, or None when there's no data_dir
+    (e.g. unit tests pass ctx={}), so caching stays best-effort."""
+    if not data_dir:
+        return None
+    try:
+        d = Path(data_dir)
+        d.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+    return d / f"result_{_cache_slug(eids, stale_h)}.json"
+
+
+def _rank(a: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not a:
+        return None
+    return {"name": a["name"], "eid": a["eid"], "c7": a["c7"]}
+
+
+def _logbook(
+    core: Any, eid: str, start_dt: datetime, end_dt: datetime
+) -> tuple[list[dict[str, Any]], str | None]:
+    """Logbook entries for one automation over [start, end] → (entries, err)."""
+    path = (
+        f"/api/logbook/{quote(start_dt.isoformat())}"
+        f"?entity={quote(eid)}&end_time={quote(end_dt.isoformat())}"
+    )
+    try:
+        data = core.request_json(path, timeout=12)
+    except Exception as err:  # noqa: BLE001 — surfaced via coerce_error
+        return [], core.coerce_error(err)
+    return ([e for e in data if isinstance(e, dict)] if isinstance(data, list) else []), None
+
+
+def fetch(
+    options: dict[str, Any], settings: dict[str, Any], *, ctx: dict[str, Any]
+) -> dict[str, Any]:
+    del settings
+    core = _core()
+    if core is None:
+        return {"error": "Install the Home Assistant Core plugin to use this widget."}
+
+    title = str(options.get("title") or "").strip()
+    wanted = _entity_list(options.get("automations"))
+    stale_h = _stale_hours(options.get("stale_hours"))
+    refresh_s = _refresh_s(options.get("refresh"))
+
+    if not core.is_configured():
+        return {
+            "error": "Set your Home Assistant URL + token in Plugins → Home Assistant Core.",
+            "title": title,
+        }
+
+    now = int(time.time())
+    cache_path = _cache_path(ctx.get("data_dir"), wanted, stale_h)
+    if cache_path and cache_path.exists() and now - int(cache_path.stat().st_mtime) < refresh_s:
+        try:
+            cached = json.loads(cache_path.read_text(encoding="utf-8"))
+            if title:
+                cached["title"] = title
+            return cached  # type: ignore[no-any-return]
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    result, err = _build(core, wanted, stale_h, now)
+    if err or result is None:
+        return {"error": err or "Couldn't read Home Assistant automations.", "title": title}
+    if title:
+        result["title"] = title
+    if cache_path:
+        with contextlib.suppress(OSError):
+            cache_path.write_text(json.dumps(result), encoding="utf-8")
+    return result
+
+
+def _build(
+    core: Any, wanted: list[str], stale_h: float, now: int
+) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        states = core.get_states()
+    except Exception as err:  # noqa: BLE001 — surfaced via coerce_error
+        return None, core.coerce_error(err)
+
+    now_dt = datetime.now(UTC)
+    window_start = now_dt - timedelta(days=WINDOW_DAYS)
+
+    autos: list[dict[str, Any]] = []
+    for st in states:
+        eid = str(st.get("entity_id") or "")
+        if not eid.startswith("automation."):
+            continue
+        if wanted and eid not in wanted:
+            continue
+        attrs = st.get("attributes") or {}
+        last_dt = _parse_ts(attrs.get("last_triggered"))
+        autos.append(
+            {
+                "eid": eid,
+                "name": core.friendly_name(st),
+                "on": str(st.get("state") or "").lower() == "on",
+                "last_dt": last_dt,
+                "c1": 0,
+                "c24": 0,
+                "c7": 0,
+            }
+        )
+
+    if not autos:
+        return {"empty": True, "title": ""}, None
+
+    # Only the automations that fired within the window need a logbook read;
+    # dormant ones keep their zero counts for free. Cap the fetch count.
+    active = sorted(
+        (a for a in autos if a["last_dt"] and a["last_dt"] >= window_start),
+        key=lambda a: a["last_dt"],
+        reverse=True,
+    )
+    capped = len(active) > MAX_LOGBOOK
+    to_fetch = active[:MAX_LOGBOOK]
+
+    # Track the single most-recent trigger per automation for the feed.
+    last_fire: dict[str, dict[str, Any]] = {}
+    fetch_err: str | None = None
+    for a in to_fetch:
+        entries, err = _logbook(core, a["eid"], window_start, now_dt)
+        if err:
+            fetch_err = err
+            continue
+        for e in entries:
+            if not _is_trigger(e):
+                continue
+            when = _parse_ts(e.get("when"))
+            if when is None:
+                continue
+            age = max(0.0, (now_dt - when).total_seconds())
+            a["c7"] += 1
+            if age <= DAY_S:
+                a["c24"] += 1
+            if age <= HOUR_S:
+                a["c1"] += 1
+            prev = last_fire.get(a["eid"])
+            if prev is None or when.isoformat() > prev["when"]:
+                last_fire[a["eid"]] = {
+                    "name": a["name"],
+                    "eid": a["eid"],
+                    "when": when.isoformat(),
+                    "ago_s": int(age),
+                }
+
+    # Every logbook call failed and nothing came back → surface the error
+    # rather than a misleading all-zero board.
+    if fetch_err and to_fetch and not last_fire:
+        return None, fetch_err
+
+    for a in autos:
+        last_dt = a["last_dt"]
+        a["last_ago_s"] = int((now_dt - last_dt).total_seconds()) if last_dt else None
+        a["last_triggered"] = last_dt.isoformat() if last_dt else None
+        a["stale"] = bool(stale_h) and (
+            last_dt is None or (now_dt - last_dt).total_seconds() > stale_h * HOUR_S
+        )
+
+    fired = [a for a in autos if a["c7"] > 0]
+    most = max(fired, key=lambda a: a["c7"]) if fired else None
+    least = min(fired, key=lambda a: a["c7"]) if fired else None
+
+    # One row per automation, most-recently-fired first.
+    recent = sorted(last_fire.values(), key=lambda r: r["when"], reverse=True)
+
+    autos.sort(key=lambda a: (-a["c7"], a["name"].lower()))
+    out_autos = [
+        {
+            "name": a["name"],
+            "eid": a["eid"],
+            "on": a["on"],
+            "c1": a["c1"],
+            "c24": a["c24"],
+            "c7": a["c7"],
+            "last_triggered": a["last_triggered"],
+            "last_ago_s": a["last_ago_s"],
+            "stale": a["stale"],
+        }
+        for a in autos
+    ]
+
+    return {
+        "title": "",
+        "count": len(autos),
+        "tracked_all": not wanted,
+        "capped": capped,
+        "window_days": WINDOW_DAYS,
+        "automations": out_autos,
+        "recent": recent[:RECENT_LIMIT],
+        "total_1h": sum(a["c1"] for a in autos),
+        "total_24h": sum(a["c24"] for a in autos),
+        "total_7d": sum(a["c7"] for a in autos),
+        "most_fired": _rank(most),
+        "least_fired": (
+            _rank(least) if least and most and least["eid"] != most["eid"] else None
+        ),
+        "stale_count": sum(1 for a in autos if a["stale"]),
+        "stale_hours": stale_h,
+        "fetched_at": now,
+    }, None

--- a/plugins/ha_automation_history/tests/test_smoke.py
+++ b/plugins/ha_automation_history/tests/test_smoke.py
@@ -1,0 +1,127 @@
+"""ha_automation_history smoke: fetch() buckets logbook triggers into
+1h/24h/7d counts, ranks most/least fired, dedupes the recent feed to one row
+per automation, and flags stale automations — ha_core.get_states,
+request_json, and is_configured monkeypatched (no network)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from flask import Flask
+from flask.testing import FlaskClient
+
+
+def _mods(app: Flask):
+    reg = app.config["PLUGIN_REGISTRY"]
+    return reg.get("ha_automation_history").server_module, reg.get("ha_core").server_module
+
+
+def _iso(delta_s: float) -> str:
+    return (datetime.now(UTC) - timedelta(seconds=delta_s)).isoformat()
+
+
+def _states() -> list[dict]:
+    """Two automations (one busy, one rare) + a non-automation entity that
+    must be ignored. last_triggered sits inside the 7-day window so both get
+    a logbook read."""
+    return [
+        {
+            "entity_id": "automation.busy",
+            "state": "on",
+            "attributes": {"friendly_name": "Busy", "last_triggered": _iso(60)},
+        },
+        {
+            "entity_id": "automation.rare",
+            "state": "on",
+            "attributes": {"friendly_name": "Rare", "last_triggered": _iso(3 * 86400)},
+        },
+        {
+            "entity_id": "light.lamp",
+            "state": "on",
+            "attributes": {"friendly_name": "Lamp"},
+        },
+    ]
+
+
+def _logbook_for(path: str) -> list[dict]:
+    """Fake per-automation logbook keyed off the entity in the request path."""
+    if "automation.busy" in path:
+        # 2 in the last hour, +1 more in 24h, +1 more in 7d → c1=2, c24=3, c7=4
+        return [
+            {"when": _iso(60), "name": "Busy"},
+            {"when": _iso(1800), "name": "Busy"},
+            {"when": _iso(7200), "name": "Busy"},
+            {"when": _iso(2 * 86400), "name": "Busy"},
+            {"when": _iso(300), "name": "Busy", "state": "off"},  # enable/disable, ignored
+        ]
+    if "automation.rare" in path:
+        return [{"when": _iso(3 * 86400), "name": "Rare"}]
+    return []
+
+
+def _wire(app: Flask, monkeypatch) -> None:
+    _, core = _mods(app)
+    monkeypatch.setattr(core, "is_configured", lambda: True)
+    monkeypatch.setattr(core, "get_states", _states)
+    monkeypatch.setattr(core, "request_json", lambda path, timeout=12: _logbook_for(path))
+
+
+def test_error_when_not_configured(app: Flask, monkeypatch) -> None:
+    mod, core = _mods(app)
+    monkeypatch.setattr(core, "is_configured", lambda: False)
+    with app.app_context():
+        out = mod.fetch({}, {}, ctx={})
+    assert "Home Assistant" in out["error"]
+
+
+def test_empty_when_no_automations(app: Flask, monkeypatch) -> None:
+    mod, core = _mods(app)
+    monkeypatch.setattr(core, "is_configured", lambda: True)
+    monkeypatch.setattr(core, "get_states", lambda: [_states()[2]])  # only the light
+    with app.app_context():
+        out = mod.fetch({}, {}, ctx={})
+    assert out["empty"] is True
+
+
+def test_counts_ranking_and_recent(app: Flask, monkeypatch) -> None:
+    mod, _core = _mods(app)
+    _wire(app, monkeypatch)
+    with app.app_context():
+        out = mod.fetch({}, {}, ctx={})
+
+    assert out["count"] == 2
+    assert out["tracked_all"] is True
+
+    by_id = {a["eid"]: a for a in out["automations"]}
+    busy = by_id["automation.busy"]
+    assert (busy["c1"], busy["c24"], busy["c7"]) == (2, 3, 4)  # off-state entry ignored
+    assert by_id["automation.rare"]["c7"] == 1
+
+    assert out["total_1h"] == 2
+    assert out["total_24h"] == 3
+    assert out["total_7d"] == 5
+
+    assert out["most_fired"]["eid"] == "automation.busy"
+    assert out["most_fired"]["c7"] == 4
+    assert out["least_fired"]["eid"] == "automation.rare"
+
+    # Recent feed is one row per automation, most-recently-fired first.
+    assert [r["eid"] for r in out["recent"]] == ["automation.busy", "automation.rare"]
+    assert out["stale_count"] == 0
+
+
+def test_stale_flag(app: Flask, monkeypatch) -> None:
+    mod, _core = _mods(app)
+    _wire(app, monkeypatch)
+    with app.app_context():
+        out = mod.fetch({"stale_hours": 1}, {}, ctx={})
+    by_id = {a["eid"]: a for a in out["automations"]}
+    assert by_id["automation.busy"]["stale"] is False  # fired 60s ago
+    assert by_id["automation.rare"]["stale"] is True  # fired 3 days ago
+    assert out["stale_count"] == 1
+
+
+def test_composer_mounts_widget(client: FlaskClient) -> None:
+    resp = client.get("/_test/render?plugin=ha_automation_history&size=md")
+    assert resp.status_code == 200
+    assert 'data-plugin="ha_automation_history"' in resp.get_data(as_text=True)


### PR DESCRIPTION
Closes #80.

A new `ha_automation_history` widget for the `ha_*` family — the automation side of `ha_history`: which Home Assistant automations fired, when, and how often. Reuses `ha_core` for the connection (no new settings/egress).

## What it shows
- **Ranking:** most-fired vs least-fired automation this week
- **Totals:** 1h / 24h / 7d trigger counts across tracked automations
- **Recently active:** most-recent-first feed, one row per automation, with its 7d count + last-fired age
- **Stale alert:** flags any tracked automation that hasn't fired within a configured cadence (header/bar count + per-row wash)

## How it works
- One `get_states()` for `automation.*` entities (name, enabled, `last_triggered`), then a per-automation `/api/logbook` read over a rolling 7-day window — **only** for automations that fired inside the window, **capped at 12** so a big install with hundreds of dormant automations stays a couple of REST calls.
- Logbook entries bucketed into 1h/24h/7d; enable/disable state-change entries filtered out. Result cached in `ctx["data_dir"]` per refresh window (60s default). Friendly-error path throughout; never raises.

## Fragments & sizing
- `full` = ranking tiles + totals + recent list; `bar` = fired-count chip.
- Painted on the shared `spectra-widgets.css` house style (`.w-title`/`.w-body`/list rows + design tokens, zebra rows, accent-1 stale wash), container-query responsive across xs/sm/md/lg.

## Cell options
`title`, `automations` (multiselect entity picker, blank = all), `stale_hours` (blank = off), `refresh`.

## Tests
`fetch()` count-bucketing, most/least ranking, recent-feed dedup, and stale flags (with `ha_core` monkeypatched), plus a composer-mount check.

## Scope note
Issue #80 asks for **per-automation** expected cadence for the stale alert. A per-row config UI isn't expressible in the multiselect editor, so v1 ships a single global **"stale after N hours"** threshold applied to all tracked automations. Per-automation cadence is a natural follow-up.

> Verified end-to-end on live HA data via Tesserae Studio (faithful renders across sizes + the `bar`/stale paths). Local `pytest` wasn't run in the authoring env (deps absent); the included tests are for CI. Gallery docs / screenshots are script-generated and intentionally not hand-edited here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xk1VBgH7VXXZdCM2jESz3p
