### PR TITLE
feat(mcp): faithful-render screenshots for the catalog (Screenshot Contract)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Added
 
+- **MCP faithful-render screenshots for the catalog (Screenshot Contract).** The
+  `GET /api/mcp/widgets/<id>/render.png` faithful render now accepts explicit `w`&`h`
+  (clamped) as an alternative to `size` (`lg` stays 1200x800), reuses the same
+  Playwright render path, and tightens its error semantics to the contract: unknown
+  widget 404, unknown fragment or invalid `options`/`opts` JSON 400, render unavailable
+  503 (was 502), never a 200 with a blank / HTML body. A small `python -m app.screenshots
+  <id> --out <dir> --lg --extra <presets.json>` CLI drives that same endpoint to write a
+  widget's whole catalog set (`lg.png` plus `extra-1..N.png` from a `{name, options}`
+  preset list). All additive; no `w`/`h` = today's behaviour.
+
 - **CircuitPython clients can request an uncompressed BMP frame.** New
   `circuitpython_bmp` renderer emits the composition quantised to the panel's palette
   as an uncompressed indexed BMP, alongside the existing `circuitpython_png`. A client

--- a/app/composer.py
+++ b/app/composer.py
@@ -41,6 +41,17 @@ SIZE_DIMENSIONS: dict[str, tuple[int, int]] = {
     "lg": (1200, 800),
 }
 
+# Bounds for an explicit ``w,h`` screenshot request (Screenshot Contract). Wide
+# enough for any real panel, tight enough that a typo can't ask the browser for
+# a runaway viewport.
+SCREENSHOT_MIN_DIM = 16
+SCREENSHOT_MAX_DIM = 4096
+
+
+def clamp_screenshot_dim(value: int) -> int:
+    """Clamp an explicit screenshot dimension to ``[MIN, MAX]``."""
+    return max(SCREENSHOT_MIN_DIM, min(SCREENSHOT_MAX_DIM, value))
+
 
 def _registry() -> PluginRegistry:
     registry: PluginRegistry = current_app.config["PLUGIN_REGISTRY"]
@@ -1066,6 +1077,10 @@ def test_render() -> str:
     size = request.args.get("size", "md")
     if size not in SIZE_DIMENSIONS:
         abort(400)
+    # Explicit ``w,h`` (Screenshot Contract) override the size preset for the
+    # cell dimensions; absent, the size mapping stands (default behaviour).
+    dim_w = request.args.get("w")
+    dim_h = request.args.get("h")
 
     sample_mode = request.args.get("sample") == "1"
     # ?theme=<id> picks one of the Spectra theme blocks
@@ -1116,7 +1131,14 @@ def test_render() -> str:
         except (json.JSONDecodeError, ValueError):
             cell_options = {}
 
-    cell_w, cell_h = SIZE_DIMENSIONS[size]
+    if dim_w is not None or dim_h is not None:
+        try:
+            cell_w = clamp_screenshot_dim(int(dim_w))  # type: ignore[arg-type]
+            cell_h = clamp_screenshot_dim(int(dim_h))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            abort(400)
+    else:
+        cell_w, cell_h = SIZE_DIMENSIONS[size]
     page = {
         "id": "_test",
         "name": f"Test: {plugin_id} @ {size}",

--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -458,28 +458,62 @@ def list_authored_widgets() -> Response:
 def widget_render(key: str) -> Response:
     """Faithful e-ink render of a single widget as a PNG, over the authed MCP
     surface (so a client can preview against a remote / HA instance where
-    ``/_test/render`` is not reachable). Query: ``size`` (xs|sm|md|lg, default lg),
-    ``opts`` (JSON cell options), optional ``theme`` / ``style`` / ``sample`` / ``zoom``,
-    ``fragment`` (render one declared fragment, default the whole widget), and
-    ``fresh=true`` (bypass caches so a just-edited server.py is reflected now)."""
+    ``/_test/render`` is not reachable). Query: ``size`` (xs|sm|md|lg, default
+    lg; ``lg`` is 1200x800) OR explicit ``w`` & ``h`` (clamped); ``options`` (or
+    ``opts``, JSON cell options); optional ``theme`` / ``style`` / ``sample`` /
+    ``zoom``; ``fragment`` (render one declared fragment, default the whole
+    widget); ``fresh=true`` (bypass caches so a just-edited server.py is
+    reflected now).
+
+    Screenshot Contract error semantics: unknown widget -> 404, unknown fragment
+    or bad ``options`` JSON -> 400, render unavailable -> 503. Never 200 + a
+    blank / HTML body."""
     from urllib.parse import urlencode
 
-    from app.composer import SIZE_DIMENSIONS
+    from app.composer import SIZE_DIMENSIONS, clamp_screenshot_dim
     from app.panels_schema import fragments_of
     from app.renderer import RenderRequest, render_to_png, to_loopback_url
 
     plugin = _pr._registry().get(key)
     if plugin is None:
         return _err(404, f"unknown widget {key!r}")
+    # Explicit ``w,h`` override the size preset (Screenshot Contract); clamped
+    # so a typo can't ask the browser for a runaway viewport. Absent, the
+    # xs|sm|md|lg mapping stands (``lg`` == 1200x800).
+    w_arg = request.args.get("w")
+    h_arg = request.args.get("h")
     size = request.args.get("size", "lg")
-    if size not in SIZE_DIMENSIONS:
-        return _err(400, f"size must be one of {'|'.join(sorted(SIZE_DIMENSIONS))}")
-    w, h = SIZE_DIMENSIONS[size]
+    if w_arg is not None or h_arg is not None:
+        try:
+            w = clamp_screenshot_dim(int(w_arg))  # type: ignore[arg-type]
+            h = clamp_screenshot_dim(int(h_arg))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return _err(400, "w and h must both be integers")
+    else:
+        if size not in SIZE_DIMENSIONS:
+            return _err(400, f"size must be one of {'|'.join(sorted(SIZE_DIMENSIONS))}")
+        w, h = SIZE_DIMENSIONS[size]
     fragment = request.args.get("fragment")
     if fragment and fragment != "full" and fragment not in {f["id"] for f in fragments_of(plugin)}:
         return _err(400, f"widget {key!r} has no fragment {fragment!r}")
+    # ``options`` is the Screenshot Contract spelling; ``opts`` is the existing
+    # one. Validate up front: bad JSON is a 400 here (the dev preview silently
+    # falls through to defaults, which would read as a passing screenshot).
+    opts_raw = request.args.get("opts") or request.args.get("options")
+    if opts_raw:
+        try:
+            parsed = json.loads(opts_raw)
+        except (json.JSONDecodeError, ValueError):
+            return _err(400, "options must be valid JSON")
+        if not isinstance(parsed, dict):
+            return _err(400, "options must be a JSON object")
     params: dict[str, str] = {"plugin": key, "size": size}
-    for arg in ("opts", "theme", "style", "sample", "zoom", "fragment", "fresh"):
+    if w_arg is not None or h_arg is not None:
+        params["w"] = str(w)
+        params["h"] = str(h)
+    if opts_raw:
+        params["opts"] = opts_raw
+    for arg in ("theme", "style", "sample", "zoom", "fragment", "fresh"):
         val = request.args.get(arg)
         if val:
             params[arg] = val
@@ -491,7 +525,7 @@ def widget_render(key: str) -> Response:
             pool=current_app.config.get("BROWSER_POOL"),
         )
     except Exception as err:
-        return _err(502, f"render failed: {type(err).__name__}: {err}")
+        return _err(503, f"render unavailable: {type(err).__name__}: {err}")
     return current_app.response_class(png, mimetype="image/png")
 
 

--- a/app/screenshots.py
+++ b/app/screenshots.py
@@ -1,0 +1,137 @@
+"""Catalog screenshot emitter for Tesserae widgets.
+
+Writes a widget's faithful-render screenshot set, ``lg.png`` (1200x800) plus
+``extra-1..N.png`` from a preset list, by driving a running Tesserae
+instance's MCP ``render.png`` endpoint. That endpoint IS Studio's faithful /
+Playwright render path, so this reuses it verbatim: no second renderer, no
+browser in this process. It just needs a Tesserae server to talk to (loopback
+by default, the same one Studio uses).
+
+    python -m app.screenshots <id> --out screenshots/<id>/ --lg \\
+        --extra presets.json
+
+``presets.json`` is a JSON list of ``{"name": str, "options": {...}}``; each
+entry may also carry ``size`` (xs|sm|md|lg, default lg) or explicit ``w`` &
+``h``. Entry *i* is written as ``extra-<i>.png`` rendered with those cell
+options, so configured / generative states come out reproducibly (a widget
+honours any seed / day it reads from its options).
+
+Connection defaults to ``TESSERAE_URL`` (http://127.0.0.1:8765) and, when the
+server isn't on loopback, ``TESSERAE_MCP_TOKEN`` for the bearer header; both
+are overridable with ``--url`` / ``--token``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+DEFAULT_BASE = os.environ.get("TESSERAE_URL", "http://127.0.0.1:8765").rstrip("/")
+DEFAULT_TOKEN = os.environ.get("TESSERAE_MCP_TOKEN", "").strip()
+
+
+def _render(
+    base: str,
+    token: str,
+    widget_id: str,
+    *,
+    size: str | None = None,
+    w: int | None = None,
+    h: int | None = None,
+    options: dict[str, Any] | None = None,
+    timeout: float = 60.0,
+) -> bytes:
+    """Fetch one faithful-render PNG from the running server's render.png
+    endpoint. Explicit ``w,h`` win over ``size`` (matching the endpoint)."""
+    params: dict[str, str] = {}
+    if w is not None and h is not None:
+        params["w"], params["h"] = str(w), str(h)
+    elif size:
+        params["size"] = size
+    if options:
+        params["opts"] = json.dumps(options, separators=(",", ":"))
+    url = f"{base}/api/mcp/widgets/{urllib.parse.quote(widget_id)}/render.png"
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url, method="GET")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return bytes(resp.read())
+    except urllib.error.HTTPError as err:
+        detail = err.read().decode("utf-8", "replace").strip()
+        raise SystemExit(f"render failed ({err.code}) for {widget_id!r}: {detail}") from err
+    except urllib.error.URLError as err:
+        raise SystemExit(
+            f"cannot reach Tesserae at {base} ({err.reason}). Is the server running?"
+        ) from err
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m app.screenshots",
+        description="Emit a widget's catalog screenshot set via the faithful renderer.",
+    )
+    parser.add_argument("widget_id", help="widget id (as in plugins/<id>/ and the catalog)")
+    parser.add_argument("--out", required=True, help="output directory (created if absent)")
+    parser.add_argument("--lg", action="store_true", help="write lg.png (1200x800)")
+    parser.add_argument("--extra", help="path to a presets JSON list ({name, options})")
+    parser.add_argument(
+        "--url", default=DEFAULT_BASE, help=f"server base URL (default {DEFAULT_BASE})"
+    )
+    parser.add_argument(
+        "--token", default=DEFAULT_TOKEN, help="MCP bearer token (loopback needs none)"
+    )
+    args = parser.parse_args(argv)
+
+    if not args.lg and not args.extra:
+        parser.error("nothing to do: pass --lg and/or --extra")
+
+    base = args.url.rstrip("/")
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    written: list[str] = []
+
+    if args.lg:
+        png = _render(base, args.token, args.widget_id, size="lg")
+        (out / "lg.png").write_bytes(png)
+        written.append("lg.png")
+
+    if args.extra:
+        try:
+            presets = json.loads(Path(args.extra).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as err:
+            raise SystemExit(f"could not read presets file {args.extra!r}: {err}") from err
+        if not isinstance(presets, list):
+            raise SystemExit("--extra file must be a JSON list of {name, options} objects")
+        for i, preset in enumerate(presets, start=1):
+            if not isinstance(preset, dict):
+                raise SystemExit(f"preset {i} must be an object, got {type(preset).__name__}")
+            options = preset.get("options") if isinstance(preset.get("options"), dict) else {}
+            png = _render(
+                base,
+                args.token,
+                args.widget_id,
+                size=str(preset.get("size", "lg")),
+                w=preset.get("w"),
+                h=preset.get("h"),
+                options=options,
+            )
+            name = f"extra-{i}.png"
+            (out / name).write_bytes(png)
+            written.append(name)
+
+    print(f"wrote {len(written)} screenshot(s) to {out}/: {', '.join(written)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.112.0"
+version = "0.113.0"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -43,6 +43,18 @@ def test_test_render_honours_fragment(client: FlaskClient) -> None:
     assert client.get("/_test/render?plugin=weather_now&size=md&fragment=nope").status_code == 400
 
 
+def test_test_render_honours_explicit_wh(client: FlaskClient) -> None:
+    """Explicit ?w&h override the size preset for the cell + panel dims
+    (Screenshot Contract); out-of-range values clamp rather than 400 or
+    overflow the viewport."""
+    html = client.get("/_test/render?plugin=clock&w=300&h=200").get_data(as_text=True)
+    assert 'data-cell-w="300"' in html
+    assert 'data-panel-w="300"' in html
+    # Above/below the bounds clamp to 4096 / 16.
+    clamped = client.get("/_test/render?plugin=clock&w=999999&h=1").get_data(as_text=True)
+    assert 'data-cell-w="4096"' in clamped
+
+
 def test_compose_route_404s_on_unknown_page(client: FlaskClient) -> None:
     resp = client.get("/compose/nonexistent")
     assert resp.status_code == 404

--- a/tests/test_mcp_api.py
+++ b/tests/test_mcp_api.py
@@ -271,6 +271,112 @@ def test_preview_returns_png(app: Flask, monkeypatch: pytest.MonkeyPatch) -> Non
     assert resp.get_data() == _FAKE_PNG
 
 
+# -- faithful render / Screenshot Contract (widgets/<id>/render.png) ------
+
+
+def _png_of_size(w: int, h: int) -> bytes:
+    """A real PNG at exactly ``w x h`` so the render mock exercises the
+    endpoint's dimensioning end to end (the browser viewport drives the size)."""
+    from io import BytesIO
+
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (w, h), "white").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _viewport_render(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.renderer.render_to_png",
+        lambda req, pool=None: _png_of_size(req.viewport_w, req.viewport_h),
+    )
+
+
+def test_render_png_lg_is_1200x800(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    from io import BytesIO
+
+    from PIL import Image
+
+    _enable(app)
+    _viewport_render(monkeypatch)
+    resp = app.test_client().get("/api/mcp/widgets/clock_analog/render.png?size=lg")
+    assert resp.status_code == 200 and resp.mimetype == "image/png"
+    assert Image.open(BytesIO(resp.get_data())).size == (1200, 800)
+
+
+def test_render_png_explicit_wh_overrides_size(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    from io import BytesIO
+
+    from PIL import Image
+
+    _enable(app)
+    _viewport_render(monkeypatch)
+    resp = app.test_client().get("/api/mcp/widgets/clock_analog/render.png?w=300&h=200")
+    assert resp.status_code == 200
+    assert Image.open(BytesIO(resp.get_data())).size == (300, 200)
+
+
+def test_render_png_wh_clamped(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    from io import BytesIO
+
+    from PIL import Image
+
+    _enable(app)
+    _viewport_render(monkeypatch)
+    resp = app.test_client().get("/api/mcp/widgets/clock_analog/render.png?w=999999&h=1")
+    assert resp.status_code == 200
+    # 4096 max / 16 min bounds (see composer.clamp_screenshot_dim).
+    assert Image.open(BytesIO(resp.get_data())).size == (4096, 16)
+
+
+def test_render_png_bad_wh_400(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(app)
+    _viewport_render(monkeypatch)
+    resp = app.test_client().get("/api/mcp/widgets/clock_analog/render.png?w=abc&h=200")
+    assert resp.status_code == 400 and "error" in resp.get_json()
+
+
+def test_render_png_unknown_widget_404(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(app)
+    monkeypatch.setattr("app.renderer.render_to_png", lambda req, pool=None: _FAKE_PNG)
+    resp = app.test_client().get("/api/mcp/widgets/does_not_exist/render.png")
+    assert resp.status_code == 404 and "error" in resp.get_json()
+
+
+def test_render_png_render_unavailable_503(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(app)
+
+    def _boom(req: Any, pool: Any = None) -> bytes:
+        raise RuntimeError("no browser")
+
+    monkeypatch.setattr("app.renderer.render_to_png", _boom)
+    resp = app.test_client().get("/api/mcp/widgets/clock_analog/render.png?size=lg")
+    assert resp.status_code == 503 and "error" in resp.get_json()
+
+
+def test_render_png_bad_options_400(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(app)
+    monkeypatch.setattr("app.renderer.render_to_png", lambda req, pool=None: _FAKE_PNG)
+    client = app.test_client()
+    # Both spellings validate; malformed JSON is a 400, not a silent fallthrough.
+    assert client.get("/api/mcp/widgets/clock_analog/render.png?opts=not-json").status_code == 400
+    assert client.get("/api/mcp/widgets/clock_analog/render.png?options=%7Bbad").status_code == 400
+    # Valid JSON that isn't an object is also rejected ([1,2]).
+    assert (
+        client.get("/api/mcp/widgets/clock_analog/render.png?opts=%5B1%2C2%5D").status_code == 400
+    )
+    # A valid object still renders.
+    assert client.get("/api/mcp/widgets/clock_analog/render.png?opts=%7B%7D").status_code == 200
+
+
+def test_render_png_unknown_fragment_400(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(app)
+    monkeypatch.setattr("app.renderer.render_to_png", lambda req, pool=None: _FAKE_PNG)
+    resp = app.test_client().get("/api/mcp/widgets/weather_now/render.png?fragment=nope")
+    assert resp.status_code == 400 and "error" in resp.get_json()
+
+
 def test_push_requires_device_ids(app: Flask) -> None:
     _enable(app)
     client = app.test_client()

--- a/tests/test_screenshots.py
+++ b/tests/test_screenshots.py
@@ -1,0 +1,66 @@
+"""The `python -m app.screenshots` catalog-set emitter.
+
+The emitter drives a running server's render.png endpoint, so these tests stub
+``_render`` (the one HTTP call) and check the CLI's file layout, preset
+handling, and argument guards, not the render itself (covered in test_mcp_api)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app import screenshots
+
+
+def _stub_render(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+
+    def fake(base, token, widget_id, *, size=None, w=None, h=None, options=None, timeout=60.0):  # type: ignore[no-untyped-def]
+        calls.append({"size": size, "w": w, "h": h, "options": options})
+        tag = size or f"{w}x{h}"
+        return f"PNG:{tag}".encode()
+
+    monkeypatch.setattr(screenshots, "_render", fake)
+    return calls
+
+
+def test_writes_lg_and_extras(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _stub_render(monkeypatch)
+    presets = tmp_path / "presets.json"
+    presets.write_text(
+        json.dumps(
+            [
+                {"name": "configured", "options": {"seed": 1}},
+                {"name": "medium", "options": {}, "size": "md"},
+            ]
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "shots"
+    rc = screenshots.main(
+        ["clock_analog", "--out", str(out), "--lg", "--extra", str(presets), "--url", "http://x"]
+    )
+    assert rc == 0
+    assert (out / "lg.png").read_bytes() == b"PNG:lg"
+    assert (out / "extra-1.png").exists()
+    assert (out / "extra-2.png").exists()
+    # lg first, then each preset with its options / size honoured.
+    assert calls[0]["size"] == "lg"
+    assert calls[1]["options"] == {"seed": 1}
+    assert calls[2]["size"] == "md"
+
+
+def test_requires_lg_or_extra(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit):
+        screenshots.main(["clock_analog", "--out", str(tmp_path / "o")])
+
+
+def test_presets_must_be_a_list(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_render(monkeypatch)
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"not": "a list"}), encoding="utf-8")
+    with pytest.raises(SystemExit):
+        screenshots.main(["clock_analog", "--out", str(tmp_path / "o"), "--extra", str(bad)])


### PR DESCRIPTION
Four MCP improvements for the Studio widget-build + publish loop were requested. On audit, **three were already shipped by #104** (`feat: MCP authoring affordances`): `fragment` on the faithful render (endpoint + `test_render`), `fresh=true` cache-bypass on data + render, page delete (`DELETE /pages/<id>` + the bridge's `delete_canvas_page`), and the clearer reload signal (`reloaded` + `modules` on `_reload_registry`). So this PR is scoped to the remaining piece: **item 4, the Screenshot Contract.**

## What this adds

- **`w`&`h` on `render.png`** as an alternative to the `size` preset, clamped to sane bounds (16–4096). `size` still maps `xs|sm|md|lg`, with `lg` == 1200×800. `test_render` honours the same `w,h` so the cell matches the viewport; absent, behaviour is unchanged.
- **Contract error semantics** on `render.png`: unknown widget → 404, unknown fragment or invalid `options`/`opts` JSON → **400**, render unavailable → **503** (was 502). Never a 200 + blank/HTML body. `options` is accepted as an alias for the existing `opts`.
- **Catalog-set CLI** — `python -m app.screenshots <id> --out <dir> --lg --extra <presets.json>`. It reuses the **same render path** by driving the running server's `render.png` endpoint over HTTP (no second renderer, no in-process browser), writing `lg.png` (1200×800) plus `extra-1..N.png` from a `{name, options}` preset list.

Reuses the existing faithful/Playwright renderer and the live plugin registry throughout; all changes are additive and bearer/loopback-authed like today.

## Tests
- `render.png?size=lg` → PNG exactly 1200×800 (via the endpoint's viewport); explicit `w,h` override + clamp; unknown id 404; render-off 503; bad `opts`/`options` JSON 400; unknown fragment 400.
- `test_render?w=&h=` sets the cell + panel dims and clamps out-of-range.
- The `app.screenshots` CLI writes `lg.png` + `extra-N.png`, honours each preset's options/size, and rejects a non-list presets file.
- Full suite green (1674 passed), mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
