### PR TITLE
feat: MCP authoring affordances (fragment render, fresh, page delete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **MCP: less friction authoring widgets via Studio.** Three additions to the
+  `/api/mcp` surface: `GET /widgets/<id>/render.png` takes a `fragment` param so an
+  agent can faithfully render a single declared fragment (not just the whole card),
+  400ing an unknown fragment id; `render.png` and `POST /widgets/<id>/data` take
+  `fresh=true` to bypass caches (surfaced to widgets as `ctx["fresh"]`, and it skips
+  the render path's last-good fallback) so a just-edited `server.py` is instantly
+  verifiable; and `DELETE /api/mcp/pages/<id>` removes a canvas dashboard (throwaway QA
+  pages), exposed in the `tesserae-mcp` bridge as `delete_canvas_page`. The reload acks
+  now carry `reloaded` (and a re-imported module count) so an agent can tell a real
+  in-process reload from a no-op. All additive; no `fragment`/`fresh` = today's behaviour.
+
 ### Changed
 
 - **The `tesserae-mcp` bridge now lives in this repo** (`packages/tesserae-mcp`) as a

--- a/app/composer.py
+++ b/app/composer.py
@@ -331,6 +331,7 @@ def _parallel_fetch_plugin_data(
     preview: bool,
     *,
     sample: bool = False,
+    fresh: bool = False,
     target_device_id: str = "",
     page_name: str = "",
     page_icon: str = "",
@@ -391,6 +392,7 @@ def _parallel_fetch_plugin_data(
                 preview,
                 cell_w=cell_w,
                 cell_h=cell_h,
+                fresh=fresh,
                 target_device_id=target_device_id,
                 page_name=page_name,
                 page_icon=page_icon,
@@ -470,7 +472,9 @@ def _parallel_fetch_plugin_data(
         if idx not in synthesised_errors:
             _LAST_GOOD_DATA[key] = result
             continue
-        fallback = _LAST_GOOD_DATA.get(key)
+        # ``fresh`` surfaces the real (fresh) result instead of masking a broken
+        # reload with a stale last-good render.
+        fallback = None if fresh else _LAST_GOOD_DATA.get(key)
         if fallback is not None:
             logger.info("widget hydration fallback to last-good for cell #%d (%s)", idx, plugin_id)
             results[idx] = fallback
@@ -487,6 +491,7 @@ def _fetch_plugin_data(
     *,
     cell_w: int = 0,
     cell_h: int = 0,
+    fresh: bool = False,
     target_device_id: str = "",
     page_name: str = "",
     page_icon: str = "",
@@ -555,6 +560,12 @@ def _fetch_plugin_data(
         "home_lat": home_lat,
         "home_lon": home_lon,
     }
+    # ``fresh`` (from ?fresh=1 on the probe / render) tells a widget to bypass
+    # its own data_dir cache, so an edit to server.py is instantly verifiable.
+    # Widgets opt in by checking ctx.get("fresh"); the field is absent otherwise
+    # so non-fresh renders are byte-identical to before.
+    if fresh:
+        ctx["fresh"] = True
     # v0.71.x: per-device rendering. When the push pipeline is fanning
     # this render out to a specific device (multiple bound to the same
     # panel), the compose URL carries ``?device_id=<id>``. Widgets that
@@ -599,7 +610,7 @@ def _fetch_plugin_data(
 
 
 def _hydrate_page(
-    page_dict: dict[str, Any], *, preview: bool = False, sample: bool = False
+    page_dict: dict[str, Any], *, preview: bool = False, sample: bool = False, fresh: bool = False
 ) -> dict[str, Any]:
     """Resolve options, fonts, server-side data, and visual layout."""
     registry = _registry()
@@ -719,6 +730,7 @@ def _hydrate_page(
         panel_h,
         preview,
         sample=sample,
+        fresh=fresh,
         target_device_id=str(page_dict.get("target_device_id") or ""),
         page_name=str(page_dict.get("name") or ""),
         page_icon=str(page_dict.get("icon") or ""),
@@ -1065,6 +1077,22 @@ def test_render() -> str:
     # the three movement styles bauhaus / destijl / brutalist).
     style_id = request.args.get("style") or "standard"
 
+    # ?fragment=<id> renders a single declared fragment of the widget
+    # (``ctx.cell.fragment``); defaults to "full". Validated against the
+    # widget's declared fragments so an unknown id 400s rather than silently
+    # rendering the whole card.
+    fragment = request.args.get("fragment") or "full"
+    plugin = _registry().get(plugin_id)
+    if fragment != "full" and plugin is not None:
+        from app.panels_schema import fragments_of
+
+        if fragment not in {f["id"] for f in fragments_of(plugin)}:
+            abort(400)
+    # ?fresh=1 bypasses caches so a just-edited server.py is reflected
+    # immediately: it sets ``ctx["fresh"]`` (widgets opt in to skip their own
+    # data_dir cache) and skips the render path's last-good fallback. Default off.
+    fresh = request.args.get("fresh") in ("1", "true", "True")
+
     # Per-widget content zoom from the gallery's zoom picker. Same
     # 0.5–3.0 clamp the Cell model enforces; out-of-range or unparseable
     # values silently fall back to 1.0.
@@ -1104,6 +1132,7 @@ def test_render() -> str:
                 "w": cell_w,
                 "h": cell_h,
                 "plugin": plugin_id,
+                "fragment": fragment,
                 "options": cell_options,
                 "zoom": zoom_val,
             }
@@ -1111,7 +1140,7 @@ def test_render() -> str:
     }
     return render_template(
         "compose.html",
-        page=_hydrate_page(page, preview=True, sample=sample_mode),
+        page=_hydrate_page(page, preview=True, sample=sample_mode, fresh=fresh),
         for_push=False,
         preview_mode=False,
     )

--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -245,9 +245,14 @@ def widget_data(key: str) -> Response:
     raw_options = body.get("options")
     options: dict[str, Any] = raw_options if isinstance(raw_options, dict) else {}
     opts = _resolved_options(key, options)
+    # ``?fresh=true`` bypasses caches (ctx["fresh"]) so a just-edited server.py is
+    # reflected immediately instead of a stale cached payload.
+    fresh = request.args.get("fresh") in ("1", "true", "True")
     live: Any = None
     try:
-        live = _fetch_plugin_data(key, opts, 600, 400, preview=False, cell_w=600, cell_h=400)
+        live = _fetch_plugin_data(
+            key, opts, 600, 400, preview=False, cell_w=600, cell_h=400, fresh=fresh
+        )
     except Exception as err:
         live = {"error": f"{type(err).__name__}: {err}"}
 
@@ -296,10 +301,10 @@ def _reload_registry(mode: str, *, restart_if_blueprint: bool) -> dict[str, Any]
         if updater is None:
             raise RuntimeError("restart unavailable (no updater configured)")
         updater.restart(delay_s=1.0)
-        return {"reload": "restart", "restarting": True}
+        return {"reload": "restart", "restarting": True, "reloaded": False}
 
     if mode == "none":
-        return {"reload": "none", "restarting": False}
+        return {"reload": "none", "restarting": False, "reloaded": False}
     if mode == "restart" or (mode == "auto" and restart_if_blueprint):
         return _restart()
 
@@ -320,7 +325,11 @@ def _reload_registry(mode: str, *, restart_if_blueprint: bool) -> dict[str, Any]
     app.config["PLUGIN_REGISTRY"] = new_registry
     for perr in new_registry.errors:
         logger.warning("plugin reload: %s, %s", perr.plugin_id, perr.message)
-    return {"reload": "in_process", "restarting": False}
+    # ``reloaded`` + the re-imported server-module count let the caller tell a real
+    # in-process reload (server.py re-imported) from a no-op it would otherwise
+    # guess needed a restart.
+    modules = sum(1 for p in new_registry.plugins.values() if p.server_module is not None)
+    return {"reload": "in_process", "restarting": False, "reloaded": True, "modules": modules}
 
 
 @bp.post("/widgets/install")
@@ -372,6 +381,7 @@ def install_widget() -> Response:
             "version": result["version"],
             "installed": True,
             "reload": rel["reload"],
+            "reloaded": rel.get("reloaded", False),
             "active": active,
             "restarting": rel["restarting"],
         }
@@ -399,6 +409,7 @@ def uninstall_widget(key: str) -> Response:
             "ok": True,
             "id": key,
             "reload": rel["reload"],
+            "reloaded": rel.get("reloaded", False),
             "active": False,
             "restarting": rel["restarting"],
         }
@@ -421,7 +432,15 @@ def reload_plugins() -> Response:
         )
     except Exception as err:
         return _err(500, f"reload failed: {err}")
-    return jsonify({"ok": True, "mode": rel["reload"], "restarting": rel["restarting"]})
+    return jsonify(
+        {
+            "ok": True,
+            "mode": rel["reload"],
+            "reloaded": rel.get("reloaded", False),
+            "modules": rel.get("modules", 0),
+            "restarting": rel["restarting"],
+        }
+    )
 
 
 @bp.get("/widgets")
@@ -440,20 +459,27 @@ def widget_render(key: str) -> Response:
     """Faithful e-ink render of a single widget as a PNG, over the authed MCP
     surface (so a client can preview against a remote / HA instance where
     ``/_test/render`` is not reachable). Query: ``size`` (xs|sm|md|lg, default lg),
-    ``opts`` (JSON cell options), optional ``theme`` / ``style`` / ``sample`` / ``zoom``."""
+    ``opts`` (JSON cell options), optional ``theme`` / ``style`` / ``sample`` / ``zoom``,
+    ``fragment`` (render one declared fragment, default the whole widget), and
+    ``fresh=true`` (bypass caches so a just-edited server.py is reflected now)."""
     from urllib.parse import urlencode
 
     from app.composer import SIZE_DIMENSIONS
+    from app.panels_schema import fragments_of
     from app.renderer import RenderRequest, render_to_png, to_loopback_url
 
-    if _pr._registry().get(key) is None:
+    plugin = _pr._registry().get(key)
+    if plugin is None:
         return _err(404, f"unknown widget {key!r}")
     size = request.args.get("size", "lg")
     if size not in SIZE_DIMENSIONS:
         return _err(400, f"size must be one of {'|'.join(sorted(SIZE_DIMENSIONS))}")
     w, h = SIZE_DIMENSIONS[size]
+    fragment = request.args.get("fragment")
+    if fragment and fragment != "full" and fragment not in {f["id"] for f in fragments_of(plugin)}:
+        return _err(400, f"widget {key!r} has no fragment {fragment!r}")
     params: dict[str, str] = {"plugin": key, "size": size}
-    for arg in ("opts", "theme", "style", "sample", "zoom"):
+    for arg in ("opts", "theme", "style", "sample", "zoom", "fragment", "fresh"):
         val = request.args.get(arg)
         if val:
             params[arg] = val
@@ -566,6 +592,16 @@ def create_page() -> Response:
             page.canvas.h = h
     _save_mcp(page)
     return jsonify({"id": page.id, "name": page.name})
+
+
+@bp.delete("/pages/<page_id>")
+def delete_page(page_id: str) -> Response:
+    """Delete a canvas dashboard (e.g. a throwaway QA page). Only removes canvas
+    pages, same guardrail as the other page writes; 404 if it isn't one."""
+    if _pr._get_canvas(page_id) is None:
+        return _err(404, f"no canvas dashboard {page_id!r}")
+    _pr._pages().delete(page_id)
+    return jsonify({"ok": True, "id": page_id})
 
 
 @bp.get("/pages/<page_id>/canvas")

--- a/packages/tesserae-mcp/tesserae_mcp/__init__.py
+++ b/packages/tesserae-mcp/tesserae_mcp/__init__.py
@@ -246,6 +246,11 @@ def build_server() -> Any:
         to lay it out. Size it to your target panel (see list_devices)."""
         return _json("POST", "/pages", {"name": name, "w": w, "h": h})
 
+    def delete_canvas_page(page_id: str) -> Any:
+        """Delete a canvas dashboard by id (e.g. a throwaway QA page). Returns
+        {ok: true} on success, or 404 if it isn't a canvas page."""
+        return _json("DELETE", f"/pages/{page_id}")
+
     def get_canvas(page_id: str) -> Any:
         """Get the full canvas document (size, appearance, and every element) for a
         page, plus "rev" / "updated_at" / "updated_by". Keep the "rev" and pass it as
@@ -351,6 +356,7 @@ def build_server() -> Any:
         list_devices,
         list_pages,
         create_canvas_page,
+        delete_canvas_page,
         get_canvas,
         update_element,
         delete_element,

--- a/packages/tesserae-mcp/tests/test_bridge.py
+++ b/packages/tesserae-mcp/tests/test_bridge.py
@@ -26,6 +26,7 @@ def test_tools_register() -> None:
         "list_devices",
         "list_pages",
         "create_canvas_page",
+        "delete_canvas_page",
         "get_canvas",
         "set_canvas",
         "add_element",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.110.4"
+version = "0.111.0"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/templates/compose.html
+++ b/templates/compose.html
@@ -129,6 +129,7 @@
          data-cell-id="{{ cell.id }}"
          data-cell-index="{{ loop.index }}"
          data-plugin="{{ cell.plugin }}"
+         data-fragment="{{ cell.fragment | default('full', true) }}"
          data-options='{{ cell.options|tojson }}'
          data-data='{{ cell.data|tojson }}'
          data-cell-w="{{ cell.w }}"

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -30,6 +30,19 @@ def test_test_render_rejects_bad_size(client: FlaskClient) -> None:
     assert resp.status_code == 400
 
 
+def test_test_render_honours_fragment(client: FlaskClient) -> None:
+    """?fragment=<id> renders a single declared fragment (data-fragment flows to
+    the widget's ctx.cell.fragment); an unknown fragment 400s."""
+    resp = client.get("/_test/render?plugin=weather_now&size=md&fragment=temp")
+    assert resp.status_code == 200
+    assert 'data-fragment="temp"' in resp.get_data(as_text=True)
+    # Default (no fragment) renders the whole widget.
+    full = client.get("/_test/render?plugin=weather_now&size=md")
+    assert 'data-fragment="full"' in full.get_data(as_text=True)
+    # Unknown fragment id is rejected.
+    assert client.get("/_test/render?plugin=weather_now&size=md&fragment=nope").status_code == 400
+
+
 def test_compose_route_404s_on_unknown_page(client: FlaskClient) -> None:
     resp = client.get("/compose/nonexistent")
     assert resp.status_code == 404

--- a/tests/test_mcp_api.py
+++ b/tests/test_mcp_api.py
@@ -142,6 +142,20 @@ def test_create_get_set_roundtrip(app: Flask) -> None:
     assert entry["created_by"] == "mcp" and entry["elements"] == 1
 
 
+def test_delete_page(app: Flask) -> None:
+    _enable(app)
+    client = app.test_client()
+    pid = _create_page(client)
+    resp = client.delete(f"/api/mcp/pages/{pid}")
+    assert resp.status_code == 200 and resp.get_json()["ok"] is True
+    pages = client.get("/api/mcp/pages").get_json()["pages"]
+    assert not any(p["id"] == pid for p in pages)
+    # Gone now -> 404; a grid page is never deletable via this route.
+    assert client.delete(f"/api/mcp/pages/{pid}").status_code == 404
+    app.config["PAGE_STORE"].save(Page(id="grid9", name="Grid", layout_kind="grid"))
+    assert client.delete("/api/mcp/pages/grid9").status_code == 404
+
+
 def test_set_canvas_compact_and_return_doc(app: Flask) -> None:
     _enable(app)
     client = app.test_client()

--- a/tests/test_widget_push.py
+++ b/tests/test_widget_push.py
@@ -99,6 +99,7 @@ def test_install_reloads_in_process_and_goes_live(app: Flask) -> None:
     body = resp.get_json()
     assert body["ok"] and body["id"] == "air_quality"
     assert body["reload"] == "in_process" and body["restarting"] is False
+    assert body["reloaded"] is True  # server modules were actually re-imported
     assert body["active"] is True
 
     # On the persistent volume, and live in the registry / catalog.
@@ -256,6 +257,41 @@ def test_render_png(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
     # Unknown widget + bad size.
     assert client.get("/api/mcp/widgets/nope/render.png").status_code == 404
     assert client.get("/api/mcp/widgets/clock_analog/render.png?size=huge").status_code == 400
+
+
+def test_render_png_fragment(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    """render.png?fragment=<id> renders one fragment; an unknown fragment 400s and
+    a valid one forwards ``fragment`` to the render URL."""
+    _enable(app)
+    captured: dict[str, str] = {}
+
+    def _capture(req: Any, pool: Any = None) -> bytes:
+        captured["url"] = req.url
+        return _FAKE_PNG
+
+    monkeypatch.setattr("app.renderer.render_to_png", _capture)
+    client = app.test_client()
+    # weather_now declares a "temp" fragment.
+    ok = client.get("/api/mcp/widgets/weather_now/render.png?size=md&fragment=temp")
+    assert ok.status_code == 200 and "fragment=temp" in captured["url"]
+    # Unknown fragment is rejected before rendering.
+    assert client.get("/api/mcp/widgets/weather_now/render.png?fragment=nope").status_code == 400
+
+
+def test_fresh_threads_ctx_flag(app: Flask) -> None:
+    """?fresh=true reaches the widget as ctx["fresh"], so a cache-aware widget can
+    bypass its own cache and a server edit is instantly verifiable."""
+    _enable(app)
+    client = app.test_client()
+    files = _widget_files()
+    files["server.py"] = (
+        "def fetch(options, settings, *, ctx):\n    return {'fresh': bool(ctx.get('fresh'))}\n"
+    )
+    _install(client, _make_tar(files, top="fresh_probe"))
+    default = client.post("/api/mcp/widgets/fresh_probe/data", json={}).get_json()
+    assert default["data_source"] == "live" and default["data"]["fresh"] is False
+    fresh = client.post("/api/mcp/widgets/fresh_probe/data?fresh=true", json={}).get_json()
+    assert fresh["data"]["fresh"] is True
 
 
 def test_render_png_screenshots_widget_not_login_with_password(


### PR DESCRIPTION
Three additive improvements to the `/api/mcp` surface that remove friction when an agent authors widgets via Tesserae Studio. No change to existing default behaviour (no `fragment`/`fresh` = today).

## 1. `fragment` on the faithful render
`GET /widgets/<id>/render.png?...&fragment=<id>` renders a single declared fragment instead of only `full`. Grid `compose.html` now emits `data-fragment` (composer.js already reads it); `composer.test_render` accepts + sets it on the cell. Validated against the widget's declared fragments, unknown id → 400 (in both `widget_render` and `test_render`).

## 2. `fresh=true` cache bypass
`render.png` and `POST /widgets/<id>/data` accept `fresh=true`. Threaded into `_fetch_plugin_data` as `ctx["fresh"]` (widgets opt in to skip their own `data_dir` cache; field absent otherwise so non-fresh renders are byte-identical), and it skips the render path's `_LAST_GOOD_DATA` fallback so a broken/edited `server.py` surfaces its real result instead of a stale render.

## 3. Page delete + clearer reload signal
- `DELETE /api/mcp/pages/<id>` removes a canvas dashboard (canvas-only guardrail, 404 otherwise), exposed in the `tesserae-mcp` bridge as `delete_canvas_page`.
- `_reload_registry` acks now carry `reloaded: bool` + a re-imported server-module count, so an agent can tell a real in-process reload from a no-op instead of guessing it needs a restart.

## Verify
- `render.png?fragment=temp` renders that fragment (data-fragment flows to `ctx.cell.fragment`); unknown id 400s.
- `probe_widget_data?fresh=true` reaches the widget as `ctx["fresh"]` (test pushes a `fetch` that echoes it); default call doesn't.
- `DELETE /pages/<id>` removes a page (gone from `list_pages`); grid pages 404; the bridge registers `delete_canvas_page`.
- mypy `--strict` clean, ruff clean, full suite 1645 passed (+5 new), bridge tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)