### PR TITLE
fix(mcp): set explicit User-Agent for Tesserae API requests

### DIFF
--- a/packages/tesserae-mcp/tesserae_mcp/__init__.py
+++ b/packages/tesserae-mcp/tesserae_mcp/__init__.py
@@ -111,6 +111,9 @@ def _request(method: str, path: str, body: dict[str, Any] | None = None) -> tupl
     url = f"{_BASE}/api/mcp{path}"
     data = json.dumps(body).encode() if body is not None else None
     req = urllib.request.Request(url, data=data, method=method)
+    # Cloudflare (and similar WAFs) block urllib's default "Python-urllib/x.y"
+    # user agent, so identify ourselves explicitly.
+    req.add_header("User-Agent", f"tesserae-mcp/{__version__}")
     if body is not None:
         req.add_header("Content-Type", "application/json")
     if _TOKEN:


### PR DESCRIPTION
## What this changes

Sets an explicit `User-Agent` header on Tesserae MCP HTTP requests.

## Why

Some WAFs, including Cloudflare configurations, block urllib’s default `Python-urllib/x.y` user agent. Identifying the bridge as `tesserae-mcp/<version>` lets the MCP client reach hosted Tesserae instances that reject the default header.

Closes #

## Test plan

- [x] `uv run --extra dev pytest -q` from repo root: `1662 passed`
- [x] `uv run --extra dev ruff check .` from repo root
- [x] `uv run --extra dev ruff format --check .` from repo root
- [x] `uv run --extra dev mypy app` from repo root
- [x] `uv run --extra dev pytest -q` in `packages/tesserae-mcp`: `3 passed`
- [x] `uv run --extra dev ruff check .` in `packages/tesserae-mcp`
- [x] `uv run --extra dev ruff format --check .` in `packages/tesserae-mcp`
- [ ] Manually verified against a Cloudflare-protected Tesserae instance

## Checklist

- [x] Tests added for new behaviour, or note why none made sense: no new test added; change is a fixed request header and existing package tests/lint pass
- [x] `ruff` + `mypy` clean
- [ ] User-facing changes documented: not updated
- [ ] CHANGELOG entry added under `## [Unreleased]` if user-facing
- [ ] `pyproject.toml` version bumped if this is going to be tagged