### PR TITLE
feat: uncompressed BMP frame format for CircuitPython clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Added
 
+- **CircuitPython clients can request an uncompressed BMP frame.** New
+  `circuitpython_bmp` renderer emits the composition quantised to the panel's palette
+  as an uncompressed indexed BMP, alongside the existing `circuitpython_png`. A client
+  declares `"format": "bmp"` on `/discover` (or `/register`) to bind it. The BMP needs
+  no `zlib.decompress` on the client: `adafruit_imageload` reads it row by row, so peak
+  RAM is the framebuffer plus a small row buffer, where an indexed PNG's one-shot inflate
+  can't fit a contiguous decode buffer on Pico W class boards. PNG stays the default for
+  boards with headroom (it's a few times smaller on the wire). The `circuitpython_generic`
+  kind now lists both renderers and pins one per instance via a `renderer_id` recorded at
+  registration; the shared pixel pipeline lives in `app.quantizer` so both formats produce
+  identical pixels. Spec: [client protocol](https://dmellok.github.io/tesserae/dev/client-protocol/).
+
 - **MCP: less friction authoring widgets via Studio.** Three additions to the
   `/api/mcp` surface: `GET /widgets/<id>/render.png` takes a `fragment` param so an
   agent can faithfully render a single declared fragment (not just the whole card),

--- a/app/device_loader.py
+++ b/app/device_loader.py
@@ -579,10 +579,22 @@ def load_instance_file(
     # /api/setup; KOReader (no MAC) keeps using token-based auth.
     if isinstance(raw_inst.get("mac"), str) and raw_inst["mac"].strip():
         inst_manifest["mac"] = raw_inst["mac"].strip()
+    # Per-instance renderer pick for kinds that offer more than one
+    # (e.g. circuitpython_generic → png / bmp). Kept on the manifest so
+    # clone_for_instances() clones only the chosen renderer and the two
+    # never fight over the device's single latest-render slot. Ignored
+    # unless it names one of the kind's renderers; absent means the
+    # kind's first renderer, which is every single-renderer built-in.
+    selected_renderer = raw_inst.get("renderer_id")
+    if isinstance(selected_renderer, str) and selected_renderer in kind.renderer_ids:
+        inst_manifest["renderer_id"] = selected_renderer
+        chosen_renderers = [selected_renderer]
+    else:
+        chosen_renderers = kind.renderer_ids[:1]
     # Point the instance at its cloned renderers so the settings UI
     # and any code that reads device.renderer_ids sees the per-
     # instance ids that clone_for_instances() will create.
-    inst_manifest["renderers"] = [f"{r}__{instance_id}" for r in kind.renderer_ids]
+    inst_manifest["renderers"] = [f"{r}__{instance_id}" for r in chosen_renderers]
     inst_data_dir = data_root / instance_id
     inst_data_dir.mkdir(parents=True, exist_ok=True)
     device = Device(

--- a/app/device_service.py
+++ b/app/device_service.py
@@ -181,6 +181,29 @@ def derive_topic(kind_topic: str, new_id: str, *, suffix: str) -> str:
     return f"tesserae/{new_id}/{suffix}"
 
 
+def renderer_id_for_format(
+    renderers: RendererRegistry, kind: Any, wire_format: str | None
+) -> str | None:
+    """Resolve a client-declared wire format (``"png"`` / ``"bmp"``) to
+    one of the kind's renderer ids by matching the renderer's file
+    extension.
+
+    Used by the discover-and-register flow so a memory-constrained
+    CircuitPython client can ask for the uncompressed-BMP renderer.
+    Returns ``None`` (leave the kind default) when the format is empty,
+    unknown, or the kind has no renderer with that extension."""
+    if not wire_format:
+        return None
+    fmt = wire_format.strip().lower().lstrip(".")
+    if not fmt:
+        return None
+    for rid in getattr(kind, "renderer_ids", []):
+        renderer = renderers.get(rid)
+        if renderer is not None and renderer.extension == fmt:
+            return str(rid)
+    return None
+
+
 def _drop_clones(renderers: RendererRegistry, instance_id: str) -> None:
     """Remove any renderer clones whose resolved device is this instance.
 
@@ -212,6 +235,7 @@ def create_instance(
     mac: str | None = None,
     api_key_strength: str = "typeable",
     transport: str | None = None,
+    renderer_id: str | None = None,
 ) -> InstanceResult:
     """Validate, persist, load, and clone-renderers for a new instance.
 
@@ -220,8 +244,14 @@ def create_instance(
     (``landscape`` / ``landscape_flipped`` / ``portrait`` /
     ``portrait_flipped``). Portrait variants swap w/h once so the stored
     canvas matches the chosen aspect; the ``_flipped`` part is a
-    renderer-side 180° turn, not a dims change. Caller rebuilds the
-    transport on success."""
+    renderer-side 180° turn, not a dims change.
+
+    ``renderer_id`` pins the instance to one of its kind's renderers when
+    the kind lists more than one (e.g. ``circuitpython_generic`` offering
+    both ``circuitpython_png`` and ``circuitpython_bmp``). Ignored when it
+    isn't one of the kind's renderers. When unset, the kind's first
+    renderer is used, so single-renderer kinds are unaffected. Caller
+    rebuilds the transport on success."""
     instance_id = instance_id.strip().lower()
     if not DEVICE_ID_RE.match(instance_id):
         return InstanceResult(
@@ -251,6 +281,12 @@ def create_instance(
     }
     if normalised_transport == "rest":
         manifest["transport"] = "rest"
+    # Pin a renderer when the kind offers a choice (multi-renderer kinds
+    # like circuitpython_generic). Only recorded when it names one of the
+    # kind's renderers, so a bad value falls back to the kind's default
+    # rather than orphaning the instance with no renderer at all.
+    if renderer_id and renderer_id in getattr(kind, "renderer_ids", []):
+        manifest["renderer_id"] = renderer_id
     # Kinds that don't speak MQTT (e.g. HTTP-polled TRMNL) declare no
     # status/config topic at all. REST instances ALSO skip these: the
     # status/config flows happen over /api/v1/device/<id>/*, not topics.

--- a/app/discovery.py
+++ b/app/discovery.py
@@ -67,6 +67,16 @@ class DiscoveredDevice:
         return str(value) if isinstance(value, str) and value else None
 
     @property
+    def wire_format(self) -> str | None:
+        """Declared wire format from the /discover payload (``"png"`` or
+        ``"bmp"``). Lets a memory-constrained CircuitPython client ask
+        for the uncompressed-BMP renderer, which needs no on-device
+        ``zlib.decompress``. Resolved to a concrete renderer at register
+        time; here we just surface whatever the client sent."""
+        value = self.parsed.get("format")
+        return str(value).strip().lower() if isinstance(value, str) and value.strip() else None
+
+    @property
     def fw_version(self) -> str | None:
         value = self.parsed.get("fw_version")
         return str(value) if isinstance(value, (str, int, float)) else None

--- a/app/onboarding.py
+++ b/app/onboarding.py
@@ -441,13 +441,17 @@ def register_discovered(discovered_id: str) -> Response:
             from app.quantizer import canonicalise_gamut
 
             overrides["gamut"] = canonicalise_gamut(entry.gamut)
+    renderers = _renderers()
+    kind = _devices().get(kind_id)
+    renderer_id = device_service.renderer_id_for_format(renderers, kind, entry.wire_format)
     result = device_service.create_instance(
         devices=_devices(),
-        renderers=_renderers(),
+        renderers=renderers,
         data_root=_data_root(),
         instance_id=discovered_id,
         kind_id=kind_id,
         panel_overrides=overrides,
+        renderer_id=renderer_id,
     )
     if not result.ok or result.device is None:
         flash(result.error or "Could not register device.", "error")

--- a/app/quantizer.py
+++ b/app/quantizer.py
@@ -695,6 +695,126 @@ def quantize_to_png(
     return out.getvalue()
 
 
+# --- CircuitPython client image pipeline ------------------------------
+#
+# Shared by the ``circuitpython_png`` and ``circuitpython_bmp``
+# renderers. Both fit the composition to the panel, contrast-adjust, and
+# quantise to the panel's exact indexed palette so ``adafruit_imageload``
+# mounts the result with no on-device quantise or dither. The only
+# difference between the two renderers is the container the result is
+# saved into (indexed PNG vs uncompressed indexed BMP), so the pixel
+# pipeline lives here and each renderer just picks the ``save`` format.
+
+_CIRCUITPYTHON_MONO_PALETTE: tuple[tuple[int, int, int], ...] = (
+    (0, 0, 0),
+    (255, 255, 255),
+)
+
+_CIRCUITPYTHON_DEFAULTS: dict[str, object] = {
+    "dither": "floyd-steinberg",
+    "contrast": 1.0,
+}
+
+
+def palette_for_circuitpython_gamut(
+    gamut: str | None,
+) -> tuple[tuple[int, int, int], ...] | None:
+    """Map a panel's declared gamut to the indexed palette a CircuitPython
+    client wants, or ``None`` when the gamut asks for a full-colour
+    (unquantised) output.
+
+    Unknown or empty gamuts fall through to Spectra 6 nominal so a panel
+    that just hasn't declared its gamut yet still produces a sensible
+    indexed image rather than 8-bit RGB. Aliases handled:
+
+      * ``mono`` -> black + white
+      * ``bwr_3`` -> 3-colour black/white/red tri-colour e-ink
+      * ``gray_4`` -> 4-level greyscale ramp (2-bit, no highlight)
+      * ``bwry_4`` -> 4-colour black/white/red/yellow
+      * ``acep_7colour`` / ``acep_7color`` / ``inky_7colour`` -> 7-colour
+      * ``rgb24`` / ``rgb16`` -> ``None`` (full-colour passthrough)
+    """
+    g = (gamut or "").lower()
+    if g == "mono":
+        return _CIRCUITPYTHON_MONO_PALETTE
+    if g == "bwry_4":
+        return BWRY_4_PALETTE
+    if g == "bwr_3":
+        return BWR_3_PALETTE
+    if g == "gray_4":
+        return GRAY_4_PALETTE
+    if g in ("acep_7colour", "acep_7color", "inky_7colour"):
+        return INKY_7COLOUR_PALETTE
+    if g in ("rgb24", "rgb16"):
+        return None
+    return SPECTRA_6_PALETTE
+
+
+def circuitpython_indexed_image(
+    png_bytes: bytes,
+    *,
+    width: int,
+    height: int,
+    gamut: str | None,
+    flip: bool = False,
+    underscan: int = 0,
+    settings: dict[str, object] | None = None,
+) -> Image.Image:
+    """Fit, contrast-adjust, and quantise a composition PNG for a
+    CircuitPython client, returning the ready-to-save Pillow image.
+
+    The result is palette-mode (``"P"``) for every quantised gamut, so a
+    caller that saves it as PNG or uncompressed BMP produces an indexed
+    file ``adafruit_imageload`` mounts natively. ``rgb24`` / ``rgb16``
+    gamuts return an ``"RGB"`` image instead (full-colour passthrough).
+
+    The device paints what arrives: no on-device quantise, no dither, no
+    nibble unpack. This is the shared pixel pipeline behind both the
+    ``circuitpython_png`` and ``circuitpython_bmp`` renderers.
+    """
+    settings = settings or {}
+    img: Image.Image = Image.open(io.BytesIO(png_bytes))
+
+    if flip:
+        # Upside-down physical mount: turn the whole image 180° so it
+        # reads upright on the wall.
+        img = img.rotate(180, expand=True)
+
+    if img.size != (width, height):
+        # Composer pre-sizes pages to ``panel.w x panel.h`` so this is
+        # usually a no-op. It only does real work on Send-page image
+        # pushes where the input PNG isn't panel-sized.
+        fit = str(settings.get("image_fit") or "fit")
+        img = fit_to_panel(img, target_w=width, target_h=height, scale=fit, bg="white")
+
+    if underscan:
+        # Per-device underscan: inset rendered content so it clears a
+        # physical bezel or mat covering the panel edge.
+        img = underscan_image(img, underscan=underscan)
+
+    contrast = float(settings.get("contrast", _CIRCUITPYTHON_DEFAULTS["contrast"]))  # type: ignore[arg-type]
+    if abs(contrast - 1.0) > 1e-6:
+        # Pre-dither contrast push: bumping contrast forces more pixels to
+        # definite black or definite white before the dither pass, which
+        # tends to read better on text-heavy dashboards.
+        img = ImageEnhance.Contrast(img.convert("L")).enhance(contrast).convert("RGB")
+
+    palette = palette_for_circuitpython_gamut(gamut)
+    if palette is None:
+        # rgb24 / rgb16: full-colour passthrough, no quantise or dither.
+        return img.convert("RGB")
+
+    pal_img = _palette_image(palette)
+    dither_mode = _PIL_DITHER_MAP.get(
+        str(settings.get("dither", _CIRCUITPYTHON_DEFAULTS["dither"])),
+        Image.Dither.FLOYDSTEINBERG,
+    )
+    # ``Image.quantize`` keeps palette mode ("P"), which is what we want:
+    # the saved file carries an indexed pixel format adafruit_imageload
+    # reads natively. Deliberately no ``.convert("RGB")`` afterwards.
+    return img.convert("RGB").quantize(palette=pal_img, dither=dither_mode)
+
+
 # --- numpy-backed dither for the panel-bin packer ---------------------
 
 

--- a/app/renderer_loader.py
+++ b/app/renderer_loader.py
@@ -160,7 +160,17 @@ def clone_for_instances(renderers: RendererRegistry, devices: Any) -> None:
     The link between an instance and its renderers is the **kind's**
     ``renderer_ids`` list (e.g. ``esp32_client`` → ``["esp32_bin"]``).
     We can't match on ``renderer.device`` because that's a topic prefix
-    (``"esp32"``), not a device id (``"esp32_client"``)."""
+    (``"esp32"``), not a device id (``"esp32_client"``).
+
+    When a kind offers more than one renderer (e.g.
+    ``circuitpython_generic`` → ``["circuitpython_png",
+    "circuitpython_bmp"]``) the instance picks exactly one via its
+    ``renderer_id`` manifest field. A device has a single latest-render
+    slot (``PushManager._latest_renders`` is keyed by device id), so
+    cloning every variant would have them fight over it. With no
+    ``renderer_id`` recorded, the kind's first renderer wins, which keeps
+    single-renderer kinds (every built-in today) behaving exactly as
+    before."""
     get_all = getattr(devices, "all", None)
     get_one = getattr(devices, "get", None)
     if not callable(get_all) or not callable(get_one):
@@ -172,7 +182,16 @@ def clone_for_instances(renderers: RendererRegistry, devices: Any) -> None:
         kind = get_one(kind_id)
         if kind is None:
             continue
-        for renderer_id in getattr(kind, "renderer_ids", []):
+        kind_renderer_ids = list(getattr(kind, "renderer_ids", []))
+        selected = getattr(dev, "manifest", {}).get("renderer_id")
+        if selected and selected in kind_renderer_ids:
+            renderer_ids = [selected]
+        else:
+            # No valid pick recorded: clone only the primary (first)
+            # renderer, so a multi-renderer kind doesn't clobber its own
+            # latest-render slot.
+            renderer_ids = kind_renderer_ids[:1]
+        for renderer_id in renderer_ids:
             base = renderers.get(renderer_id)
             if base is None:
                 continue

--- a/app/rest_api.py
+++ b/app/rest_api.py
@@ -908,6 +908,13 @@ def post_register() -> Response:
         )
     markers.clear(device_id)
 
+    # Wire format the client asked for (png / bmp), resolved to a
+    # renderer of the chosen kind. Lets a memory-constrained
+    # CircuitPython client pin the uncompressed-BMP renderer at pairing
+    # time, matching the discover-and-claim path.
+    from app.device_service import renderer_id_for_format
+
+    renderer_id_arg = renderer_id_for_format(_renderers(), kind, body.get("format"))
     result = create_instance(
         devices=devices_registry,
         renderers=_renderers(),
@@ -918,6 +925,7 @@ def post_register() -> Response:
         panel_overrides=panel_overrides,
         access_token=None,  # let create_instance mint one
         mac=incoming_mac,
+        renderer_id=renderer_id_arg,
         api_key_strength="typeable",  # ignored for REST devices, see below
         # Mark the instance REST-mode so the push pipeline skips
         # broker publishes and the admin UI shows the right transport

--- a/app/settings/devices_routes.py
+++ b/app/settings/devices_routes.py
@@ -632,9 +632,17 @@ def devices_register_discovered(discovered_id: str) -> Response:
             data_root=Path(current_app.config["DATA_ROOT"]),
         )
     markers.clear(target_id)
+    # Wire format the client asked for (png / bmp). A memory-constrained
+    # CircuitPython client declares "bmp" so it gets the uncompressed-BMP
+    # renderer and never runs zlib.decompress on-device. Resolved to a
+    # concrete renderer of the chosen kind; None leaves the kind default.
+    renderers_registry = renderers()
+    renderer_id_arg = device_service.renderer_id_for_format(
+        renderers_registry, devices().get(kind_id), entry.wire_format
+    )
     result = device_service.create_instance(
         devices=devices(),
-        renderers=renderers(),
+        renderers=renderers_registry,
         data_root=device_data_root(),
         instance_id=form.get("id") or default_id,
         kind_id=kind_id,
@@ -643,6 +651,7 @@ def devices_register_discovered(discovered_id: str) -> Response:
         access_token=discovered_token if isinstance(discovered_token, str) else None,
         mac=mac_arg,
         transport=transport_arg,
+        renderer_id=renderer_id_arg,
     )
     if not result.ok or result.device is None:
         flash(result.error or "Failed to register device.", "error")

--- a/devices/circuitpython_generic/device.json
+++ b/devices/circuitpython_generic/device.json
@@ -3,8 +3,8 @@
   "name": "CircuitPython client (generic)",
   "icon": "device-tablet-speaker",
   "version": "0.1.0",
-  "description": "Generic CircuitPython client kind for boards driving an e-paper panel from a Pico W / Pico 2 W / Feather / similar microcontroller. Pairs with the circuitpython_png renderer, which emits an indexed PNG that adafruit_imageload can decode directly. Pairing follows the v1 REST discover-and-approve flow (POST /api/v1/device/discover with the board's MAC); steady state polls GET /api/v1/device/<id>/frame and POSTs heartbeats to /status. The kind is deliberately broad: a maintainer's own circuitpython_<board> kind (e.g. circuitpython_pico_w_inky) is welcome and stays compatible, this entry is the catch-all so boards without a tighter manifest still register cleanly.",
-  "renderers": ["circuitpython_png"],
+  "description": "Generic CircuitPython client kind for boards driving an e-paper panel from a Pico W / Pico 2 W / Feather / similar microcontroller. Serves the composition already quantised to the panel's palette, as an indexed PNG (default) or an uncompressed indexed BMP, either of which adafruit_imageload decodes directly. Declare format:'bmp' on discover for memory-constrained boards (Pico W class), where CircuitPython's one-shot zlib.decompress can't fit a PNG's decode buffer; the BMP needs no zlib. Pairing follows the v1 REST discover-and-approve flow (POST /api/v1/device/discover with the board's MAC); steady state polls GET /api/v1/device/<id>/frame and POSTs heartbeats to /status. The kind is deliberately broad: a maintainer's own circuitpython_<board> kind (e.g. circuitpython_pico_w_inky) is welcome and stays compatible, this entry is the catch-all so boards without a tighter manifest still register cleanly.",
+  "renderers": ["circuitpython_png", "circuitpython_bmp"],
   "panel": { "w": 800, "h": 480, "orientation": "landscape", "name": "Generic 800×480" },
   "config_schema": {
     "sleep_interval_s": {

--- a/docs/dev/client-protocol.md
+++ b/docs/dev/client-protocol.md
@@ -162,6 +162,30 @@ server URL.
        (e.g. `spectra_6_pack_waveshare`) would need a migration for
        every existing config, so the awkward names stay for backwards
        compat and the aliases carry the semantic intent.
+
+   `format` is optional and selects the wire container the server
+   renders into. It only applies to kinds that offer more than one
+   renderer; `circuitpython_generic` offers two:
+
+   | Value | Renderer | Notes |
+   | --- | --- | --- |
+   | `png` (default) | `circuitpython_png` | Indexed PNG. Smallest download. Needs `zlib.decompress` on the client. |
+   | `bmp` | `circuitpython_bmp` | Uncompressed indexed BMP. No `zlib` on the client at all. |
+
+   Declare `"format": "bmp"` when the board can't spare a contiguous
+   decode buffer. CircuitPython's `zlib.decompress` is one-shot (no
+   streaming inflate), so decoding even a small indexed PNG needs the
+   whole inflated image in RAM alongside the `displayio.Bitmap`; on a
+   Pico W class board (~110K free SRAM) that exhausts or fragments
+   memory. An uncompressed BMP sidesteps it: `adafruit_imageload` reads
+   it row by row with `file.read` / `seek`, so peak RAM is the
+   framebuffer plus a small row buffer. Boards with headroom (ESP32-S3
+   etc.) should keep the default PNG, which is a few times smaller on the
+   wire (the server writes palette-mode BMP at 8 bits per pixel). The
+   value is resolved to a renderer by matching its file extension, so the
+   `format` you declare is exactly the `format` field you'll get back
+   from `/frame`. An unknown or absent value leaves the kind's default
+   (PNG) renderer in place.
 2. Server caches the announcement. Returns:
    ```json
    {
@@ -221,7 +245,8 @@ click.
 
    `gamut` follows the same rules as on `/discover` (v0.69.1). Both
    paths write the canonicalised value onto the auto-provisioned
-   instance's panel block.
+   instance's panel block. `format` (`png` / `bmp`) is honoured here
+   too, same rules as on `/discover`.
    ```
 3. Server validates, creates the instance, returns a token:
    ```json
@@ -644,6 +669,33 @@ bin/png variants.
 
 Reference: [`renderers/pi_png/renderer.py`](https://github.com/dmellok/tesserae/blob/main/renderers/pi_png/renderer.py),
 [`renderers/trmnl/renderer.py`](https://github.com/dmellok/tesserae/blob/main/renderers/trmnl/renderer.py).
+
+### CircuitPython indexed `.png` / `.bmp`
+
+The `circuitpython_generic` kind serves the composition already
+quantised to the panel's exact palette, as either an indexed PNG
+(`circuitpython_png`) or an uncompressed indexed BMP
+(`circuitpython_bmp`), selected by the `format` field on `discover` /
+`register`. Both mount straight into a `displayio.Bitmap` via
+`adafruit_imageload` with no on-device quantise, dither, or nibble
+unpack, the device paints what arrives.
+
+Pick BMP on memory-constrained boards. CircuitPython's
+`zlib.decompress` is one-shot, so decoding an indexed PNG needs the
+whole inflated image in a contiguous buffer alongside the bitmap; on a
+Pico W class board that exhausts or fragments SRAM. The BMP has no
+`zlib` in the path, `adafruit_imageload` reads it row by row with
+`file.read` / `seek`, so peak RAM is the framebuffer plus a small row
+buffer. Trade-off: the server writes palette-mode BMP at 8 bits per
+pixel, so it's a few times larger on the wire than the PNG. The
+constraint on these boards is the decode buffer, not download size.
+
+The BMP is always uncompressed `BI_RGB`, bottom-up (Pillow's default),
+which is the form `adafruit_imageload` decodes; it rejects RLE-packed
+BMP.
+
+Reference: [`renderers/circuitpython_png/renderer.py`](https://github.com/dmellok/tesserae/blob/main/renderers/circuitpython_png/renderer.py),
+[`renderers/circuitpython_bmp/renderer.py`](https://github.com/dmellok/tesserae/blob/main/renderers/circuitpython_bmp/renderer.py).
 
 ## Configuration push
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.111.0"
+version = "0.112.0"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/renderers/circuitpython_bmp/renderer.json
+++ b/renderers/circuitpython_bmp/renderer.json
@@ -1,0 +1,36 @@
+{
+  "tesserae_compat": "1.x",
+  "name": "CircuitPython client (indexed BMP)",
+  "version": "0.1.0",
+  "description": "Composition quantized to the panel's palette and emitted as an uncompressed indexed BMP for adafruit_imageload on memory-constrained CircuitPython microcontrollers. Unlike the indexed-PNG output, a BMP needs no zlib.decompress on the client: adafruit_imageload reads it row by row with file.read / seek, so peak RAM is the framebuffer plus a small row buffer with no whole-image inflate. This is the path for Pico W class boards where CircuitPython's one-shot zlib decode exhausts (or fragments) SRAM decoding even a small PNG. Same palette selection as circuitpython_png (1-bit mono through 7-colour ACeP), the device paints what arrives without an on-device quantize or dither pass.",
+  "orientation": "composition",
+  "mime": "image/bmp",
+  "extension": "bmp",
+  "topic_pattern": "tesserae/{device}/frame/bmp",
+  "device": "circuitpython",
+  "retain": false,
+  "settings": [
+    {
+      "name": "dither",
+      "type": "select",
+      "label": "Dither mode",
+      "default": "floyd-steinberg",
+      "device_setting": true,
+      "choices": [
+        { "value": "floyd-steinberg", "label": "Floyd-Steinberg (smooth gradients)" },
+        { "value": "none", "label": "None (nearest palette, no dither)" }
+      ]
+    },
+    {
+      "name": "contrast",
+      "type": "slider",
+      "label": "Pre-dither contrast",
+      "default": 1.0,
+      "min": 0.5,
+      "max": 2.5,
+      "step": 0.05,
+      "device_setting": true,
+      "help": "Push midtones toward black or white before the dither pass. 1.0 leaves the image alone; > 1.0 deepens contrast (good for photos with grey skies); < 1.0 softens (good for text-heavy dashboards)."
+    }
+  ]
+}

--- a/renderers/circuitpython_bmp/renderer.py
+++ b/renderers/circuitpython_bmp/renderer.py
@@ -1,0 +1,81 @@
+"""circuitpython_bmp renderer.
+
+Composition -> palette-quantized *uncompressed* indexed BMP at the
+panel's exact dims. Sibling of ``circuitpython_png`` for the same
+generic CircuitPython client, differing only in the wire container.
+
+Why BMP as well as PNG: CircuitPython's ``zlib.decompress`` is
+one-shot (no streaming inflate like MicroPython has), so decoding even
+a small indexed PNG needs a contiguous buffer for the inflated image
+data alongside the ``displayio.Bitmap``. On a Pico W (~110K free SRAM)
+that either exhausts memory or fails on fragmentation. An uncompressed
+BMP has no zlib in the path at all: ``adafruit_imageload`` walks it row
+by row with ``file.read`` / ``seek``, so peak RAM is basically the
+framebuffer plus a small row buffer. Boards with room to spare
+(ESP32-S3 etc.) can keep using the smaller PNG; Pico W class boards
+declare BMP and skip the decompress wall.
+
+Output palette selected from the bound panel's gamut, identical to
+``circuitpython_png``:
+
+* ``mono``                             -> black + white
+* ``bwr_3``                            -> 3-colour black/white/red
+* ``gray_4``                           -> 4-level greyscale ramp (2-bit)
+* ``bwry_4``                           -> 4-colour black/white/red/yellow
+* ``spectra_6`` / ``waveshare_e6``     -> 6-colour Spectra 6
+* ``acep_7colour`` / ``inky_7colour``  -> 7-colour ACeP
+* ``rgb24`` / ``rgb16``                -> 24-bit RGB BMP, no quantise
+
+Unknown or custom gamuts fall back to Spectra 6 nominal.
+
+Note on wire size: Pillow writes palette-mode BMP at 8 bits per pixel,
+so the 2-bit gamuts go out a few times larger than the equivalent PNG.
+The client's constraint here is the decode buffer, not download size,
+so that trade is deliberate; a sub-byte BMP writer is a follow-up if
+bandwidth ever matters.
+
+Same per-device settings as ``circuitpython_png``: a dither-mode select
+and a pre-dither contrast slider.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from app.quantizer import circuitpython_indexed_image
+from app.state.page_store import Panel
+
+
+def transform(png_bytes: bytes, *, panel: Panel, settings: dict[str, Any]) -> bytes:
+    """Fit, contrast-adjust, quantize, and save the composition as an
+    uncompressed indexed BMP at the panel's exact dims.
+
+    Shares the pixel pipeline (fit, contrast, palette-quantise) with
+    ``circuitpython_png`` via
+    :func:`app.quantizer.circuitpython_indexed_image`; this renderer
+    saves the result as an uncompressed BMP so the client never runs
+    ``zlib.decompress``. Pillow's BMP writer emits BI_RGB (uncompressed)
+    bottom-up bitmaps, the format ``adafruit_imageload`` reads.
+    """
+    img = circuitpython_indexed_image(
+        png_bytes,
+        width=panel.w,
+        height=panel.h,
+        gamut=panel.gamut,
+        flip=panel.flip,
+        underscan=panel.underscan,
+        settings=settings,
+    )
+    buf = io.BytesIO()
+    # Uncompressed BMP: no ``compression`` kwarg means BI_RGB, which is
+    # the only BMP form adafruit_imageload decodes (it rejects RLE).
+    img.save(buf, format="BMP")
+    return buf.getvalue()
+
+
+def payload(digest: str, base_url: str, *, settings: dict[str, Any]) -> dict[str, Any]:
+    """Indexed-BMP output is self-contained; no rotation / scale / bg
+    knobs in the wire payload since the renderer applied them already."""
+    del settings
+    return {"url": f"{base_url.rstrip('/')}/renders/{digest}.bmp"}

--- a/renderers/circuitpython_bmp/tests/test_smoke.py
+++ b/renderers/circuitpython_bmp/tests/test_smoke.py
@@ -1,0 +1,125 @@
+"""circuitpython_bmp renderer smoke: composition PNG in, uncompressed
+indexed BMP out. Confirms the loader registers the renderer, the
+manifest fields are wired for BMP, output is a genuinely indexed BMP
+(mode "P" with the panel's palette) that carries no zlib compression
+(so adafruit_imageload can stream it without a decompress buffer), and
+the shared pixel pipeline matches circuitpython_png's palette choices.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+from app.main import REPO_ROOT
+from app.renderer_loader import discover
+from app.state.page_store import Panel
+
+
+@pytest.fixture
+def circuitpython_bmp(tmp_path):
+    registry = discover(
+        REPO_ROOT / "renderers",
+        schema_path=REPO_ROOT / "schema" / "renderer.schema.json",
+        data_root=tmp_path,
+    )
+    assert registry.errors == [], registry.errors
+    renderer = registry.get("circuitpython_bmp")
+    assert renderer is not None
+    return renderer
+
+
+@pytest.fixture
+def composition_png() -> bytes:
+    """A 200x100 colour-graded PNG to exercise the dither + quantize
+    path. Diagonal gradient stripes give the dither pass real work
+    rather than a flat block."""
+    img = Image.new("RGB", (200, 100))
+    for y in range(100):
+        for x in range(200):
+            img.putpixel((x, y), ((x + y) % 256, (x * 2) % 256, (y * 3) % 256))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _colors_used(out: Image.Image) -> set[tuple[int, int, int]]:
+    palette = out.getpalette() or []
+    indices = set(out.getdata())
+    return {(palette[i * 3], palette[i * 3 + 1], palette[i * 3 + 2]) for i in indices}
+
+
+def test_circuitpython_bmp_manifest_fields(circuitpython_bmp) -> None:
+    assert circuitpython_bmp.device == "circuitpython"
+    assert circuitpython_bmp.orientation == "composition"
+    assert circuitpython_bmp.extension == "bmp"
+    assert circuitpython_bmp.mime == "image/bmp"
+    assert circuitpython_bmp.retain is False
+    assert circuitpython_bmp.topic == "tesserae/circuitpython/frame/bmp"
+
+
+def test_circuitpython_bmp_output_is_bmp(circuitpython_bmp, composition_png) -> None:
+    # The whole point of this renderer: emit a real BMP (not a PNG the
+    # client would then have to zlib-decompress). Pillow tags the format
+    # on open, so a genuine BMP round-trips as "BMP".
+    panel = Panel(w=200, h=100, gamut="bwr_3")
+    artifact = circuitpython_bmp.transform(
+        composition_png, panel=panel, settings=circuitpython_bmp.settings_defaults()
+    )
+    assert artifact[:2] == b"BM", "BMP magic missing"
+    out = Image.open(io.BytesIO(artifact))
+    assert out.format == "BMP"
+
+
+def test_circuitpython_bmp_is_uncompressed(circuitpython_bmp, composition_png) -> None:
+    # adafruit_imageload rejects RLE-compressed BMP; the client needs
+    # BI_RGB (compression == 0). The 40-byte BITMAPINFOHEADER stores the
+    # compression method as a little-endian uint32 at byte offset 30.
+    panel = Panel(w=200, h=100, gamut="bwr_3")
+    artifact = circuitpython_bmp.transform(
+        composition_png, panel=panel, settings=circuitpython_bmp.settings_defaults()
+    )
+    compression = int.from_bytes(artifact[30:34], "little")
+    assert compression == 0, f"expected BI_RGB (0), got {compression}"
+
+
+def test_circuitpython_bmp_bwr_3_uses_tricolour_palette(circuitpython_bmp, composition_png) -> None:
+    from app.quantizer import BWR_3_PALETTE
+
+    panel = Panel(w=200, h=100, gamut="bwr_3")
+    artifact = circuitpython_bmp.transform(
+        composition_png, panel=panel, settings=circuitpython_bmp.settings_defaults()
+    )
+    out = Image.open(io.BytesIO(artifact))
+    assert out.mode == "P"
+    assert _colors_used(out) <= set(BWR_3_PALETTE)
+
+
+def test_circuitpython_bmp_matches_png_pixels(circuitpython_bmp, composition_png) -> None:
+    # BMP and PNG share the pixel pipeline (circuitpython_indexed_image);
+    # only the container differs. The decoded pixels must be identical so
+    # a client sees the same frame whichever format it asked for.
+    from app.quantizer import circuitpython_indexed_image
+
+    panel = Panel(w=200, h=100, gamut="spectra_6")
+    expected = circuitpython_indexed_image(
+        composition_png,
+        width=panel.w,
+        height=panel.h,
+        gamut=panel.gamut,
+        settings=circuitpython_bmp.settings_defaults(),
+    )
+    artifact = circuitpython_bmp.transform(
+        composition_png, panel=panel, settings=circuitpython_bmp.settings_defaults()
+    )
+    out = Image.open(io.BytesIO(artifact))
+    assert list(out.convert("RGB").getdata()) == list(expected.convert("RGB").getdata())
+
+
+def test_circuitpython_bmp_payload_points_at_bmp(circuitpython_bmp) -> None:
+    payload = circuitpython_bmp.payload(
+        "deadbeef", "http://host:8080", settings=circuitpython_bmp.settings_defaults()
+    )
+    assert payload["url"] == "http://host:8080/renders/deadbeef.bmp"

--- a/renderers/circuitpython_png/renderer.py
+++ b/renderers/circuitpython_png/renderer.py
@@ -41,88 +41,8 @@ from __future__ import annotations
 import io
 from typing import Any
 
-from PIL import Image, ImageEnhance
-
-from app.quantizer import (
-    BWR_3_PALETTE,
-    BWRY_4_PALETTE,
-    GRAY_4_PALETTE,
-    INKY_7COLOUR_PALETTE,
-    SPECTRA_6_PALETTE,
-    fit_to_panel,
-    underscan_image,
-)
+from app.quantizer import circuitpython_indexed_image
 from app.state.page_store import Panel
-
-_MONO_PALETTE: tuple[tuple[int, int, int], ...] = (
-    (0, 0, 0),
-    (255, 255, 255),
-)
-
-DEFAULTS: dict[str, Any] = {
-    "dither": "floyd-steinberg",
-    "contrast": 1.0,
-}
-
-# Pillow's ``Image.quantize`` only accepts Floyd-Steinberg or None via
-# its ``dither`` kwarg. The numpy-backed dither modes (Atkinson, Jarvis,
-# halftone, etc.) are bin-packer-only, so this renderer's manifest
-# narrows the choice list to match what Pillow can actually do here.
-_PIL_DITHER_MAP: dict[str, Image.Dither] = {
-    "floyd-steinberg": Image.Dither.FLOYDSTEINBERG,
-    "none": Image.Dither.NONE,
-}
-
-
-def _setting(settings: dict[str, Any], key: str) -> Any:
-    return settings.get(key, DEFAULTS[key])
-
-
-def _palette_for(gamut: str | None) -> tuple[tuple[int, int, int], ...] | None:
-    """Map a panel's declared gamut to an RGB palette tuple, or ``None``
-    when the gamut wants a full-colour (unquantised) output. Unknown
-    or empty gamuts fall through to Spectra 6 nominal so the renderer
-    is forgiving of custom panels that haven't named their gamut.
-
-    Aliases handled:
-      * ``mono`` -> black + white
-      * ``spectra_6`` / ``waveshare_e6`` / ``e6`` -> Spectra 6
-      * ``acep_7colour`` / ``acep_7color`` / ``inky_7colour`` -> 7-colour
-      * ``bwry_4`` -> 4-colour BWRY (v0.69.3 for PicPak-class panels)
-      * ``bwr_3`` -> 3-colour black/white/red tri-colour e-ink
-      * ``gray_4`` -> 4-level greyscale ramp (2-bit, no highlight)
-      * ``rgb24`` / ``rgb16`` -> None (24-bit RGB PNG passthrough,
-        v0.69.1 per issue #41)
-    """
-    g = (gamut or "").lower()
-    if g == "mono":
-        return _MONO_PALETTE
-    if g == "bwry_4":
-        return BWRY_4_PALETTE
-    if g == "bwr_3":
-        return BWR_3_PALETTE
-    if g == "gray_4":
-        return GRAY_4_PALETTE
-    if g in ("acep_7colour", "acep_7color", "inky_7colour"):
-        return INKY_7COLOUR_PALETTE
-    if g in ("rgb24", "rgb16"):
-        return None
-    # Spectra 6, Waveshare E6, e6, or anything else: 6-colour nominal.
-    return SPECTRA_6_PALETTE
-
-
-def _make_palette_image(palette: tuple[tuple[int, int, int], ...]) -> Image.Image:
-    """Build the Pillow palette image that ``Image.quantize`` expects.
-    Pads the unused entries with black so Pillow's quantiser sees a
-    full 256-entry table without those entries ever being selected
-    (the palette tuples themselves are short, 2 to 7 entries)."""
-    pal_img = Image.new("P", (16, 16))
-    flat: list[int] = []
-    for r, g, b in palette:
-        flat.extend((r, g, b))
-    flat.extend([0, 0, 0] * (256 - len(palette)))
-    pal_img.putpalette(flat)
-    return pal_img
 
 
 def transform(png_bytes: bytes, *, panel: Panel, settings: dict[str, Any]) -> bytes:
@@ -132,60 +52,23 @@ def transform(png_bytes: bytes, *, panel: Panel, settings: dict[str, Any]) -> by
     Output is palette-mode PNG so ``adafruit_imageload`` (and any other
     paletted-PNG loader) mounts it with minimal RAM. The device paints
     what arrives, no on-device quantize, no dither, no nibble unpack.
+
+    The pixel pipeline (fit, contrast, palette-quantise) is shared with
+    the ``circuitpython_bmp`` renderer via
+    :func:`app.quantizer.circuitpython_indexed_image`; this renderer
+    just saves the result as an indexed PNG.
     """
-    img = Image.open(io.BytesIO(png_bytes))
-    target_w, target_h = panel.w, panel.h
-
-    if panel.flip:
-        # Upside-down physical mount: turn the whole image 180° so it
-        # reads upright on the wall. Same shape as the other PNG
-        # renderers.
-        img = img.rotate(180, expand=True)
-
-    if img.size != (target_w, target_h):
-        # Composer pre-sizes pages to ``panel.w x panel.h`` so this is
-        # usually a no-op. It only does real work on Send-page image
-        # pushes where the user's input PNG isn't panel-sized.
-        fit = str(settings.get("image_fit") or "fit")
-        img = fit_to_panel(img, target_w=target_w, target_h=target_h, scale=fit, bg="white")
-
-    if panel.underscan:
-        # Per-device underscan: inset rendered content so it clears a
-        # physical bezel or mat covering the panel edge.
-        img = underscan_image(img, underscan=panel.underscan)
-
-    contrast = float(_setting(settings, "contrast"))
-    if abs(contrast - 1.0) > 1e-6:
-        # Pre-dither contrast push, same idea as trmnl_png: bumping
-        # contrast forces more pixels to definite black or definite
-        # white before the dither pass runs, which tends to read
-        # better on text-heavy dashboards.
-        img = ImageEnhance.Contrast(img.convert("L")).enhance(contrast).convert("RGB")
-
-    palette = _palette_for(panel.gamut)
-    buf = io.BytesIO()
-    if palette is None:
-        # rgb24 / rgb16 (v0.69.1): emit a plain 24-bit RGB PNG. Skips
-        # both palette-quantise and dither, so the client gets the
-        # composition's full colour range on the wire. rgb16 panels
-        # pack down to RGB565 in firmware (a Python one-liner:
-        # ``((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3)`` per
-        # pixel); a raw RGB565 wire format is a bandwidth-only
-        # follow-up.
-        img.convert("RGB").save(buf, format="PNG", optimize=True)
-        return buf.getvalue()
-    pal_img = _make_palette_image(palette)
-    dither_mode = _PIL_DITHER_MAP.get(
-        str(_setting(settings, "dither")), Image.Dither.FLOYDSTEINBERG
+    img = circuitpython_indexed_image(
+        png_bytes,
+        width=panel.w,
+        height=panel.h,
+        gamut=panel.gamut,
+        flip=panel.flip,
+        underscan=panel.underscan,
+        settings=settings,
     )
-    # ``Image.quantize`` keeps palette mode ("P"), which is what we
-    # want: the saved PNG carries an indexed pixel format that
-    # adafruit_imageload reads natively. We deliberately do not
-    # ``.convert("RGB")`` afterwards (that's what ``quantize_to_png``
-    # in app/quantizer.py does, for the bin-packer feed path).
-    indexed = img.convert("RGB").quantize(palette=pal_img, dither=dither_mode)
-
-    indexed.save(buf, format="PNG", optimize=True)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
     return buf.getvalue()
 
 

--- a/tests/test_device_service.py
+++ b/tests/test_device_service.py
@@ -77,6 +77,76 @@ def test_create_instance_derives_topics_and_clones(registries) -> None:
     assert (data_root / "esp32_lab.json").exists()
 
 
+def test_renderer_id_for_format_matches_extension(registries) -> None:
+    devices, renderers, _ = registries
+    kind = devices.get("circuitpython_generic")
+    assert kind is not None
+    assert kind.renderer_ids == ["circuitpython_png", "circuitpython_bmp"]
+    assert device_service.renderer_id_for_format(renderers, kind, "bmp") == "circuitpython_bmp"
+    assert device_service.renderer_id_for_format(renderers, kind, "png") == "circuitpython_png"
+    # Leading dot / casing tolerated.
+    assert device_service.renderer_id_for_format(renderers, kind, ".BMP") == "circuitpython_bmp"
+    # Unknown / empty leaves the kind default (None).
+    assert device_service.renderer_id_for_format(renderers, kind, "webp") is None
+    assert device_service.renderer_id_for_format(renderers, kind, None) is None
+
+
+def test_circuitpython_generic_defaults_to_png_clone_only(registries) -> None:
+    # No format declared: the multi-renderer kind must clone only its
+    # first renderer so the two never fight over the device's single
+    # latest-render slot.
+    devices, renderers, data_root = registries
+    result = device_service.create_instance(
+        devices=devices,
+        renderers=renderers,
+        data_root=data_root,
+        instance_id="cp_default",
+        kind_id="circuitpython_generic",
+    )
+    assert result.ok and result.device is not None
+    assert renderers.get("circuitpython_png__cp_default") is not None
+    assert renderers.get("circuitpython_bmp__cp_default") is None
+    assert result.device.renderer_ids == ["circuitpython_png__cp_default"]
+
+
+def test_circuitpython_generic_bmp_pick_clones_bmp_only(registries) -> None:
+    devices, renderers, data_root = registries
+    result = device_service.create_instance(
+        devices=devices,
+        renderers=renderers,
+        data_root=data_root,
+        instance_id="cp_bmp",
+        kind_id="circuitpython_generic",
+        renderer_id="circuitpython_bmp",
+    )
+    assert result.ok and result.device is not None
+    assert renderers.get("circuitpython_bmp__cp_bmp") is not None
+    assert renderers.get("circuitpython_png__cp_bmp") is None
+    assert result.device.renderer_ids == ["circuitpython_bmp__cp_bmp"]
+    # Persisted on the manifest so it survives a reload.
+    saved = json.loads((data_root / "cp_bmp.json").read_text())
+    assert saved["renderer_id"] == "circuitpython_bmp"
+
+
+def test_create_instance_ignores_unknown_renderer_id(registries) -> None:
+    # A renderer_id that isn't one of the kind's renderers is dropped, so
+    # the instance falls back to the kind default rather than orphaning
+    # itself with no renderer clone at all.
+    devices, renderers, data_root = registries
+    result = device_service.create_instance(
+        devices=devices,
+        renderers=renderers,
+        data_root=data_root,
+        instance_id="cp_bad",
+        kind_id="circuitpython_generic",
+        renderer_id="does_not_exist",
+    )
+    assert result.ok and result.device is not None
+    assert result.device.renderer_ids == ["circuitpython_png__cp_bad"]
+    saved = json.loads((data_root / "cp_bad.json").read_text())
+    assert "renderer_id" not in saved
+
+
 def test_create_instance_portrait_swaps_dims(registries) -> None:
     devices, renderers, data_root = registries
     result = device_service.create_instance(

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -247,6 +247,47 @@ def test_register_discovered_materialises_instance(app: Flask, tmp_path: Path) -
     assert (tmp_path / "devices" / "esp32_attic.json").exists()
 
 
+def test_register_discovered_honours_bmp_format(app: Flask, tmp_path: Path) -> None:
+    # A memory-constrained CircuitPython client declares format:"bmp" in
+    # its discover payload so registering it binds the uncompressed-BMP
+    # renderer, not the default PNG one.
+    cache = app.config["DISCOVERY_CACHE"]
+    cache.record(
+        "cp_kitchen",
+        b'{"kind":"circuitpython_generic","panel_w":400,"panel_h":300,'
+        b'"gamut":"bwr_3","format":"bmp"}',
+    )
+    client = app.test_client()
+    _sign_in(client)
+    resp = client.post("/settings/devices/discovery/cp_kitchen/register", follow_redirects=False)
+    assert resp.status_code == 302
+
+    dev = app.config["DEVICE_REGISTRY"].get("cp_kitchen")
+    assert dev is not None
+    assert dev.renderer_ids == ["circuitpython_bmp__cp_kitchen"]
+    registry = app.config["RENDERER_REGISTRY"]
+    assert registry.get("circuitpython_bmp__cp_kitchen") is not None
+    assert registry.get("circuitpython_png__cp_kitchen") is None
+
+
+def test_register_discovered_defaults_to_png_without_format(app: Flask, tmp_path: Path) -> None:
+    cache = app.config["DISCOVERY_CACHE"]
+    cache.record(
+        "cp_hall",
+        b'{"kind":"circuitpython_generic","panel_w":400,"panel_h":300,"gamut":"bwr_3"}',
+    )
+    client = app.test_client()
+    _sign_in(client)
+    resp = client.post("/settings/devices/discovery/cp_hall/register", follow_redirects=False)
+    assert resp.status_code == 302
+
+    dev = app.config["DEVICE_REGISTRY"].get("cp_hall")
+    assert dev is not None
+    assert dev.renderer_ids == ["circuitpython_png__cp_hall"]
+    registry = app.config["RENDERER_REGISTRY"]
+    assert registry.get("circuitpython_bmp__cp_hall") is None
+
+
 def test_register_refuses_without_kind(app: Flask) -> None:
     """A heartbeat with no 'kind' field can't be one-click registered
     , the form falls back to the manual Add-device path."""


### PR DESCRIPTION
## What

Adds an uncompressed-BMP frame format for CircuitPython clients, so a memory-constrained board can skip the `zlib.decompress` an indexed PNG needs.

Context: [discussion #24](https://github.com/dmellok/tesserae/discussions/24#discussioncomment-17618377). On a Pico W (~110K free SRAM), decoding even a small indexed PNG fails because CircuitPython's `zlib.decompress` is one-shot and needs the whole inflated image in a contiguous buffer alongside the `displayio.Bitmap`. An uncompressed BMP has no `zlib` in the path: `adafruit_imageload` reads it row by row with `file.read` / `seek`, so peak RAM is the framebuffer plus a small row buffer.

## How

- New `circuitpython_bmp` renderer (sibling of `circuitpython_png`), emitting uncompressed `BI_RGB` indexed BMP.
- Shared fit / contrast / palette-quantise pipeline extracted to `app.quantizer.circuitpython_indexed_image`, so both renderers produce identical pixels and only the container differs.
- `circuitpython_generic` lists both renderers; a client declares `"format": "bmp"` on `/discover` (or `/register`) and the instance pins one renderer via a `renderer_id` recorded at registration. Resolution matches the renderer's file extension, so the `format` you declare is the `format` you get back from `/frame`.
- `clone_for_instances` and the instance loader honour the per-instance `renderer_id`; with none recorded, a multi-renderer kind clones only its first renderer so the two never fight over the device's single latest-render slot. Single-renderer kinds (every other built-in) are unchanged.
- Default stays PNG (a few times smaller on the wire; server writes palette-mode BMP at 8bpp).

## Notes

- Client-protocol spec updated (`discover` `format` field, frame-formats section).
- Full suite green (1662 passed), mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
