### PR TITLE
feat: AI-generated canvas backgrounds via fal.ai (composite)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Added
 
+- **AI-generated canvas backgrounds (fal.ai).** A canvas dashboard can generate a full-bleed
+  background image from a text prompt; the data widgets composite crisply on top, so the data
+  never passes through the image model (the background is decorative, the numbers stay exact).
+  New `app.fal_backgrounds` service calls fal.ai, stores the result as a local render asset, and
+  sets the canvas' existing `bg_image`. Exposed as `POST /api/mcp/pages/<id>/background` (and
+  `set_canvas_background` in the `tesserae-mcp` bridge) and as a "Generate background" control in
+  the canvas editor's appearance panel. Model + style presets mirror the fal-image widget; the
+  fal key is reused from an installed fal-image widget, else `app.fal.api_key`, else `FAL_KEY`.
+  Generation is on-demand (set-and-forget). Needs a fal.ai key; no key = the feature 400s cleanly.
+
 - **MCP faithful-render screenshots for the catalog (Screenshot Contract).** The
   `GET /api/mcp/widgets/<id>/render.png` faithful render now accepts explicit `w`&`h`
   (clamped) as an alternative to `size` (`lg` stays 1200x800), reuses the same

--- a/app/fal_backgrounds.py
+++ b/app/fal_backgrounds.py
@@ -1,0 +1,261 @@
+"""AI-generated canvas backgrounds via fal.ai (Approach A: composite).
+
+Generates a full-bleed background image from a text prompt and stores it as a
+local render asset, so a canvas dashboard can set it as ``bg_image`` and paint
+its data widgets crisply ON TOP. The data never passes through the image model,
+which is the whole point: the background is decorative, the numbers stay exact.
+
+The heavy lifting downstream already exists, ``CanvasLayout.bg_image`` /
+``bg_fit`` render a full-bleed ``<img>`` at ``z-index:0`` behind every element.
+This module only covers the missing piece: call fal, fetch the bytes, and
+hand back a stored PNG the canvas can point at.
+
+Ported from the community ``fal-image`` widget's fal client so the request
+shapes and model handling stay in lockstep, but scoped to a one-shot,
+on-demand background (no per-cadence rotation).
+
+Key resolution (see :func:`resolve_fal_key`) reuses an installed fal-image
+widget's key first, then an app-level setting, then ``FAL_KEY`` in the env.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+from PIL import Image
+
+API_BASE = "https://fal.run"
+USER_AGENT = "tesserae/fal-backgrounds"
+HTTP_TIMEOUT_S = 60.0
+DEFAULT_MODEL = "fal-ai/flux/schnell"
+
+# The curated model list, mirroring the fal-image widget. Backgrounds default
+# to Flux Schnell (~$0.003) for cheap, fast, dithers-clean output.
+MODELS: tuple[str, ...] = (
+    "fal-ai/flux/schnell",
+    "fal-ai/hyper-sdxl",
+    "fal-ai/fast-sdxl",
+    "fal-ai/flux/dev",
+    "fal-ai/recraft-v3",
+    "fal-ai/flux-pro/v1.1",
+    "fal-ai/nano-banana",
+    "fal-ai/nano-banana-2",
+    "fal-ai/nano-banana-pro",
+)
+
+# Nano Banana (Gemini) accepts only ratio strings, not width/height. Map the
+# canvas aspect onto its vocabulary.
+_NANO_MODELS = frozenset({"fal-ai/nano-banana", "fal-ai/nano-banana-2", "fal-ai/nano-banana-pro"})
+FLUX_DEV = "fal-ai/flux/dev"
+
+# Flux + SDXL want width/height rounded to a multiple of 16 and clamped to
+# [256, 1536]; below ~256 the models produce garbage.
+_DIM_MIN = 256
+_DIM_MAX = 1536
+_DIM_STEP = 16
+
+# Style presets prepended to the prompt. Same vocabulary as the fal-image
+# widget so a user's mental model carries over.
+STYLE_PRESETS: dict[str, str] = {
+    "none": "",
+    "oil_painting": "oil painting style, painterly brushstrokes, rich textures",
+    "watercolor": "watercolor painting, soft washes, paper texture",
+    "pencil_sketch": "graphite pencil sketch, hatched lines, paper grain",
+    "pixel_art": "pixel art, 16-bit aesthetic, blocky shapes",
+    "cyberpunk": "cyberpunk aesthetic, neon lights, rain-slick streets",
+    "botanical": "vintage botanical illustration, scientific plate, fine ink lines",
+    "bauhaus": "bauhaus geometric design, primary colors, hard edges, modernist",
+    "risograph": "risograph print, limited two-color palette, paper grain, offset registration",
+    "line_art": "minimal continuous line art, single line drawing, white background",
+    "ukiyo_e": "ukiyo-e Japanese woodblock print, flat colors, bold outlines",
+    "art_deco": "art deco style, geometric symmetry, gold accents, 1920s",
+}
+
+# For a *background*, low-contrast busy output turns to mud behind widgets and
+# under 6-colour dithering. This suffix steers toward a clean backdrop and,
+# unlike the widget's version, nudges detail away from the centre where the
+# data sits.
+_EINK_SUFFIX = (
+    ", high contrast, limited palette, simple composition, "
+    "uncluttered center, suitable as a background"
+)
+
+
+class FalError(RuntimeError):
+    """A fal.ai request or image fetch failed. Carries a client-safe message."""
+
+
+def resolve_fal_key(registry: Any, settings_store: Any) -> str | None:
+    """Find a fal.ai API key: an installed fal-image widget's key first, then an
+    app-level setting (``app.fal.api_key``), then the ``FAL_KEY`` /
+    ``FAL_API_KEY`` env var. Returns ``None`` when none is configured."""
+    if registry is not None and settings_store is not None:
+        for plugin in getattr(registry, "plugins", {}).values():
+            manifest = getattr(plugin, "manifest", {}) or {}
+            fields = manifest.get("settings", []) or []
+            if not any(f.get("name") == "api_key" for f in fields):
+                continue
+            pid = str(getattr(plugin, "id", "") or "")
+            name = str(manifest.get("name", "") or "")
+            if "fal" not in pid.lower() and "fal" not in name.lower():
+                continue
+            vals = settings_store.get_for_runtime("plugins", pid, fields)
+            key = str(vals.get("api_key") or "").strip()
+            if key:
+                return key
+    if settings_store is not None:
+        vals = settings_store.get_for_runtime("app", "fal", [{"name": "api_key", "secret": True}])
+        key = str(vals.get("api_key") or "").strip()
+        if key:
+            return key
+    for env in ("FAL_KEY", "FAL_API_KEY"):
+        val = (os.environ.get(env) or "").strip()
+        if val:
+            return val
+    return None
+
+
+def build_prompt(prompt: str, style: str, *, eink_friendly: bool = True) -> str:
+    """Prepend the style preset and append the e-ink suffix, same order as the
+    fal-image widget."""
+    parts: list[str] = []
+    preset = STYLE_PRESETS.get((style or "none").strip().lower(), "")
+    if preset:
+        parts.append(preset)
+    parts.append(prompt.strip())
+    final = ", ".join(p for p in parts if p)
+    if eink_friendly:
+        final += _EINK_SUFFIX
+    return final
+
+
+def _round_dim(px: int) -> int:
+    px = max(_DIM_MIN, min(_DIM_MAX, px))
+    return round(px / _DIM_STEP) * _DIM_STEP
+
+
+def _nano_aspect(width: int, height: int) -> str:
+    """Snap a canvas aspect to Nano Banana's nearest ratio string."""
+    ratio = width / height if height else 1.0
+    table = {"1:1": 1.0, "4:3": 4 / 3, "16:9": 16 / 9, "3:4": 3 / 4, "9:16": 9 / 16}
+    return min(table, key=lambda r: abs(table[r] - ratio))
+
+
+def _build_body(model: str, prompt: str, width: int, height: int, seed: int) -> dict[str, Any]:
+    if model in _NANO_MODELS:
+        return {"prompt": prompt, "aspect_ratio": _nano_aspect(width, height), "num_images": 1}
+    body: dict[str, Any] = {
+        "prompt": prompt,
+        "seed": seed,
+        "image_size": {"width": _round_dim(width), "height": _round_dim(height)},
+    }
+    if model == FLUX_DEV:
+        body["num_inference_steps"] = 28
+    return body
+
+
+def _fal_request(model: str, body: dict[str, Any], api_key: str) -> Any:
+    import json
+
+    url = f"{API_BASE}/{model.lstrip('/')}"
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        method="POST",
+        headers={
+            "Authorization": f"Key {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": USER_AGENT,
+        },
+    )
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as resp:
+        import json as _json
+
+        return _json.loads(resp.read().decode("utf-8"))
+
+
+def _pick_image_url(payload: Any) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    images = payload.get("images")
+    if isinstance(images, list) and images and isinstance(images[0], dict):
+        url = images[0].get("url")
+        if isinstance(url, str) and url:
+            return url
+    image = payload.get("image")
+    if isinstance(image, dict):
+        url = image.get("url")
+        if isinstance(url, str) and url:
+            return url
+    return None
+
+
+def _download(url: str) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as resp:
+        return bytes(resp.read())
+
+
+def _to_png(raw: bytes) -> bytes:
+    """Re-encode whatever fal returned (jpeg/webp/png) to PNG so the stored
+    asset is a valid ``.png`` and serves with the right mime."""
+    buf = io.BytesIO()
+    Image.open(io.BytesIO(raw)).convert("RGB").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def generate(
+    prompt: str,
+    *,
+    api_key: str,
+    model: str = DEFAULT_MODEL,
+    style: str = "none",
+    width: int,
+    height: int,
+    eink_friendly: bool = True,
+    seed: int | None = None,
+) -> bytes:
+    """Generate one background image and return PNG bytes. Raises
+    :class:`FalError` (client-safe message) on any request / fetch failure."""
+    if not prompt.strip():
+        raise FalError("prompt is required")
+    model = (model or DEFAULT_MODEL).strip()
+    if model not in MODELS:
+        raise FalError(f"unknown model {model!r}")
+    final_prompt = build_prompt(prompt, style, eink_friendly=eink_friendly)
+    if seed is None:
+        seed = int(hashlib.sha256(final_prompt.encode("utf-8")).hexdigest()[:8], 16)
+    body = _build_body(model, final_prompt, width, height, seed)
+    try:
+        payload = _fal_request(model, body, api_key)
+    except urllib.error.HTTPError as err:
+        detail = err.read().decode("utf-8", "replace")[:200].strip()
+        raise FalError(f"fal.ai returned {err.code}: {detail}") from err
+    except urllib.error.URLError as err:
+        raise FalError(f"cannot reach fal.ai: {err.reason}") from err
+    url = _pick_image_url(payload)
+    if not url:
+        raise FalError("fal.ai returned no image")
+    try:
+        raw = _download(url)
+        return _to_png(raw)
+    except (urllib.error.URLError, OSError) as err:
+        raise FalError(f"could not fetch the generated image: {err}") from err
+
+
+def store_background(renders_dir: Any, png_bytes: bytes) -> str:
+    """Write ``png_bytes`` content-addressed under ``renders_dir`` and return the
+    ``/renders/<digest>.png`` URL path the canvas ``bg_image`` points at."""
+    from pathlib import Path
+
+    digest = hashlib.sha256(png_bytes).hexdigest()[:16]
+    renders = Path(renders_dir)
+    renders.mkdir(parents=True, exist_ok=True)
+    (renders / f"{digest}.png").write_bytes(png_bytes)
+    return f"/renders/{digest}.png"

--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -725,6 +725,70 @@ def set_canvas(page_id: str) -> Response:
     return _saved(new_page)
 
 
+@bp.post("/pages/<page_id>/background")
+def generate_background(page_id: str) -> Response:
+    """Generate an AI background for a canvas (fal.ai) and set it as ``bg_image``.
+
+    Body: ``{prompt (required), model?, style?, fit?, eink_friendly?, seed?}``.
+    The image is generated from the prompt, stored as a local render asset, and
+    the canvas' ``bg_image`` / ``bg_fit`` are updated. This is Approach A: the
+    background is decorative and the data widgets composite on top, so the data
+    never passes through the image model. Uses the canvas' own w/h for the
+    aspect. 400 if no prompt or no fal key is configured; 502 if fal fails. Same
+    drift guard + compact ack as the other canvas writes, plus ``bg_image``."""
+    from app import fal_backgrounds as fb
+    from app.state.panel_store import CanvasLayout
+
+    page = _pr._get_canvas(page_id)
+    if page is None:
+        return _err(404, f"no canvas dashboard {page_id!r}")
+    conflict = _drift_conflict(page)
+    if conflict is not None:
+        return conflict
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return _err(400, "body must be a JSON object")
+    prompt = str(body.get("prompt") or "").strip()
+    if not prompt:
+        return _err(400, "prompt is required")
+    api_key = fb.resolve_fal_key(_pr._registry(), _settings())
+    if not api_key:
+        return _err(
+            400,
+            "no fal.ai API key configured: set one on an installed fal-image widget, "
+            "under app.fal.api_key, or in the FAL_KEY environment variable",
+        )
+    layout = page.canvas or CanvasLayout()
+    model = str(body.get("model") or fb.DEFAULT_MODEL).strip()
+    style = str(body.get("style") or "none").strip()
+    fit = str(body.get("fit") or layout.bg_fit or "cover").strip().lower()
+    if fit not in ("cover", "contain", "stretch"):
+        fit = "cover"
+    seed_in = body.get("seed")
+    seed = int(seed_in) if isinstance(seed_in, int) else None
+    try:
+        png = fb.generate(
+            prompt,
+            api_key=api_key,
+            model=model,
+            style=style,
+            width=int(layout.w),
+            height=int(layout.h),
+            eink_friendly=bool(body.get("eink_friendly", True)),
+            seed=seed,
+        )
+    except fb.FalError as err:
+        return _err(502, f"background generation failed: {err}")
+    url = fb.store_background(current_app.config["RENDERS_DIR"], png)
+    layout.bg_image = url
+    layout.bg_fit = fit
+    page.canvas = layout
+    _save_mcp(page)
+    data = _saved(page).get_json()
+    data.update({"bg_image": url, "model": model, "prompt": prompt})
+    return jsonify(data)
+
+
 @bp.post("/pages/<page_id>/elements")
 def append_element(page_id: str) -> Response:
     """Append one element to a canvas and save (each call is one save, so an open

--- a/app/panels_routes.py
+++ b/app/panels_routes.py
@@ -308,6 +308,58 @@ def preview(canvas_id: str) -> Response:
     return current_app.response_class(png, mimetype="image/png")
 
 
+@bp.post("/c/<canvas_id>/generate-bg")
+def generate_bg(canvas_id: str) -> Response:
+    """Generate an AI background image (fal.ai) for a canvas and set it as
+    ``bg_image``. Body: ``{prompt (required), model?, style?, fit?}``. The image
+    is stored as a local render asset; the canvas elements composite on top
+    (Approach A), so the data never passes through the image model. Returns
+    ``{status, bg_image, bg_fit, rev}``. 400 without a prompt or fal key; 502 on
+    a fal failure."""
+    from app import fal_backgrounds as fb
+    from app.state.panel_store import CanvasLayout
+
+    _guard()
+    page = _get_canvas(canvas_id)
+    if page is None:
+        abort(404)
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        return _error(400, "body must be a JSON object")
+    prompt = str(body.get("prompt") or "").strip()
+    if not prompt:
+        return _error(400, "prompt is required")
+    api_key = fb.resolve_fal_key(_registry(), current_app.config.get("SETTINGS_STORE"))
+    if not api_key:
+        return _error(
+            400,
+            "no fal.ai API key configured: set one on an installed fal-image widget, "
+            "under app.fal.api_key, or in the FAL_KEY environment variable",
+        )
+    layout = page.canvas or CanvasLayout()
+    fit = str(body.get("fit") or layout.bg_fit or "cover").strip().lower()
+    if fit not in ("cover", "contain", "stretch"):
+        fit = "cover"
+    try:
+        png = fb.generate(
+            prompt,
+            api_key=api_key,
+            model=str(body.get("model") or fb.DEFAULT_MODEL).strip(),
+            style=str(body.get("style") or "none").strip(),
+            width=int(layout.w),
+            height=int(layout.h),
+        )
+    except fb.FalError as err:
+        return _error(502, f"background generation failed: {err}")
+    url = fb.store_background(current_app.config["RENDERS_DIR"], png)
+    layout.bg_image = url
+    layout.bg_fit = fit
+    page.canvas = layout
+    page = _stamp(page, "ui")
+    _pages().save(page)
+    return jsonify({"status": "ok", "bg_image": url, "bg_fit": fit, "rev": _canvas_rev(page)})
+
+
 @bp.get("/canvases.json")
 def canvases() -> Response:
     """All canvas dashboards (for the editor's canvas switcher)."""

--- a/packages/tesserae-mcp/pyproject.toml
+++ b/packages/tesserae-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae-mcp"
-version = "0.5.1"
+version = "0.5.2"
 description = "MCP bridge for Tesserae: build e-ink canvas dashboards with an AI agent."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/tesserae-mcp/tesserae_mcp/__init__.py
+++ b/packages/tesserae-mcp/tesserae_mcp/__init__.py
@@ -23,7 +23,7 @@ import urllib.error
 import urllib.request
 from typing import Any
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 _BASE = os.environ.get("TESSERAE_URL", "http://127.0.0.1:8765").rstrip("/")
 _TOKEN = os.environ.get("TESSERAE_MCP_TOKEN", "").strip()
@@ -266,6 +266,29 @@ def build_server() -> Any:
     def set_canvas(page_id: str, canvas: dict[str, Any], base_rev: str = "") -> Any:
         return _json("PUT", f"/pages/{page_id}/canvas{_rev_suffix(base_rev)}", canvas)
 
+    def set_canvas_background(
+        page_id: str,
+        prompt: str,
+        model: str = "",
+        style: str = "",
+        fit: str = "",
+    ) -> Any:
+        """Generate an AI background image (fal.ai) from "prompt" and set it as the
+        canvas' full-bleed background; the data elements composite crisply ON TOP,
+        so the data never passes through the image model. Sized to the canvas'
+        aspect. Optional "model" (default flux/schnell), "style" (e.g. watercolor,
+        bauhaus, risograph), and "fit" (cover|contain|stretch). Needs a fal.ai key
+        (an installed fal-image widget's key, app.fal.api_key, or FAL_KEY). Returns
+        the ack plus the stored "bg_image" URL; 502 if generation fails."""
+        body: dict[str, Any] = {"prompt": prompt}
+        if model:
+            body["model"] = model
+        if style:
+            body["style"] = style
+        if fit:
+            body["fit"] = fit
+        return _json("POST", f"/pages/{page_id}/background", body)
+
     def add_element(page_id: str, element: dict[str, Any], base_rev: str = "") -> Any:
         """Append ONE element to a canvas and save. Each call is a separate save, so
         an editor open on the page updates live as you build. "element" is a single
@@ -361,6 +384,7 @@ def build_server() -> Any:
         create_canvas_page,
         delete_canvas_page,
         get_canvas,
+        set_canvas_background,
         update_element,
         delete_element,
         patch_canvas,

--- a/packages/tesserae-mcp/tests/test_bridge.py
+++ b/packages/tesserae-mcp/tests/test_bridge.py
@@ -29,6 +29,7 @@ def test_tools_register() -> None:
         "delete_canvas_page",
         "get_canvas",
         "set_canvas",
+        "set_canvas_background",
         "add_element",
         "update_element",
         "delete_element",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.113.0"
+version = "0.114.0"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/static/panels/editor.js
+++ b/static/panels/editor.js
@@ -1019,6 +1019,74 @@
       fs.addEventListener("change", function () { pushHistory(); S.doc.bg_fit = fs.value; scheduleSave(); paint(); });
       fr.appendChild(fs); mount.appendChild(fr);
     }
+
+    // Generative background (fal.ai, Approach A). Generates an image from a
+    // prompt and sets it as bg_image; the data elements composite on top, so
+    // data never passes through the image model. Prompt/model/style live in
+    // S.bg (editor-only, not part of the saved doc).
+    if (S.cfg.bgUrl) {
+      S.bg = S.bg || { prompt: "", model: "fal-ai/flux/schnell", style: "none" };
+      var gr = el("div", "prow"); gr.style.display = "block";
+      var gtog = el("button", "minibtn", "Generate background (AI)");
+      gtog.style.cssText = "width:100%;margin-top:2px";
+      gr.appendChild(gtog); mount.appendChild(gr);
+
+      var gpanel = el("div");
+      gpanel.style.cssText = "display:" + (S.bg.open ? "flex" : "none") + ";flex-direction:column;gap:6px;margin-top:6px";
+      var gprompt = el("textarea", "dinput");
+      gprompt.placeholder = "Describe the background…"; gprompt.rows = 3;
+      gprompt.style.cssText = "width:100%;resize:vertical"; gprompt.value = S.bg.prompt || "";
+      gprompt.addEventListener("pointerdown", function (ev) { ev.stopPropagation(); });
+      gprompt.addEventListener("input", function () { S.bg.prompt = gprompt.value; });
+
+      var models = [
+        ["fal-ai/flux/schnell", "Flux Schnell (fast, ~$0.003)"],
+        ["fal-ai/recraft-v3", "Recraft V3 (crisp, ~$0.04)"],
+        ["fal-ai/flux-pro/v1.1", "Flux Pro 1.1 (~$0.04)"],
+        ["fal-ai/nano-banana", "Nano Banana / Gemini (~$0.039)"]
+      ];
+      var styles = ["none", "oil_painting", "watercolor", "pencil_sketch", "bauhaus",
+        "risograph", "line_art", "ukiyo_e", "art_deco", "botanical", "cyberpunk", "pixel_art"];
+      var gm = el("select", "psel");
+      gm.innerHTML = models.map(function (m) { return '<option value="' + m[0] + '">' + m[1] + "</option>"; }).join("");
+      gm.value = S.bg.model; gm.addEventListener("change", function () { S.bg.model = gm.value; });
+      var gs = el("select", "psel");
+      gs.innerHTML = styles.map(function (x) { return '<option value="' + x + '">' + x.replace(/_/g, " ") + "</option>"; }).join("");
+      gs.value = S.bg.style; gs.addEventListener("change", function () { S.bg.style = gs.value; });
+
+      var ggo = el("button", "minibtn", "Generate");
+      var gstat = el("span"); gstat.style.cssText = "font-size:11px;color:var(--t-muted)";
+      ggo.addEventListener("click", function () {
+        var p = (gprompt.value || "").trim();
+        if (!p) { gstat.textContent = "Enter a prompt first."; return; }
+        ggo.disabled = true; gstat.textContent = "Generating… (this can take a few seconds)";
+        fetch(S.cfg.bgUrl, {
+          method: "POST", headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ prompt: p, model: gm.value, style: gs.value, fit: S.doc.bg_fit || "cover" })
+        }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+          .then(function (res) {
+            ggo.disabled = false;
+            if (!res.ok) { gstat.textContent = (res.j && res.j.error) || "Generation failed."; return; }
+            pushHistory();
+            S.doc.bg_image = res.j.bg_image;
+            if (res.j.bg_fit) S.doc.bg_fit = res.j.bg_fit;
+            S.bg.open = true;
+            scheduleSave(); paint(); renderAppearance();
+          })
+          .catch(function () { ggo.disabled = false; gstat.textContent = "Generation failed."; });
+      });
+      gtog.addEventListener("click", function () {
+        S.bg.open = gpanel.style.display === "none";
+        gpanel.style.display = S.bg.open ? "flex" : "none";
+      });
+      gpanel.appendChild(gprompt);
+      gpanel.appendChild(apRow("Model", gm));
+      gpanel.appendChild(apRow("Style", gs));
+      var gbar = el("div"); gbar.style.cssText = "display:flex;gap:8px;align-items:center";
+      gbar.appendChild(ggo); gbar.appendChild(gstat);
+      gpanel.appendChild(gbar);
+      mount.appendChild(gpanel);
+    }
   }
 
   // ---- layers -----------------------------------------------------------
@@ -2184,6 +2252,7 @@
       devicesUrl: root.dataset.devicesUrl,
       sendUrl: root.dataset.sendUrl,
       previewUrl: root.dataset.previewUrl,
+      bgUrl: root.dataset.bgUrl,
       sourceFormUrl: root.dataset.sourceFormUrl,
       sourceOptionsUrl: root.dataset.sourceOptionsUrl,
       streamUrl: root.dataset.streamUrl,

--- a/templates/panels_editor.html
+++ b/templates/panels_editor.html
@@ -120,6 +120,7 @@
        data-devices-url="{{ url_for('panels.devices') }}"
        data-send-url="{{ url_for('panels.send', canvas_id=canvas_id) }}"
        data-preview-url="{{ url_for('panels.preview', canvas_id=canvas_id) }}"
+       data-bg-url="{{ url_for('panels.generate_bg', canvas_id=canvas_id) }}"
        data-source-form-url="{{ url_for('panels.source_form') }}"
        data-source-options-url="{{ url_for('panels.source_options') }}">
 

--- a/tests/test_fal_backgrounds.py
+++ b/tests/test_fal_backgrounds.py
@@ -1,0 +1,74 @@
+"""The fal.ai background service (app.fal_backgrounds).
+
+The network round-trip is stubbed; these cover prompt assembly, per-model
+request bodies, key resolution precedence, the PNG re-encode, and storage."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from app import fal_backgrounds as fb
+
+
+def test_build_prompt_prepends_style_and_appends_suffix() -> None:
+    p = fb.build_prompt("a lake", "watercolor", eink_friendly=True)
+    assert p.startswith("watercolor painting")
+    assert "a lake" in p
+    assert "high contrast" in p  # e-ink suffix
+    # No style, no suffix: the prompt is untouched.
+    assert fb.build_prompt("a lake", "none", eink_friendly=False) == "a lake"
+
+
+def test_build_body_nano_uses_aspect_ratio() -> None:
+    body = fb._build_body("fal-ai/nano-banana", "p", 800, 480, 7)
+    assert "aspect_ratio" in body and "image_size" not in body and "seed" not in body
+
+
+def test_build_body_flux_uses_image_size_clamped() -> None:
+    body = fb._build_body("fal-ai/flux/schnell", "p", 800, 480, 7)
+    assert body["image_size"] == {"width": 800, "height": 480} and body["seed"] == 7
+    # Clamp to [256, 1536] and round to /16.
+    big = fb._build_body("fal-ai/flux/schnell", "p", 99999, 100, 1)
+    assert big["image_size"] == {"width": 1536, "height": 256}
+
+
+def test_resolve_key_env_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.delenv("FAL_API_KEY", raising=False)
+    assert fb.resolve_fal_key(None, None) is None
+    monkeypatch.setenv("FAL_KEY", "env-key")
+    assert fb.resolve_fal_key(None, None) == "env-key"
+
+
+def test_generate_reencodes_to_png(monkeypatch: pytest.MonkeyPatch) -> None:
+    # fal often returns jpeg/webp; the service re-encodes to PNG.
+    raw = io.BytesIO()
+    Image.new("RGB", (64, 48), "blue").save(raw, format="JPEG")
+    monkeypatch.setattr(fb, "_fal_request", lambda m, b, k: {"images": [{"url": "http://x/y.jpg"}]})
+    monkeypatch.setattr(fb, "_download", lambda url: raw.getvalue())
+    out = fb.generate("a sea", api_key="k", model="fal-ai/flux/schnell", width=800, height=480)
+    assert out[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_generate_no_image_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fb, "_fal_request", lambda m, b, k: {"nope": 1})
+    with pytest.raises(fb.FalError):
+        fb.generate("x", api_key="k", width=800, height=480)
+
+
+def test_generate_rejects_unknown_model() -> None:
+    with pytest.raises(fb.FalError):
+        fb.generate("x", api_key="k", model="fal-ai/not-a-model", width=800, height=480)
+
+
+def test_store_background_content_addressed(tmp_path: Path) -> None:
+    url = fb.store_background(tmp_path, b"\x89PNG-data")
+    assert url.startswith("/renders/") and url.endswith(".png")
+    fname = url.split("/renders/")[1]
+    assert (tmp_path / fname).read_bytes() == b"\x89PNG-data"
+    # Same bytes → same digest → same URL (idempotent).
+    assert fb.store_background(tmp_path, b"\x89PNG-data") == url

--- a/tests/test_mcp_api.py
+++ b/tests/test_mcp_api.py
@@ -377,6 +377,79 @@ def test_render_png_unknown_fragment_400(app: Flask, monkeypatch: pytest.MonkeyP
     assert resp.status_code == 400 and "error" in resp.get_json()
 
 
+# -- AI background generation (fal.ai, Approach A) -----------------------
+
+
+def test_generate_background_sets_bg_image(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(app)
+    from app import fal_backgrounds as fb
+
+    monkeypatch.setattr(fb, "resolve_fal_key", lambda reg, ss: "test-key")
+    # Stand in for the fal round-trip: return a PNG sized to the canvas.
+    monkeypatch.setattr(
+        fb, "generate", lambda prompt, **kw: _png_of_size(kw["width"], kw["height"])
+    )
+    client = app.test_client()
+    pid = _create_page(client)
+    resp = client.post(
+        f"/api/mcp/pages/{pid}/background",
+        json={"prompt": "a calm foggy sea", "style": "watercolor", "fit": "cover"},
+    )
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["bg_image"].startswith("/renders/") and body["bg_image"].endswith(".png")
+    # Persisted on the canvas doc so the render + editor pick it up.
+    doc = client.get(f"/api/mcp/pages/{pid}/canvas").get_json()
+    assert doc["bg_image"] == body["bg_image"] and doc["bg_fit"] == "cover"
+    # The asset was actually written under the renders dir.
+    fname = body["bg_image"].split("/renders/")[1]
+    assert (app.config["RENDERS_DIR"] / fname).exists()
+
+
+def test_generate_background_requires_prompt(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(app)
+    from app import fal_backgrounds as fb
+
+    monkeypatch.setattr(fb, "resolve_fal_key", lambda reg, ss: "k")
+    client = app.test_client()
+    pid = _create_page(client)
+    assert client.post(f"/api/mcp/pages/{pid}/background", json={}).status_code == 400
+
+
+def test_generate_background_no_key_400(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(app)
+    from app import fal_backgrounds as fb
+
+    monkeypatch.setattr(fb, "resolve_fal_key", lambda reg, ss: None)
+    client = app.test_client()
+    pid = _create_page(client)
+    r = client.post(f"/api/mcp/pages/{pid}/background", json={"prompt": "x"})
+    assert r.status_code == 400 and "fal" in r.get_json()["error"].lower()
+
+
+def test_generate_background_fal_failure_502(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    _enable(app)
+    from app import fal_backgrounds as fb
+
+    monkeypatch.setattr(fb, "resolve_fal_key", lambda reg, ss: "k")
+
+    def _boom(prompt: str, **kw: Any) -> bytes:
+        raise fb.FalError("fal.ai returned 401: bad key")
+
+    monkeypatch.setattr(fb, "generate", _boom)
+    client = app.test_client()
+    pid = _create_page(client)
+    r = client.post(f"/api/mcp/pages/{pid}/background", json={"prompt": "x"})
+    assert r.status_code == 502 and "generation failed" in r.get_json()["error"]
+
+
+def test_generate_background_unknown_page_404(app: Flask) -> None:
+    _enable(app)
+    r = app.test_client().post("/api/mcp/pages/nope/background", json={"prompt": "x"})
+    assert r.status_code == 404
+
+
 def test_push_requires_device_ids(app: Flask) -> None:
     _enable(app)
     client = app.test_client()

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -662,3 +662,56 @@ def test_source_options_parses_form(app: Flask, monkeypatch: pytest.MonkeyPatch)
     assert resp.status_code == 200
     options = resp.get_json()["options"]
     assert options["units"] == "imperial" and options["label"] == "Home"
+
+
+# -- generative background (fal.ai, Approach A) --------------------------
+
+
+def _mini_png() -> bytes:
+    from io import BytesIO
+
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (32, 24), "white").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_generate_bg_sets_bg_image(app: Flask, monkeypatch: Any) -> None:
+    from app import fal_backgrounds as fb
+
+    monkeypatch.setattr(fb, "resolve_fal_key", lambda reg, ss: "k")
+    monkeypatch.setattr(fb, "generate", lambda prompt, **kw: _mini_png())
+    client = app.test_client()
+    _sign_in(client)
+    cid = client.get("/pages/canvas/").location.rsplit("/", 1)[1]
+    r = client.post(
+        f"/pages/canvas/c/{cid}/generate-bg",
+        json={"prompt": "a foggy shore", "style": "watercolor", "fit": "cover"},
+    )
+    assert r.status_code == 200, r.get_data(as_text=True)
+    body = r.get_json()
+    assert body["status"] == "ok" and body["bg_image"].startswith("/renders/")
+    doc = client.get(f"/pages/canvas/c/{cid}/doc.json").get_json()
+    assert doc["bg_image"] == body["bg_image"] and doc["bg_fit"] == "cover"
+
+
+def test_generate_bg_requires_prompt(app: Flask, monkeypatch: Any) -> None:
+    from app import fal_backgrounds as fb
+
+    monkeypatch.setattr(fb, "resolve_fal_key", lambda reg, ss: "k")
+    client = app.test_client()
+    _sign_in(client)
+    cid = client.get("/pages/canvas/").location.rsplit("/", 1)[1]
+    assert client.post(f"/pages/canvas/c/{cid}/generate-bg", json={}).status_code == 400
+
+
+def test_generate_bg_no_key_400(app: Flask, monkeypatch: Any) -> None:
+    from app import fal_backgrounds as fb
+
+    monkeypatch.setattr(fb, "resolve_fal_key", lambda reg, ss: None)
+    client = app.test_client()
+    _sign_in(client)
+    cid = client.get("/pages/canvas/").location.rsplit("/", 1)[1]
+    r = client.post(f"/pages/canvas/c/{cid}/generate-bg", json={"prompt": "x"})
+    assert r.status_code == 400 and "fal" in r.get_json()["error"].lower()


### PR DESCRIPTION
Builds **Approach A** for AI-restyled dashboards ([discussion context](https://github.com/dmellok/tesserae/discussions/24)): an AI-generated background with the data widgets composited crisply on top, so the **data never passes through the image model**. The numbers stay exact; only the backdrop is generative.

## Why this is small
The compositing was already built: `CanvasLayout.bg_image` / `bg_fit` render a full-bleed `<img>` at `z-index:0` behind every element, the MCP canvas endpoints persist those fields, and the editor already paints a `bg_image` live. The only missing piece was "generate a fal image and set it as `bg_image`."

## What's here
- **`app/fal_backgrounds.py`** — service ported from the community fal-image widget's client (`fal.run/<model>`, per-model body, image extraction, style presets + an e-ink-background suffix). It generates, **downloads the bytes, re-encodes to PNG, and stores content-addressed under the renders dir** — so `bg_image` points at a stable local `/renders/<digest>.png`, not fal's CDN (no expiry, no re-fetch every render).
- **MCP** — `POST /api/mcp/pages/<id>/background` `{prompt, model?, style?, fit?, seed?}` generates, stores, sets `bg_image`+`bg_fit`, returns the ack + url. Plus `set_canvas_background` in the `tesserae-mcp` bridge (bumped to 0.5.2).
- **Editor** — a "Generate background (AI)" control in the canvas editor's appearance panel (prompt + model + style + Generate); on success it sets `bg_image` and repaints via the existing path.
- **Key resolution** — reuse an installed fal-image widget's key, else `app.fal.api_key`, else `FAL_KEY` env. On-demand generation (set-and-forget); no key = a clean 400.

## Tests
- Service: prompt assembly, per-model bodies (nano ratio vs flux image_size + clamp), key precedence, PNG re-encode, content-addressed storage.
- MCP + editor endpoints: sets `bg_image` and persists to the doc, writes the asset, requires a prompt, 400 without a key, 502 on fal failure, 404 unknown page.
- Bridge tool registration.
- Full app suite green (1690), bridge (3), mypy + ruff clean.

Data flows one way: prompt → fal → background image → behind the widgets. The widgets render as vector/HTML and quantize to the panel palette exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
