### PR TITLE
Add fetch_latest button action and History preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Added
 
+- **`fetch_latest` button action.** Re-downloads and repaints the latest frame
+  already rendered for the device without running the composer, publishing a
+  new artefact, moving the rotation, or setting a manual override. The action
+  bypasses a matching `If-None-Match` for its `/frame` response, so its meaning
+  does not depend on a particular firmware clearing its cached ETag first.
 - **MCP: rotations, schedules, and decks.** The agent MCP surface (`/api/mcp`) and the
   `tesserae-mcp` bridge now expose list / create / delete for rotations and schedules, and list /
   create / delete / suggest for decks, so an agent that builds pages can also wire how they cycle
@@ -63,7 +68,6 @@ All notable changes to Tesserae are recorded here. Format loosely follows
   **suggested automatically**: when pages link to each other via tap / swipe "go to page" actions set
   in the canvas editor, the Decks page offers a one-click deck for each cluster, with the graph and
   touch zones derived from those links.
-
 - **OTA per-kind rollout: manual promote + canary (#121).** Beyond staging a build for a single
   device, an operator can now set a signed build as a device kind's release and roll it out
   deliberately: `python -m app.ota.release set` (offered first to the canary devices you list),

--- a/app/button_actions.py
+++ b/app/button_actions.py
@@ -26,6 +26,8 @@ plus their ``arg``. They return an ``ActionResult`` describing:
   rotation's resolved page (``target_page_id``),
 * whether the caller should force a re-render even if the resolved
   page is unchanged (``force_refresh``),
+* whether the current frame response should bypass ``If-None-Match``
+  and serve the latest already-rendered artefact (``force_download``),
 * a short log-friendly description of what happened.
 
 Adding a new action is one function + one registry entry. Custom
@@ -77,6 +79,9 @@ class ActionResult:
     * ``force_refresh``: re-render even if the resolved page hasn't
       changed. ``refresh`` is the canonical case; ``page:<id>`` also
       sets this when the target matches the currently-pushed page.
+    * ``force_download``: serve the latest already-rendered artefact
+      with a full ``200`` response even when the client's ETag matches.
+      This does not render, push, move the rotation, or set an override.
     * ``description``: short human-readable label, used in event log
       + admin surfaces.
     """
@@ -85,6 +90,7 @@ class ActionResult:
     target_page_id: str | None
     force_refresh: bool
     description: str
+    force_download: bool = False
 
 
 ActionFn = Callable[[ActionContext, str | None], ActionResult]
@@ -176,6 +182,17 @@ def _refresh(ctx: ActionContext, _arg: str | None) -> ActionResult:
     )
 
 
+def _fetch_latest(ctx: ActionContext, _arg: str | None) -> ActionResult:
+    """Re-serve the latest rendered frame without producing a new one."""
+    return ActionResult(
+        new_step_index=ctx.current_step_index,
+        target_page_id=None,
+        force_refresh=False,
+        description="fetch_latest (download latest rendered frame)",
+        force_download=True,
+    )
+
+
 def _step(ctx: ActionContext, arg: str | None) -> ActionResult:
     if arg is None:
         raise ButtonActionError("step action requires an index arg, e.g. 'step:2'")
@@ -245,6 +262,7 @@ def _webhook(_ctx: ActionContext, arg: str | None) -> ActionResult:
 register("rotate_prev", _rotate_prev)
 register("rotate_next", _rotate_next)
 register("refresh", _refresh)
+register("fetch_latest", _fetch_latest)
 register("step", _step)
 register("page", _page)
 register("webhook", _webhook)

--- a/app/button_service.py
+++ b/app/button_service.py
@@ -129,6 +129,7 @@ class ButtonHandleResult:
     override_until: datetime | None
     pushed_page_id: str | None
     push_result: PushResult | None
+    force_download: bool = False
 
     def to_envelope(self) -> dict[str, str | int | bool | None]:
         """Serialisable subset for the ``rotation`` block on ``/frame``
@@ -806,6 +807,8 @@ class ButtonService:
             outcome = "error"
         elif base.pushed_page_id is not None:
             outcome = "dispatched"
+        elif base.force_download:
+            outcome = "fetched"
         elif spec.startswith("webhook"):
             outcome = "webhook_dispatched"
         else:
@@ -1115,6 +1118,21 @@ class ButtonService:
             }
             self._fire_webhook_async(action_arg, payload)
 
+        # ``fetch_latest`` serves an artefact that already exists, so there is
+        # no PushResult carrying the composition thumbnail. Snapshot the
+        # current composition digest into the button event instead. The event's
+        # top-level ``digest`` deliberately stays None: History treats that as
+        # the resend contract, while this value is preview-only.
+        preview_composition_digest: str | None = None
+        if result.force_download and pusher is not None:
+            latest_render_for = getattr(pusher, "latest_render_for", None)
+            if callable(latest_render_for):
+                latest = latest_render_for(device_id)
+                if isinstance(latest, dict):
+                    candidate = latest.get("composition_digest")
+                    if isinstance(candidate, str) and candidate:
+                        preview_composition_digest = candidate
+
         step_page_id = (
             rotation.steps[result.new_step_index].page_id if rotation is not None else None
         )
@@ -1142,6 +1160,7 @@ class ButtonService:
             override_until=override_until,
             pushed_page_id=pushed_page_id,
             push_result=push_result,
+            force_download=result.force_download,
         )
         # Status distinguishes the outcomes admins care about: an actual
         # push, a fire-and-forget webhook (no push), or a rotate/refresh
@@ -1149,12 +1168,18 @@ class ButtonService:
         # showing so the user sees the press wasn't lost).
         if action_name == "webhook":
             status = "webhook_dispatched"
+        elif result.force_download:
+            status = "fetched"
         elif pushed_page_id is not None:
             status = "dispatched"
         else:
             status = "noop"
         self._emit_history_row(
-            result=result_ok, origin=origin, origin_extra=origin_extra, status=status
+            result=result_ok,
+            origin=origin,
+            origin_extra=origin_extra,
+            status=status,
+            composition_digest=preview_composition_digest,
         )
         return result_ok
 
@@ -1168,6 +1193,7 @@ class ButtonService:
         origin_extra: dict[str, object],
         status: str,
         error: str | None = None,
+        composition_digest: str | None = None,
     ) -> None:
         """Append a row to the event log so the History page has the
         button / touch feed as a first-class surface. Non-fatal on
@@ -1176,8 +1202,8 @@ class ButtonService:
         already logs its own row via ``PushManager``; this row is the
         "user pressed / tapped" event alongside that "server pushed the
         page" event, so a busy device produces two rows per
-        state-changing wake. Non-push branches (dedup, unmapped, error,
-        webhook, noop) get one row that captures the whole outcome.
+        state-changing wake. Non-push branches (fetch, dedup, unmapped,
+        error, webhook, noop) get one row that captures the whole outcome.
 
         Button rows use ``type="push"`` so the existing ``/history``
         route (which filters on that type) picks them up. Touch rows use
@@ -1185,10 +1211,12 @@ class ButtonService:
         chip on the Events page, carrying the full stroke / gesture /
         region / action payload for diagnostics, including the misses
         (no_target / stale / blocked), which are the ones worth seeing.
-        ``digest`` is None so the row's Resend button stays disabled and
-        no thumbnail is rendered. ``origin`` becomes the row's source
-        (``button`` / ``touch``); ``origin_extra`` carries the
-        origin-specific fields (button name vs stroke + gesture)."""
+        ``digest`` is None so the row's Resend button stays disabled.
+        ``fetch_latest`` may carry a preview-only ``composition_digest`` in
+        ``extra`` so History can render the exact existing frame without
+        changing that resend contract. ``origin`` becomes the row's source
+        (``button`` / ``touch``); ``origin_extra`` carries the origin-specific
+        fields (button name vs stroke + gesture)."""
         if self._event_log is None:
             return
         try:
@@ -1209,6 +1237,11 @@ class ButtonService:
                     "step_page_id": result.step_page_id,
                     "pushed_page_id": result.pushed_page_id,
                     "manual_override": result.manual_override,
+                    **(
+                        {"composition_digest": composition_digest}
+                        if composition_digest is not None
+                        else {}
+                    ),
                 },
             )
         except Exception:

--- a/app/history_routes.py
+++ b/app/history_routes.py
@@ -83,6 +83,20 @@ def _renderer_label(renderer_id: str) -> str:
     return renderer.name
 
 
+def _preview_digest(ev: EventRow) -> str | None:
+    """Composition PNG to show for a History row.
+
+    Normal push rows use the top-level digest, which also means they can be
+    resent. Non-push button outcomes keep that field empty; ``fetch_latest``
+    instead snapshots a preview-only composition digest in ``extra`` so its
+    thumbnail can be shown without making the row resendable.
+    """
+    if isinstance(ev.digest, str) and ev.digest:
+        return ev.digest
+    candidate = ev.extra.get("composition_digest")
+    return candidate if isinstance(candidate, str) and candidate else None
+
+
 def history_view(rows: list[EventRow]) -> list[dict[str, Any]]:
     """Shape raw event rows for the History page: page name instead of id,
     humanised time, friendly device labels."""
@@ -136,11 +150,14 @@ def history_view(rows: list[EventRow]) -> list[dict[str, Any]]:
         # actually happened" is visible without opening the raw event
         # (which the History page doesn't expose today).
         button_detail = _button_detail(ev, page_names) if ev.source == "button" else None
+        preview_digest = _preview_digest(ev)
         out.append(
             {
                 "id": ev.id,
                 "status": ev.status,
                 "digest": ev.digest,
+                "preview_digest": preview_digest,
+                "can_resend": bool(ev.digest),
                 "source": ev.source,
                 "target": target,
                 "target_devices": target_devices,

--- a/app/rest_api.py
+++ b/app/rest_api.py
@@ -580,10 +580,18 @@ def get_frame(device_id: str) -> Response:
     if button_svc is not None:
         if button_raw:
             try:
+                # ``button_event_id`` is the canonical client-protocol
+                # parameter. Firmware through v1.5.0 sent the same monotonic
+                # counter as ``event`` on /frame (while /status used the
+                # canonical name), so retain that as a compatibility alias.
+                # A present canonical parameter always wins, even if malformed.
+                raw_event_id = request.args.get("button_event_id")
+                if raw_event_id is None:
+                    raw_event_id = request.args.get("event")
                 button_result = button_svc.handle_button(
                     device_id=device.id,
                     button=button_raw,
-                    event_id=_parse_button_event_id(request.args.get("button_event_id")),
+                    event_id=_parse_button_event_id(raw_event_id),
                 )
             except Exception:
                 current_app.logger.exception(
@@ -644,8 +652,14 @@ def get_frame(device_id: str) -> Response:
     # 304 this once, then clear the flag so the next poll of the same
     # frame goes back to 304.
     force_refetch = bool(latest.get("force_refetch"))
+    # ``fetch_latest`` is deliberately narrower than ``refresh``: do not
+    # render or publish anything, but bypass the conditional GET for this
+    # response so the client downloads the latest artefact already on disk.
+    # Carrying the intent through ButtonHandleResult also makes the action
+    # work for clients that keep their ETag on button/touch requests.
+    force_download = bool(button_result is not None and button_result.force_download)
     if_none_match = request.headers.get("If-None-Match", "")
-    if if_none_match and if_none_match == etag and not force_refetch:
+    if if_none_match and if_none_match == etag and not (force_refetch or force_download):
         resp = Response(status=304)
         resp.headers["ETag"] = etag
         resp.headers["Content-Location"] = image_url

--- a/docs/dev/client-protocol.md
+++ b/docs/dev/client-protocol.md
@@ -386,14 +386,15 @@ Headers: `ETag: "<digest>"`, `Content-Location: <absolute URL of the frame>`, `C
 - Other renderers may ship their own extras in the future. The contract is: anything not listed in the "always present" set above is renderer-specific, and **clients should ignore unknown fields** so new renderers don't break older firmware. Note that things like the TRMNL renderer's `dither` and `contrast` knobs are *device-side settings* (configured per instance in Settings → Devices, applied server-side before encoding) rather than envelope fields, the wire payload stays minimal.
 
 **Physical button wakes** — devices with hardware buttons add
-`?button=<name>` to the frame request on a button-driven wake (the
+`?button=<name>&button_event_id=<uint>` to the frame request on a
+button-driven wake (the
 name matches the device's `button_map`; conventionally `left`,
 `right`, `refresh`). The server dispatches the mapped action
 synchronously before selecting the frame, so the returned artefact
 already reflects the new state on this same wake:
 
 ```
-GET /api/v1/device/kitchen/frame?button=right
+GET /api/v1/device/kitchen/frame?button=right&button_event_id=42
 ```
 
 When bound to a rotation, the response also carries a `rotation`
@@ -414,11 +415,19 @@ block describing where the device is now:
 }
 ```
 
+`button_event_id` is the same monotonic counter reported in `/status`.
+Retries reuse the same value. The legacy query name `event` is accepted as a
+fallback for firmware through v1.5.0, but new clients should use the canonical
+name.
+
 The `rotation` block is omitted when the device isn't bound to any
 rotation. `manual_override: true` means a button press is currently
 suppressing the time-based scheduler; the scheduler resumes at
 `override_until` (server-side; the firmware doesn't need to check
-this itself). On a `refresh` action the firmware should drop its
+this itself). A `fetch_latest` action bypasses a matching
+`If-None-Match` for that response and returns the latest existing
+artefact with `200`, without triggering a render or push. On a
+`refresh` action the firmware should drop its
 cached `ETag` before making the request so the server always returns
 `200` with a full frame rather than `304`.
 

--- a/docs/install/buttons.md
+++ b/docs/install/buttons.md
@@ -4,7 +4,8 @@ Hardware buttons on a Tesserae device (the front buttons on a Seeed
 reTerminal E-Series, the back-panel buttons on a Pimoroni Inky
 Impression, etc.) can be bound to server-side **actions**: rotate
 through the dashboards on this device, jump straight to a specific
-dashboard, force a fresh render, fire a webhook. The mapping is
+dashboard, download the latest rendered frame, force a fresh render,
+or fire a webhook. The mapping is
 per-device and edited from **Settings → Devices**.
 
 Introduced in v0.65.0. Server-side works for any device kind whose
@@ -62,6 +63,7 @@ name (`rotate_next`) or `<action>:<arg>` (`page:morning_briefing`,
 |---|---|---|
 | `rotate_prev` | none | Advance the device's rotation one step backwards. Wraps at the start. |
 | `rotate_next` | none | Advance the device's rotation one step forwards. Wraps at the end. |
+| `fetch_latest` | none | Download and repaint the latest frame already rendered for this device. Does not re-render, push, move the rotation, or set a manual override. |
 | `refresh` | none | Force a fresh render + push of the current step. Useful when a widget's upstream data changed but the composition hash is stable. |
 | `step:<index>` | rotation step index (0-based) | Jump straight to that step in the rotation. |
 | `page:<page_id>` | dashboard page id | Push a specific dashboard to this device. Doesn't touch rotation state, so a later timer wake resumes the scheduled step. |
@@ -115,7 +117,7 @@ chip in the History toolbar to see just the button feed.
 If you're building a client and want it to send button events, see
 the [Client protocol spec](../dev/client-protocol.md). Short version:
 
-- On the frame request: `GET /api/v1/device/<id>/frame?button=<name>`.
+- On the frame request: `GET /api/v1/device/<id>/frame?button=<name>&button_event_id=<uint>`.
 - In the status body: `{"button": "<name>", "button_event_id": <uint>, …}`.
 - The server dispatches the mapped action synchronously before
   selecting the frame, so the returned artefact reflects the new

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -121,6 +121,8 @@ paths:
         - $ref: '#/components/parameters/DeviceIdPath'
         - $ref: '#/components/parameters/IfNoneMatchHeader'
         - $ref: '#/components/parameters/ButtonQueryParam'
+        - $ref: '#/components/parameters/ButtonEventIdQueryParam'
+        - $ref: '#/components/parameters/LegacyButtonEventQueryParam'
       responses:
         '200':
           description: Frame envelope. Body is JSON; `ETag` carries the artifact digest.
@@ -754,10 +756,36 @@ components:
         selecting the frame, so the returned artefact reflects the
         new state on this same wake. Firmwares that support buttons
         SHOULD drop their cached `ETag` when the action is `refresh`
-        so the server returns a fresh 200 rather than a 304.
+        so the server returns a fresh 200 rather than a 304. The
+        `fetch_latest` action instead makes the server bypass a matching
+        ETag for that response while serving the already-rendered frame.
       schema:
         type: string
         example: right
+    ButtonEventIdQueryParam:
+      name: button_event_id
+      in: query
+      required: false
+      description: |
+        Monotonically increasing physical-button event id. Retries reuse the
+        same value so the server can deduplicate them across `/frame` and
+        `/status`. Preferred over the legacy `event` alias.
+      schema:
+        type: integer
+        minimum: 0
+        example: 42
+    LegacyButtonEventQueryParam:
+      name: event
+      in: query
+      required: false
+      deprecated: true
+      description: |
+        Compatibility alias for `button_event_id`, emitted by Tesserae ESP32
+        firmware through v1.5.0. Ignored when `button_event_id` is present.
+      schema:
+        type: integer
+        minimum: 0
+        example: 42
     TrmnlIdHeader:
       name: Id
       in: header

--- a/static/touch_monitor.js
+++ b/static/touch_monitor.js
@@ -50,7 +50,7 @@
   panelEl.appendChild(svg);
 
   function statusClass(status) {
-    if (["dispatched", "ha_dispatched", "webhook_dispatched", "noop"].indexOf(status) >= 0) return "ok";
+    if (["dispatched", "ha_dispatched", "webhook_dispatched", "fetched", "noop"].indexOf(status) >= 0) return "ok";
     if (["blocked", "error", "ha_failed"].indexOf(status) >= 0) return "bad";
     return "miss"; // no_target / stale / deduped / no_frame
   }

--- a/templates/history.html
+++ b/templates/history.html
@@ -40,6 +40,7 @@
   {% elif status == 'no_change' %}<span class="dx-pill is-info"><span class="dx-pill-dot"></span>no change</span>
   {% elif status == 'dispatched' %}<span class="dx-pill is-ok"><span class="dx-pill-dot"></span>button</span>
   {% elif status == 'webhook_dispatched' %}<span class="dx-pill is-info"><span class="dx-pill-dot"></span>webhook</span>
+  {% elif status == 'fetched' %}<span class="dx-pill is-ok"><span class="dx-pill-dot"></span>fetched</span>
   {% elif status == 'noop' %}<span class="dx-pill is-info"><span class="dx-pill-dot"></span>no-op</span>
   {% elif status == 'deduped' %}<span class="dx-pill is-info"><span class="dx-pill-dot"></span>duplicate</span>
   {% elif status == 'unmapped' %}<span class="dx-pill is-warn"><span class="dx-pill-dot"></span>unmapped</span>
@@ -138,20 +139,20 @@
   {% else %}
   <ul class="dx-discovered-list">
     {% for ev in history %}
-    {% set is_failed = ev.status not in ('sent', 'busy', 'quiet', 'no_change', 'dispatched', 'webhook_dispatched', 'noop', 'deduped', 'unmapped') %}
+    {% set is_failed = ev.status not in ('sent', 'busy', 'quiet', 'no_change', 'dispatched', 'webhook_dispatched', 'fetched', 'noop', 'deduped', 'unmapped') %}
     <li class="dx-inset-row dx-history-row{% if is_failed %} dx-history-row--failed{% endif %}">
       <input type="checkbox" class="dx-history-select" value="{{ ev.id }}"
              aria-label="Select entry #{{ ev.id }}" title="Select for bulk delete">
-      {% if ev.digest %}
-      <a class="dx-history-thumb" href="{{ url_for('renders', filename=ev.digest ~ '.png') }}" data-lightbox aria-label="Open render for push #{{ ev.id }}">
-        <img src="{{ url_for('renders', filename=ev.digest ~ '.png', w=180) }}" alt="" width="64" height="64" loading="lazy" decoding="async">
+      {% if ev.preview_digest %}
+      <a class="dx-history-thumb" href="{{ url_for('renders', filename=ev.preview_digest ~ '.png') }}" data-lightbox aria-label="Open render for push #{{ ev.id }}">
+        <img src="{{ url_for('renders', filename=ev.preview_digest ~ '.png', w=180) }}" alt="" width="64" height="64" loading="lazy" decoding="async">
       </a>
       {% else %}
       <span class="dx-history-thumb dx-history-thumb--empty" aria-hidden="true">
         <i class="ph ph-image-square"></i>
       </span>
       {% endif %}
-      <a class="dx-history-time" {% if ev.digest %}href="{{ url_for('renders', filename=ev.digest ~ '.png') }}" data-lightbox aria-label="Push #{{ ev.id }}"{% endif %}>
+      <a class="dx-history-time" {% if ev.preview_digest %}href="{{ url_for('renders', filename=ev.preview_digest ~ '.png') }}" data-lightbox aria-label="Push #{{ ev.id }}"{% endif %}>
         <span class="dx-history-clock"><code>{{ ev.abs.split(' ')[1] if ' ' in ev.abs else ev.abs }}</code></span>
         <span class="dx-history-date">{{ ev.rel }}</span>
       </a>
@@ -172,7 +173,7 @@
         {{ status_chip(ev.status) }}
         <span class="dx-history-dur">{% if ev.duration_s %}{{ '%.1f'|format(ev.duration_s) }}s{% else %}—{% endif %}</span>
         <form method="post" action="{{ url_for('send.resend', event_id=ev.id) }}" class="form form--inline">
-          <button type="submit" class="dx-btn-ghost-sm dx-btn-icon-only" {% if not ev.digest %}disabled title="no composition PNG stored"{% else %}title="Resend this push"{% endif %}>
+          <button type="submit" class="dx-btn-ghost-sm dx-btn-icon-only" {% if not ev.can_resend %}disabled title="preview only; resend from the original push"{% else %}title="Resend this push"{% endif %}>
             <i class="ph ph-arrow-clockwise" aria-hidden="true"></i>
           </button>
         </form>

--- a/tests/test_button_actions.py
+++ b/tests/test_button_actions.py
@@ -107,6 +107,17 @@ def test_refresh_keeps_step_and_forces_refresh() -> None:
     assert result.target_page_id is None
 
 
+# -- fetch_latest ---------------------------------------------------
+
+
+def test_fetch_latest_only_forces_frame_download() -> None:
+    result = dispatch("fetch_latest", _ctx(current_step_index=1))
+    assert result.new_step_index == 1
+    assert result.target_page_id is None
+    assert result.force_refresh is False
+    assert result.force_download is True
+
+
 # -- step:<i> -------------------------------------------------------
 
 
@@ -216,7 +227,15 @@ def test_register_overwrites_existing_action() -> None:
 
 def test_registered_actions_includes_defaults() -> None:
     names = set(registered_actions())
-    assert {"rotate_prev", "rotate_next", "refresh", "step", "page", "webhook"} <= names
+    assert {
+        "rotate_prev",
+        "rotate_next",
+        "refresh",
+        "fetch_latest",
+        "step",
+        "page",
+        "webhook",
+    } <= names
 
 
 # -- default button map --------------------------------------------

--- a/tests/test_button_service.py
+++ b/tests/test_button_service.py
@@ -54,7 +54,11 @@ class StubPushManager:
     kwargs ButtonService actually uses."""
 
     calls: list[dict[str, Any]] = field(default_factory=list)
+    latest_renders: dict[str, dict[str, Any]] = field(default_factory=dict)
     fail: bool = False
+
+    def latest_render_for(self, device_id: str) -> dict[str, Any] | None:
+        return self.latest_renders.get(device_id)
 
     def push(
         self,
@@ -279,6 +283,34 @@ def test_refresh_forces_push_of_current_page(
 
     assert result.step_index == 0
     assert result.pushed_page_id == "morning"
+
+
+def test_fetch_latest_does_not_push_or_set_manual_override(
+    rotation_store: RotationStore,
+    state_store: DeviceRotationStateStore,
+    settings_store: SettingsStore,
+    page_store: PageStore,
+    push_manager: StubPushManager,
+    clock: FakeClock,
+) -> None:
+    _seed_rotation(rotation_store)
+    settings_store.patch_section("devices", {"kitchen": {"button_map": {"custom": "fetch_latest"}}})
+    svc = _wire(
+        rotation_store=rotation_store,
+        state_store=state_store,
+        settings_store=settings_store,
+        page_store=page_store,
+        push_manager=push_manager,
+        clock=clock,
+    )
+
+    result = svc.handle_button(device_id="kitchen", button="custom", event_id=1)
+
+    assert result.step_index == 0
+    assert result.pushed_page_id is None
+    assert result.manual_override is False
+    assert result.force_download is True
+    assert push_manager.calls == []
 
 
 # -- dedup --------------------------------------------------------
@@ -771,6 +803,70 @@ def test_unmapped_press_emits_history_row(
     assert len(rows) == 1
     assert rows[0].status == "unmapped"
     assert rows[0].extra["button"] == "unicorn"
+
+
+def test_fetch_latest_press_emits_fetched_history_row(
+    rotation_store: RotationStore,
+    state_store: DeviceRotationStateStore,
+    settings_store: SettingsStore,
+    page_store: PageStore,
+    push_manager: StubPushManager,
+    clock: FakeClock,
+    event_log: EventLog,
+) -> None:
+    settings_store.patch_section("devices", {"kitchen": {"button_map": {"custom": "fetch_latest"}}})
+    push_manager.latest_renders["kitchen"] = {
+        "digest": "wire123",
+        "composition_digest": "composition456",
+    }
+    svc = _wire(
+        rotation_store=rotation_store,
+        state_store=state_store,
+        settings_store=settings_store,
+        page_store=page_store,
+        push_manager=push_manager,
+        clock=clock,
+        event_log=event_log,
+    )
+
+    svc.handle_button(device_id="kitchen", button="custom", event_id=1)
+
+    rows = _button_rows(event_log)
+    assert len(rows) == 1
+    assert rows[0].status == "fetched"
+    assert rows[0].digest is None
+    assert rows[0].extra["action_spec"] == "fetch_latest"
+    assert rows[0].extra["composition_digest"] == "composition456"
+    assert rows[0].extra["pushed_page_id"] is None
+    assert push_manager.calls == []
+
+
+def test_fetch_latest_without_existing_frame_keeps_preview_empty(
+    rotation_store: RotationStore,
+    state_store: DeviceRotationStateStore,
+    settings_store: SettingsStore,
+    page_store: PageStore,
+    push_manager: StubPushManager,
+    clock: FakeClock,
+    event_log: EventLog,
+) -> None:
+    settings_store.patch_section("devices", {"kitchen": {"button_map": {"custom": "fetch_latest"}}})
+    svc = _wire(
+        rotation_store=rotation_store,
+        state_store=state_store,
+        settings_store=settings_store,
+        page_store=page_store,
+        push_manager=push_manager,
+        clock=clock,
+        event_log=event_log,
+    )
+
+    svc.handle_button(device_id="kitchen", button="custom", event_id=1)
+
+    row = _button_rows(event_log)[0]
+    assert row.status == "fetched"
+    assert row.digest is None
+    assert "composition_digest" not in row.extra
 
 
 def test_webhook_press_emits_webhook_dispatched_row(

--- a/tests/test_history_button_detail.py
+++ b/tests/test_history_button_detail.py
@@ -8,7 +8,9 @@ so the History row stays informative for the common outcomes.
 
 from __future__ import annotations
 
-from app.history_routes import _button_detail
+from dataclasses import replace
+
+from app.history_routes import _button_detail, _preview_digest
 from app.state.event_log import EventRow
 
 
@@ -78,3 +80,15 @@ def test_deduped_press_falls_back_to_description() -> None:
 def test_row_without_any_button_info_returns_none() -> None:
     row = _row()
     assert _button_detail(row, page_names={}) is None
+
+
+def test_fetch_latest_uses_preview_only_composition_digest() -> None:
+    row = _row(action_spec="fetch_latest", composition_digest="comp123")
+    assert row.digest is None
+    assert _preview_digest(row) == "comp123"
+
+
+def test_top_level_digest_wins_over_preview_only_digest() -> None:
+    row = _row(composition_digest="preview123")
+    row = replace(row, digest="push456")
+    assert _preview_digest(row) == "push456"

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -856,6 +856,93 @@ def test_frame_returns_304_when_if_none_match_matches(app: Flask) -> None:
     assert resp.headers["Content-Location"].endswith("/renders/abc123.bin")
 
 
+def test_fetch_latest_action_bypasses_matching_etag_without_rendering(app: Flask) -> None:
+    """``fetch_latest`` returns the existing artefact with 200 while
+    leaving the render pipeline and latest-render entry untouched."""
+    client = app.test_client()
+    _sign_in(client)
+    code = _issue_pairing(app)
+    resp = _register_via_api(client, code=code, device_id="bedroom_pico")
+    token = resp.get_json()["device_token"]
+
+    settings = app.config["SETTINGS_STORE"]
+    devices = settings.get_section("devices") or {}
+    devices["bedroom_pico"] = {
+        **devices.get("bedroom_pico", {}),
+        "button_map": {"custom": "fetch_latest"},
+    }
+    settings.update_section("devices", devices)
+
+    push_mgr = app.config["PUSH_MANAGER"]
+    latest = {
+        "digest": "abc123",
+        "ext": "bin",
+        "filename": "abc123.bin",
+        "renderer_id": "pico_bin",
+        "timestamp": time.time(),
+        "composition_digest": "comp123",
+    }
+    push_mgr._latest_renders["bedroom_pico"] = latest.copy()
+
+    resp = client.get(
+        "/api/v1/device/bedroom_pico/frame?button=custom&button_event_id=1",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "If-None-Match": '"abc123"',
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["render_id"] == "abc123"
+    assert push_mgr._latest_renders["bedroom_pico"] == latest
+
+
+def test_frame_accepts_legacy_event_alias_and_prefers_canonical_id(app: Flask) -> None:
+    """Firmware through v1.5.0 sent ``event`` on /frame. Accept it as
+    an alias, but let an explicitly supplied ``button_event_id`` win."""
+    client = app.test_client()
+    _sign_in(client)
+    code = _issue_pairing(app)
+    resp = _register_via_api(client, code=code, device_id="bedroom_pico")
+    token = resp.get_json()["device_token"]
+
+    settings = app.config["SETTINGS_STORE"]
+    devices = settings.get_section("devices") or {}
+    devices["bedroom_pico"] = {
+        **devices.get("bedroom_pico", {}),
+        "button_map": {"custom": "fetch_latest"},
+    }
+    settings.update_section("devices", devices)
+    app.config["PUSH_MANAGER"]._latest_renders["bedroom_pico"] = {
+        "digest": "abc123",
+        "ext": "bin",
+        "filename": "abc123.bin",
+        "renderer_id": "pico_bin",
+        "timestamp": time.time(),
+        "composition_digest": "comp123",
+    }
+    headers = {"Authorization": f"Bearer {token}"}
+
+    first = client.get(
+        "/api/v1/device/bedroom_pico/frame?button=custom&button_event_id=7&event=6",
+        headers=headers,
+    )
+    retry = client.get(
+        "/api/v1/device/bedroom_pico/frame?button=custom&event=7",
+        headers=headers,
+    )
+
+    assert first.status_code == 200
+    assert retry.status_code == 200
+    rows = [
+        row
+        for row in app.config["EVENT_LOG"].list(type="push")
+        if row.source == "button" and row.target == "bedroom_pico"
+    ]
+    assert [row.status for row in rows[:2]] == ["deduped", "fetched"]
+    assert [row.extra["button_event_id"] for row in rows[:2]] == [7, 7]
+
+
 def test_resend_forces_one_200_then_reverts_to_304(app: Flask) -> None:
     """Resend from History (#119): a frame flagged ``force_refetch`` serves
     one 200 to a REST client even when its ETag matches (so an explicit

--- a/tests/test_send_routes.py
+++ b/tests/test_send_routes.py
@@ -238,6 +238,30 @@ def test_history_lists_event_log_rows(app: Flask, tmp_path: Path) -> None:
     assert "boom" in body
 
 
+def test_fetch_latest_history_shows_preview_but_disables_resend(app: Flask) -> None:
+    log = app.config["EVENT_LOG"]
+    log.record(
+        type="push",
+        source="button",
+        target="panel_one",
+        status="fetched",
+        digest=None,
+        extra={
+            "button": "refresh",
+            "action_spec": "fetch_latest",
+            "composition_digest": "comp123",
+        },
+    )
+
+    client = app.test_client()
+    _sign_in(client)
+    body = client.get("/history").get_data(as_text=True)
+
+    assert "/renders/comp123.png" in body
+    assert "preview only; resend from the original push" in body
+    assert "fetch_latest" in body
+
+
 def test_resend_invokes_republish(app: Flask) -> None:
     pm = MagicMock()
     pm.republish.return_value = PushResult(status="sent", page_id="resent")


### PR DESCRIPTION
## Summary

Companion firmware change: [dmellok/tesserae-device-firmware#5](https://github.com/dmellok/tesserae-device-firmware/pull/5).

- add a `fetch_latest` button action that returns the latest existing frame without rendering, pushing, changing rotation state, or setting a manual override
- accept the deployed firmware's legacy `event` frame-query parameter as a fallback alias for `button_event_id`
- snapshot the current `composition_digest` on fetched History rows so they have a thumbnail and click-through
- separate History previewability from resendability, keeping Resend disabled when the event's top-level `digest` is null
- document the action and client protocol, including the preferred query parameter and compatibility alias

## Why

There was no button action for re-downloading a frame the server had already rendered: `refresh` necessarily enters the render/push pipeline.

In addition, firmware through v1.5.0 sends `event` on `/frame`, while the server only parsed `button_event_id`. The event id was therefore dropped on that path and deduplication depended on the short time window.

Finally, button History rows deliberately used `digest=null` to disable Resend, which also prevented a fetched row from showing the existing composition it downloaded. This keeps `digest` as the resend contract and adds a preview-only `composition_digest`.

## Confirmed contract

This implements the server half agreed in [Discussion #132](https://github.com/dmellok/tesserae/discussions/132#discussioncomment-17714414):

- `button_event_id` is preferred and `event` remains a fallback alias
- `fetch_latest` bypasses a matching ETag for that response without producing a new render
- fetched rows carry the existing composition preview while Resend stays disabled

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` — 2118 passed
- `git diff upstream/main...HEAD --check`
