### PR TITLE
Fix photo orientation for portrait-native ESP32 panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Fixed
 
+- **Photo sends to portrait-native ESP32 panels keep their visual orientation.**
+  Send-page and Companion uploads are now fitted into the display's composition
+  dimensions before the renderer reconciles that composition with the
+  firmware-native row stride. Landscape photos sent to devices such as the
+  reTerminal E1004 no longer rotate 90 degrees clockwise while History remains
+  upright.
+
 - **v2 staleness is anchored to layout, not pixels (live bench round 3, 2026-07-25).** A region
   report against a superseded frame digest now dispatches when that frame's untrimmed region-id
   set matches the live one, resolved through a new ~10-generation digest lineage per device; a

--- a/renderers/esp32_bin/renderer.py
+++ b/renderers/esp32_bin/renderer.py
@@ -27,14 +27,18 @@ Pipeline:
 
 1. Use ``panel.native_w / panel.native_h`` if present, else fall back
    to ``(panel.w, panel.h)`` for custom panels.
-2. If the input image's orientation doesn't match the firmware's,
-   rotate 90° CW so its left edge lands at the panel's top edge.
-3. Apply ``panel.flip`` (180° for upside-down mounts).
-4. Letterbox (white) to fit the firmware-native dims exactly.
-5. Apply per-device underscan.
-6. Apply ``panel.vflip`` (row reverse for panels whose hardware scans
+2. Fit uploaded images into the panel's composition dimensions
+   (``panel.w × panel.h``). A landscape photo sent to a portrait display
+   stays landscape content; Fit/Fill decides how it is letterboxed/cropped.
+3. If the *composition* orientation doesn't match the firmware-native
+   stride, rotate the completed composition 90° CW.
+4. Apply ``panel.flip`` (180° for upside-down mounts).
+5. Fit to the firmware-native dims if a non-standard panel declaration
+   requires it.
+6. Apply per-device underscan.
+7. Apply ``panel.vflip`` (row reverse for panels whose hardware scans
    bottom-to-top, e.g. the PicPak 4-colour BWRY).
-7. Pack at the firmware-native dims.
+8. Pack at the firmware-native dims.
 """
 
 from __future__ import annotations
@@ -85,21 +89,41 @@ def transform(png_bytes: bytes, *, panel: Panel, settings: dict[str, Any]) -> by
     if regions:
         mask_img = rasterize_region_mask(regions, img.width, img.height)
     native_w, native_h = _firmware_native_dims(panel)
+    fit = str(settings.get("image_fit") or "fit")
+
+    # A Send-page / Companion upload is arbitrary source media, not a
+    # pre-composed panel frame. Fit it into the display's *composition*
+    # dimensions before considering the firmware-native row stride.
+    #
+    # Comparing the raw photo's aspect to the firmware aspect here used
+    # to rotate every landscape photo sent to a portrait-native E1004 by
+    # 90° CW. History stayed correct because it stores the source image;
+    # only the packed device artifact was wrong.
+    if img.size != (panel.w, panel.h):
+        img = fit_to_panel(
+            img,
+            target_w=panel.w,
+            target_h=panel.h,
+            scale=fit,
+            bg="white",
+        )
+
     firmware_landscape = native_w > native_h
-    img_landscape = img.size[0] > img.size[1]
-    orientation_mismatch = firmware_landscape != img_landscape
+    composition_landscape = panel.w > panel.h
+    orientation_mismatch = firmware_landscape != composition_landscape
     if orientation_mismatch:
-        # Orientation mismatch (either input PNG or user-calibrated
-        # composition), rotate 90° CW so the input's left edge lands
-        # at the panel's top edge. PIL ``rotate(angle)`` is
+        # The user-calibrated composition orientation differs from the
+        # hardware row stride. Rotate the completed composition 90° CW
+        # so its left edge lands at the panel's top edge. PIL ``rotate`` is
         # counter-clockwise; ``-90`` gives CW.
         img = img.rotate(-90, expand=True)
     if panel.flip:
         # Upside-down physical mount, turn 180° so it reads upright.
         img = img.rotate(180, expand=True)
     if img.size != (native_w, native_h):
-        # Send-page per-push fit mode (fit/fill/stretch/center/blur).
-        fit = str(settings.get("image_fit") or "fit")
+        # Normally the composition dims equal the native dims (or are the
+        # exact swapped pair after rotation). Keep a bounded fallback for
+        # custom/legacy manifests whose declared sizes differ.
         img = fit_to_panel(img, target_w=native_w, target_h=native_h, scale=fit, bg="white")
     # Per-device underscan: inset content so it clears a physical mat/bezel.
     if panel.underscan:

--- a/renderers/esp32_bin/tests/test_smoke.py
+++ b/renderers/esp32_bin/tests/test_smoke.py
@@ -7,9 +7,9 @@ panel orientations:
   * 13.3" Waveshare: portrait native (1200, 1600)
   * 7.3" PhotoPainter: landscape native (800, 480)
 
-When the composition's orientation doesn't match the panel's, the
-input gets a 90° CW rotation before packing so the bytes land at the
-firmware's expected row stride."""
+Uploaded images are first fitted into the panel's composition dimensions.
+Only a mismatch between that composition orientation and the firmware's
+native row stride gets a 90° CW rotation before packing."""
 
 from __future__ import annotations
 
@@ -109,67 +109,63 @@ def test_matching_orientation_round_trip(registry, panel_w: int, panel_h: int) -
         assert _decode_pixel(out, panel_w // 2, 3 * panel_h // 4, panel_w) == blue_nibble
 
 
-def test_landscape_source_to_portrait_panel_rotates_cw(registry) -> None:
-    """13.3" Waveshare is portrait native. A landscape composition gets
-    a 90° CW rotation so its left edge lands at the panel top. Solid
-    red on the left and solid blue on the right of the 1600×400 input
-    must end up as red TOP and blue BOTTOM of the 1200×1600 buffer."""
-    img = Image.new("RGB", (1600, 400), "white")
-    img.paste((255, 0, 0), (0, 0, 800, 400))
-    img.paste((0, 0, 255), (800, 0, 1600, 400))
+def test_landscape_photo_to_portrait_panel_fits_without_rotation(registry) -> None:
+    """Regression: a 4:3 landscape photo sent to a portrait-native E1004
+    is source media, not a landscape-calibrated composition. Fit must
+    letterbox it without turning the photo 90°."""
+    img = Image.new("RGB", (400, 300), "white")
+    img.paste((255, 0, 0), (0, 0, 200, 300))
+    img.paste((0, 0, 255), (200, 0, 400, 300))
 
     esp = registry.get("esp32_bin")
     assert esp is not None
     out = esp.transform(
         _png_bytes(img),
-        panel=Panel(w=1200, h=1600),  # portrait native
-        settings={"dither": "none", "saturation": 1.0, "contrast": 1.0},
+        panel=Panel(w=120, h=160, native_w=120, native_h=160),
+        settings={
+            "dither": "none",
+            "saturation": 1.0,
+            "contrast": 1.0,
+            "image_fit": "fit",
+        },
     )
-    assert len(out) == 1200 * 1600 // 2
+    assert len(out) == 120 * 160 // 2
 
     red_nibble = 0x3
     blue_nibble = 0x5
     white_nibble = 0x1
-    # After CW rotation + letterbox-fit to 1200×1600, the 400-wide CW-
-    # rotated strip lands centred. Red (was left) is the top half of
-    # the centre strip; blue (was right) is the bottom half.
-    assert _decode_pixel(out, 600, 400, 1200) == red_nibble
-    assert _decode_pixel(out, 600, 1200, 1200) == blue_nibble
-    # Letterbox columns left + right of the strip stay white.
-    assert _decode_pixel(out, 100, 800, 1200) == white_nibble
-    assert _decode_pixel(out, 1100, 800, 1200) == white_nibble
+    # The landscape photo stays left-to-right, centred vertically.
+    assert _decode_pixel(out, 30, 80, 120) == red_nibble
+    assert _decode_pixel(out, 90, 80, 120) == blue_nibble
+    assert _decode_pixel(out, 60, 10, 120) == white_nibble
+    assert _decode_pixel(out, 60, 150, 120) == white_nibble
 
 
-def test_portrait_source_to_landscape_panel_rotates_cw(registry) -> None:
-    """7.3" PhotoPainter is landscape native. A portrait composition
-    gets a 90° CW rotation so its top edge lands at the panel's RIGHT
-    edge (think of physically rotating the image clockwise: north →
-    east). Red TOP + blue BOTTOM portrait input ends up as red on the
-    RIGHT, blue on the LEFT of the 800×480 landscape buffer.
-
-    Without this, the firmware would feed the panel a 400-byte/row
-    stride against the renderer's 240-byte/row pack, paints garbled
-    vertical ghosts (the reported PhotoPainter symptom)."""
-    img = Image.new("RGB", (480, 800), "white")
-    img.paste((255, 0, 0), (0, 0, 480, 400))
-    img.paste((0, 0, 255), (0, 400, 480, 800))
+def test_landscape_photo_to_portrait_panel_fills_without_rotation(registry) -> None:
+    """Fill crops a 4:3 photo to the portrait panel while preserving
+    its visual orientation. This is the Companion app's reported path."""
+    img = Image.new("RGB", (400, 300), "white")
+    img.paste((255, 0, 0), (0, 0, 200, 300))
+    img.paste((0, 0, 255), (200, 0, 400, 300))
 
     esp = registry.get("esp32_bin")
     assert esp is not None
     out = esp.transform(
         _png_bytes(img),
-        panel=Panel(w=800, h=480),  # landscape native
-        settings={"dither": "none", "saturation": 1.0, "contrast": 1.0},
+        panel=Panel(w=120, h=160, native_w=120, native_h=160),
+        settings={
+            "dither": "none",
+            "saturation": 1.0,
+            "contrast": 1.0,
+            "image_fit": "fill",
+        },
     )
-    assert len(out) == 800 * 480 // 2  # 192000 bytes, matches the firmware report
+    assert len(out) == 120 * 160 // 2
 
     red_nibble = 0x3
     blue_nibble = 0x5
-    # CW rotation maps original top → right, original bottom → left.
-    # Red (was on top) lands on the panel's RIGHT half; blue (was on
-    # bottom) lands on the LEFT half.
-    assert _decode_pixel(out, 200, 240, 800) == blue_nibble  # mid of left half
-    assert _decode_pixel(out, 600, 240, 800) == red_nibble  # mid of right half
+    assert _decode_pixel(out, 10, 80, 120) == red_nibble
+    assert _decode_pixel(out, 110, 80, 120) == blue_nibble
 
 
 def test_portrait_calibration_on_landscape_native_panel(registry) -> None:


### PR DESCRIPTION
## What changed

- Fit arbitrary Send-page and Companion image uploads into the display's composition dimensions before reconciling that composition with the firmware-native row stride.
- Base the ESP32 packer's 90-degree rotation on `panel.w × panel.h` versus `native_w × native_h`, rather than on the uploaded image's own aspect ratio.
- Add Fit and Fill regressions for a 4:3 landscape photo sent to a portrait-native panel.
- Document the user-visible fix in the changelog.

## Why

This surfaced while testing the community iOS Companion with a portrait Seeed reTerminal E1004 (1200 × 1600). A 4:3 landscape photo appeared upright in Tesserae History, but the physical display painted it 90 degrees clockwise. The same bug also affected direct uploads through the web Send page because both paths use `PushManager.push_image()` and the same `esp32_bin` transform.

History was correct because it preserves the source composition before the device-specific transform. In `esp32_bin`, the renderer compared the raw upload's orientation with the firmware-native dimensions and rotated whenever they differed. That treated a landscape photo as if it were a landscape-calibrated panel composition.

The corrected pipeline first applies the requested Fit/Fill mode at the display's composition dimensions. It then rotates only when the completed composition orientation differs from the firmware-native stride. Existing calibrated portrait/landscape mounting behavior remains covered by the renderer tests.

## User impact

Landscape photos sent to portrait-native ESP32 panels such as the reTerminal E1004 now retain their visual orientation. The fix applies to both the web Send page and Companion clients.

## Validation

- `13 passed` — `renderers/esp32_bin/tests/test_smoke.py`
- `73 passed` — Companion jobs, web Send routes, PushManager, and push extras
- Ruff lint and format checks passed
- Hot-patched and verified on a running Tesserae v0.207.0 instance
- Retested with the original photo on a physical reTerminal E1004; the reporter confirmed the orientation is now correct
