### PR TITLE
fix: distinguish firmware queue from rollout membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Fixed
 
+- **Completed firmware updates stayed labelled as queued.** The Firmware page now distinguishes
+  retained canary/fleet rollout membership from a release that is still newer than the device.
+  Once a device reports the imported version it reads as up to date, while pending rows name the
+  actual imported release instead of a potentially newer online Available version.
+
 - **Deck heartbeat reports could revert a freshly pushed dashboard.** v0.187.1's report promotion
   promoted whatever page the panel said was on glass, so a heartbeat arriving between a push and
   the device's next fetch clobbered the pending frame with the older deck frame, and the new

--- a/app/settings/firmware_routes.py
+++ b/app/settings/firmware_routes.py
@@ -201,13 +201,19 @@ def _devices_model(*, online: bool) -> list[dict[str, Any]]:
         for v in dev_views:
             fw = str(v["fw_version"] or "")
             update_available = bool(available) and (not fw or is_newer(str(available), fw))
-            queued = bool(v["is_canary"])
+            # Rollout membership is retained after a device updates so the
+            # Fleet view can still identify its canaries.  The flat device
+            # list, however, should only call that membership "queued" while
+            # the imported release can actually be offered to this device.
+            release_pending = bool(rel_fw) and (not fw or is_newer(str(rel_fw), fw))
+            queued = bool(v["is_canary"] and release_pending)
             rows.append(
                 {
                     **v,
                     "kind_id": kind_id,
                     "kind_name": names.get(kind_id, kind_id),
                     "queued": queued,
+                    "queued_fw": rel_fw if queued else None,
                     "available_fw": available,
                     "release_url": str(latest["url"]) if latest and latest.get("url") else None,
                     "notes_headline": (
@@ -220,7 +226,7 @@ def _devices_model(*, online: bool) -> list[dict[str, Any]]:
                     "can_queue": bool(
                         v["capable"] and update_available and not queued and offerable
                     ),
-                    "can_withdraw": bool(queued and update_available),
+                    "can_withdraw": queued,
                 }
             )
     # rolled_back / failed float to the top, then by name.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.188.0"
+version = "0.188.1"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/templates/settings_firmware.html
+++ b/templates/settings_firmware.html
@@ -91,7 +91,7 @@
           </span>
           {% if d.report_relative %}<span class="dx-status-muted">{{ d.report_relative }}</span>{% endif %}
           {% elif d.queued %}
-          <span class="pill is-accent">queued{% if d.available_fw %} {{ fw(d.available_fw) }}{% endif %}</span>
+          <span class="pill is-accent">queued{% if d.queued_fw %} {{ fw(d.queued_fw) }}{% endif %}</span>
           {% elif d.update_available %}
           <span class="pill is-warn">update available</span>
           {% elif d.fw_version %}

--- a/tests/test_firmware_rollout.py
+++ b/tests/test_firmware_rollout.py
@@ -96,6 +96,13 @@ def _import_valid(client) -> None:  # type: ignore[no-untyped-def]
     )
 
 
+def _device_row(app: Flask, device_id: str, *, online: bool = False) -> dict:
+    import app.settings.firmware_routes as fr
+
+    with app.app_context():
+        return next(row for row in fr._devices_model(online=online) if row["id"] == device_id)
+
+
 def test_import_valid_sets_release(app: Flask) -> None:
     with app.app_context():
         _mk_device(app, "dev_a")
@@ -134,6 +141,103 @@ def test_queue_offers_release_to_device(app: Flask) -> None:
     # The offer machinery now serves this device the descriptor.
     assert app.config["OTA_RELEASE"].descriptor_for(KIND, "dev_a") is not None
     assert app.config["OTA_RELEASE"].descriptor_for(KIND, "dev_other") is None
+
+
+def test_pending_canary_shows_imported_release_as_queued(app: Flask) -> None:
+    with app.app_context():
+        _mk_device(app, "dev_a")
+    _set_status(app, "dev_a", fw="1.3.0")
+    client = _authed_client(app)
+    _import_valid(client)
+    client.post("/settings/firmware/queue", data={"device_id": "dev_a"})
+
+    row = _device_row(app, "dev_a")
+    assert row["queued"] is True
+    assert row["queued_fw"] == REL_FW
+    assert row["can_withdraw"] is True
+
+    html = client.get("/settings/firmware").get_data(as_text=True)
+    assert "queued v1.4.0" in html
+    assert "Withdraw" in html
+
+
+def test_completed_canary_shows_up_to_date_and_keeps_membership(app: Flask) -> None:
+    with app.app_context():
+        _mk_device(app, "dev_a")
+    _set_status(app, "dev_a", fw="1.3.0")
+    client = _authed_client(app)
+    _import_valid(client)
+    client.post("/settings/firmware/queue", data={"device_id": "dev_a"})
+
+    # The successful post-update heartbeat advances the installed version,
+    # while the rollout keeps its canary selection for Fleet history/state.
+    _set_status(app, "dev_a", fw=REL_FW)
+
+    row = _device_row(app, "dev_a")
+    assert row["is_canary"] is True
+    assert row["queued"] is False
+    assert row["queued_fw"] is None
+    assert row["update_available"] is False
+    assert row["can_withdraw"] is False
+    assert app.config["OTA_RELEASE"].get(KIND)["canary_device_ids"] == ["dev_a"]
+
+    html = client.get("/settings/firmware").get_data(as_text=True)
+    assert "up to date" in html
+    assert "queued v1.4.0" not in html
+
+
+def test_completed_promoted_release_shows_up_to_date(app: Flask) -> None:
+    with app.app_context():
+        _mk_device(app, "dev_a")
+    _set_status(app, "dev_a", fw=REL_FW)
+    client = _authed_client(app)
+    _import_valid(client)
+    app.config["OTA_RELEASE"].promote(KIND)
+
+    row = _device_row(app, "dev_a")
+    assert row["is_canary"] is True  # promoted materialises every capable device
+    assert row["queued"] is False
+    assert row["queued_fw"] is None
+    assert app.config["OTA_RELEASE"].get(KIND)["state"] == "promoted"
+
+
+def test_old_rollout_membership_does_not_claim_new_available_is_queued(
+    app: Flask, monkeypatch
+) -> None:  # type: ignore[no-untyped-def]
+    import json as _json
+
+    import app.firmware_check as fwc
+    from app.firmware_check import FirmwareInfo
+
+    with app.app_context():
+        _mk_device(app, "dev_a")
+    _set_status(app, "dev_a", fw="1.3.0")
+    app.config["OTA_RELEASE"].set_target(
+        KIND,
+        _json.loads(VALID.read_text()),
+        fw_version="1.3.0",
+        canary_device_ids=["dev_a"],
+    )
+    monkeypatch.setattr(
+        fwc,
+        "latest_for_kind",
+        lambda kind, current="": FirmwareInfo(
+            version="1.9.0",
+            released_at="",
+            url="https://example.test/r",
+            notes_headline="",
+            assets=(),
+            descriptor_url="https://api.tesserae.ink/d.json",
+        ),
+    )
+
+    row = _device_row(app, "dev_a", online=True)
+    assert row["is_canary"] is True
+    assert row["available_fw"] == "1.9.0"
+    assert row["update_available"] is True
+    assert row["queued"] is False
+    assert row["queued_fw"] is None
+    assert row["can_queue"] is True
 
 
 def test_queue_rejects_non_capable_device(app: Flask) -> None:


### PR DESCRIPTION
## Summary

- distinguish retained canary/fleet rollout membership from an update that is still pending
- show the imported release version in the queued chip instead of a potentially newer online `Available` version
- keep completed canaries available to the Fleet rollout model while rendering their device row as up to date
- add regression coverage for pending, completed, promoted, and newer-online-release states
- document the fix and bump the app version to 0.188.1

## Root cause

The unified Firmware page treated `is_canary` as equivalent to `queued`. Because rollout membership is intentionally retained, a device that had already reported the imported release still rendered as queued. The delivery path itself was safe: `_released_ota()` already withholds releases that are not strictly newer than the device's reported firmware.

The device-list model now derives effective queue state from both membership and whether the imported release is still newer. It keeps the underlying membership intact for the Advanced/Fleet view.

This also prevents an older imported release membership from making a newer online `Available` version look queued when that newer descriptor has not actually been imported.

## Validation

- `python -m pytest tests/test_firmware_rollout.py -q` — 32 passed
- `python -m pytest -q` — 2257 passed
- `python -m ruff check .` — passed
- `python -m ruff format --check .` — passed

Local `mypy app` was blocked before project analysis by the shared Python 3.12 environment's NumPy 2.5.1 stubs being parsed against this project's Python 3.11 mypy target. The canonical clean Python 3.11 mypy job remains enabled on this PR.

## Context

Real-device reproduction and the proposed state boundary were discussed here:

https://github.com/dmellok/tesserae/discussions/121#discussioncomment-17754716
