### PR TITLE
Fix battery analytics during active charging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Fixed
 
+- **Battery analytics now separate charging from drain phases.** The Device batteries page
+  shows live `Charging` / `Charge rate` / `Full in` values without labelling a positive charge
+  ramp as `Drain rate`, and retains the preceding clean discharge slope as `Last drain rate`
+  when available. Robust Theil-Sen fits prevent a single glitched reading or post-unplug voltage
+  relaxation drop from dominating either estimate, while raw chart samples remain unchanged.
+
 - **v2 staleness is anchored to layout, not pixels (live bench round 3, 2026-07-25).** A region
   report against a superseded frame digest now dispatches when that frame's untrimmed region-id
   set matches the live one, resolved through a new ~10-generation digest lineage per device; a

--- a/app/device_battery_routes.py
+++ b/app/device_battery_routes.py
@@ -143,6 +143,8 @@ def _device_card(
         "series": series,
         "prediction": {
             "slope_per_day": prediction.slope_per_day,
+            "is_charging": prediction.is_charging,
+            "charge_rate_per_day": prediction.charge_rate_per_day,
             "days_to_20pct": prediction.days_to_20pct,
             "days_to_empty": prediction.days_to_empty,
             "days_to_full": prediction.days_to_full,
@@ -227,8 +229,11 @@ def series_json(device_id: str) -> Any:
             "series": series,
             "prediction": {
                 "slope_per_day": prediction.slope_per_day,
+                "is_charging": prediction.is_charging,
+                "charge_rate_per_day": prediction.charge_rate_per_day,
                 "days_to_20pct": prediction.days_to_20pct,
                 "days_to_empty": prediction.days_to_empty,
+                "days_to_full": prediction.days_to_full,
                 "samples": prediction.samples,
             }
             if prediction is not None

--- a/app/state/battery_history.py
+++ b/app/state/battery_history.py
@@ -11,15 +11,14 @@ default 15-min wake cadence) the table grows by ~35 k rows / device /
 year. SQLite handles low-millions easily; we'll add a rolldown when
 someone hits multi-year retention.
 
-The prediction is a plain linear regression of percentage vs unix
-time over the most recent ``window_days`` of samples. ``slope_per_day``
-is a negative number for a draining battery; we project to the 20%
-and 0% intercepts. We bail out (return ``None``) when:
+The prediction separates the trailing charging phase from the latest
+clean discharge phase, then fits each phase with a robust Theil-Sen
+median slope. ``slope_per_day`` is reserved for drain data (negative
+or zero); live charging speed is exposed separately as
+``charge_rate_per_day``. We bail out (return ``None``) when:
 
 * there are fewer than ``MIN_SAMPLES`` points in the window, OR
-* the slope is non-negative (battery flat or charging), OR
-* the slope is so shallow the projection would exceed 10 years (the
-  battery's probably plugged in).
+* no fitted phase has enough distinct timestamps.
 """
 
 from __future__ import annotations
@@ -27,6 +26,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import sqlite3
+import statistics
 import threading
 import time
 from collections.abc import Iterator
@@ -65,6 +65,13 @@ MIN_CHARGE_PER_DAY: float = 0.5
 # discharge episode mid-window from pulling the regression
 # downward and masking an in-progress charge.
 MIN_CHARGE_SEGMENT_SAMPLES: int = 4
+# A two-point net rise is enough to distinguish a real charge from the
+# common +/-1 percentage-point ADC wobble.
+MIN_CHARGE_GAIN_PCT: int = 2
+# Theil-Sen considers every pair (O(n^2)). A deterministic, evenly
+# spaced cap keeps long high-frequency windows cheap while retaining
+# the shape of the full series.
+MAX_THEIL_SEN_SAMPLES: int = 300
 
 
 @dataclass(frozen=True)
@@ -72,7 +79,10 @@ class Prediction:
     """One-shot regression result for a device's last N days.
 
     ``slope_per_day`` is negative on a draining battery (e.g. -3.2
-    means it loses 3.2 % per day) and positive when charging.
+    means it loses 3.2 % per day), zero when flat, and ``None`` when
+    no clean discharge segment is available. It is never a charging
+    slope. ``charge_rate_per_day`` carries the positive live charging
+    slope when ``is_charging`` is true.
     ``days_to_20pct`` / ``days_to_empty`` are projections from
     ``current_pct``; both ``None`` when the battery's flat or rising.
     ``days_to_full`` is the inverse: present only when the recent
@@ -82,7 +92,9 @@ class Prediction:
 
     device_id: str
     current_pct: float
-    slope_per_day: float
+    slope_per_day: float | None
+    is_charging: bool
+    charge_rate_per_day: float | None
     days_to_20pct: float | None
     days_to_empty: float | None
     days_to_full: float | None
@@ -217,79 +229,87 @@ class BatteryHistory:
         *,
         window_days: int = DEFAULT_WINDOW_DAYS,
     ) -> Prediction | None:
-        """Linear regression of percent vs time over the last
-        ``window_days``. ``None`` when there isn't enough data; a
-        Prediction with ``days_to_*=None`` when the battery's flat
-        or charging.
+        """Robust phase-aware battery trend over the last
+        ``window_days``.
 
-        Critically, if the window contains a charge event (a jump
-        of ``CHARGE_JUMP_PCT`` or more between consecutive samples),
-        the regression fits ONLY the most recent discharge segment
-        — otherwise the upward jump dominates the linear fit and we
-        end up projecting a non-draining battery on a fleet that's
-        actually draining between charges. Falls back to the full
-        window when the latest segment is too short to be useful."""
+        A trailing rising phase is fitted independently and reported
+        through ``is_charging`` / ``charge_rate_per_day`` /
+        ``days_to_full``. While charging, ``slope_per_day`` comes only
+        from the preceding clean discharge phase, so a positive charge
+        ramp can never surface as a drain rate. All fits use Theil-Sen
+        to keep a single glitched reading or unplug relaxation drop
+        from dominating the estimate."""
         all_rows = self.recent(device_id, window_days=window_days)
         if len(all_rows) < MIN_SAMPLES:
             return None
-        rows = _last_discharge_segment(all_rows)
-        if len(rows) < MIN_SEGMENT_SAMPLES:
-            # Either no charge event in the window, or the segment
-            # after the last charge is too short for a meaningful
-            # fit. Fall back to the full window so a long flat or
-            # gently-draining battery still gets a slope reading.
-            # ``all_rows`` already cleared MIN_SAMPLES above, so we
-            # don't re-check here (segments intentionally accept
-            # fewer points than the full window).
-            rows = all_rows
-        # x is days since the oldest sample so the regression's
-        # numerical conditioning is reasonable.
-        t0 = rows[0].timestamp
-        xs = [(r.timestamp - t0) / 86400.0 for r in rows]
-        ys = [float(r.pct) for r in rows]
-        n = len(xs)
-        sum_x = sum(xs)
-        sum_y = sum(ys)
-        mean_x = sum_x / n
-        mean_y = sum_y / n
-        num = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys, strict=True))
-        den = sum((x - mean_x) ** 2 for x in xs)
-        if den == 0:
-            return None
-        slope = num / den  # %-points per day
-        intercept = mean_y - slope * mean_x
-        # Current pct: take the LAST sample of the full series, not
-        # the segment, so the projection projects from where the
-        # device actually is right now (the segment may end on an
-        # older sample if we fell back).
-        current_pct = max(0.0, min(100.0, float(all_rows[-1].pct)))
 
-        if slope >= -MIN_DRAIN_PER_DAY:
-            # Flat or charging. Fit a separate regression to just the
-            # latest charging segment so a half-window-old discharge
-            # doesn't drag the slope below the charging threshold.
-            # When the segment fit shows sustained positive slope we
-            # produce a days_to_full projection; otherwise it's a
-            # genuinely flat battery and only the slope reading goes
-            # back.
-            days_to_full = _maybe_days_to_full(all_rows, current_pct)
+        current_pct = max(0.0, min(100.0, float(all_rows[-1].pct)))
+        charging_rows = _last_charging_segment(all_rows)
+        charge_slope = _theil_sen_slope(charging_rows) if charging_rows else None
+        is_charging = (
+            charge_slope is not None
+            and charge_slope >= MIN_CHARGE_PER_DAY
+            and max(r.pct for r in charging_rows) - min(r.pct for r in charging_rows)
+            >= MIN_CHARGE_GAIN_PCT
+        )
+
+        if is_charging:
+            assert charge_slope is not None
+            prior_rows = all_rows[: len(all_rows) - len(charging_rows)]
+            drain_rows = _last_discharge_segment(prior_rows)
+            drain_slope = (
+                _theil_sen_slope(drain_rows) if len(drain_rows) >= MIN_SEGMENT_SAMPLES else None
+            )
+            if drain_slope is not None and drain_slope >= -MIN_DRAIN_PER_DAY:
+                drain_slope = None
+            days_to_full = (
+                0.0 if current_pct >= 100.0 else max(0.0, (100.0 - current_pct) / charge_slope)
+            )
             return Prediction(
                 device_id=device_id,
                 current_pct=current_pct,
-                slope_per_day=slope,
+                slope_per_day=drain_slope,
+                is_charging=True,
+                charge_rate_per_day=charge_slope,
                 days_to_20pct=None,
                 days_to_empty=None,
                 days_to_full=days_to_full,
+                samples=len(drain_rows) if drain_slope is not None else len(charging_rows),
+                window_days=window_days,
+            )
+
+        rows = _last_discharge_segment(all_rows)
+        if len(rows) < MIN_SEGMENT_SAMPLES:
+            # A single recent jump is not enough to establish a charge
+            # phase. Preserve the older fallback for that ambiguous
+            # case, but never expose a positive result as drain.
+            rows = all_rows
+        slope = _theil_sen_slope(rows)
+        if slope is None:
+            return None
+        n = len(rows)
+
+        if slope >= -MIN_DRAIN_PER_DAY:
+            return Prediction(
+                device_id=device_id,
+                current_pct=current_pct,
+                slope_per_day=min(0.0, slope),
+                is_charging=False,
+                charge_rate_per_day=None,
+                days_to_20pct=None,
+                days_to_empty=None,
+                days_to_full=None,
                 samples=n,
                 window_days=window_days,
             )
-        del intercept  # not exposed; kept for clarity if we add a chart trendline
         days_to_20pct = (current_pct - 20.0) / (-slope) if current_pct > 20.0 else 0.0
         days_to_empty = current_pct / (-slope)
         return Prediction(
             device_id=device_id,
             current_pct=current_pct,
             slope_per_day=slope,
+            is_charging=False,
+            charge_rate_per_day=None,
             days_to_20pct=max(0.0, days_to_20pct),
             days_to_empty=max(0.0, days_to_empty),
             days_to_full=None,
@@ -314,71 +334,61 @@ def _last_discharge_segment(rows: list[BatteryRow]) -> list[BatteryRow]:
 
 
 def _last_charging_segment(rows: list[BatteryRow]) -> list[BatteryRow]:
-    """Return the trailing slice of ``rows`` where the percent is
-    monotonically non-decreasing across at least
-    ``MIN_CHARGE_SEGMENT_SAMPLES`` consecutive samples ending at the
-    last row.
+    """Return the candidate trailing charging phase.
 
-    Walks back from the tail until the first sample that DROPS, which
-    marks the boundary between "the last discharge" and "the charge
-    currently in progress". Wobble of one percent point is allowed
-    within the segment (firmware ADC noise; a 4.16 V cell can read as
-    99 / 100 / 99 / 100 over four consecutive heartbeats), so we look
-    for drops of more than one percent rather than strict monotonicity.
-    Returns an empty list when the latest segment is too short to fit
-    on; the caller treats that as "not currently charging"."""
-    if not rows:
+    A large upward step is the strongest boundary signal, and its high
+    sample starts the fit so an instantaneous firmware correction does
+    not inflate the charge rate. Without a step, walk backward to the
+    latest trough, tolerating one point of ADC wobble. This stops a slow
+    prior discharge from being absorbed into the charging fit (the old
+    "break only on a two-point drop" rule could consume the whole
+    previous discharge).
+    """
+    if len(rows) < MIN_CHARGE_SEGMENT_SAMPLES:
         return []
-    end = len(rows) - 1
-    start = end
-    for i in range(end - 1, -1, -1):
-        # A drop of more than one percent breaks the segment; this
-        # cell IS discharging (or at best flat) over this gap.
-        if rows[i + 1].pct - rows[i].pct < -1:
+
+    for i in range(len(rows) - 1, 0, -1):
+        if rows[i].pct - rows[i - 1].pct >= CHARGE_JUMP_PCT:
+            segment = rows[i:]
+            if len(segment) >= MIN_CHARGE_SEGMENT_SAMPLES:
+                return segment
+
+    min_pct = rows[-1].pct
+    min_idx = len(rows) - 1
+    for i in range(len(rows) - 2, -1, -1):
+        pct = rows[i].pct
+        if pct > min_pct + 1:
             break
-        start = i
-    segment = rows[start : end + 1]
+        if pct < min_pct:
+            min_pct = pct
+            min_idx = i
+    segment = rows[min_idx:]
     if len(segment) < MIN_CHARGE_SEGMENT_SAMPLES:
         return []
     return segment
 
 
-def _maybe_days_to_full(rows: list[BatteryRow], current_pct: float) -> float | None:
-    """Return the projected days until ``current_pct`` reaches 100%,
-    or ``None`` when the latest samples don't show sustained charging.
+def _theil_sen_slope(rows: list[BatteryRow]) -> float | None:
+    """Median pairwise slope in percentage points per day.
 
-    Uses :func:`_last_charging_segment` to isolate the trailing
-    charging slice, then fits the same simple linear regression as
-    ``predict()`` on that subset. Two reasons to gate this beyond the
-    main slope:
-
-    * The main slope is fit to the most recent DISCHARGE segment for
-      the days-to-empty projection; it's the wrong signal for the
-      charge case (it can be slightly negative even while a charge is
-      mid-progress).
-    * A genuinely flat battery shouldn't get a "Full in ∞" indicator;
-      requiring ``MIN_CHARGE_PER_DAY`` of charging slope filters that
-      out cleanly.
-
-    Returns 0 (not None) when the battery is already at or above 100%
-    so the UI can render "Full now" rather than hiding the indicator.
+    Long series are evenly subsampled to cap the quadratic pair count.
+    Duplicate timestamps are skipped; ``None`` means no usable pair.
     """
-    if current_pct >= 100.0:
-        return 0.0
-    segment = _last_charging_segment(rows)
-    if not segment:
+    if len(rows) < 2:
         return None
-    t0 = segment[0].timestamp
-    xs = [(r.timestamp - t0) / 86400.0 for r in segment]
-    ys = [float(r.pct) for r in segment]
-    n = len(xs)
-    mean_x = sum(xs) / n
-    mean_y = sum(ys) / n
-    num = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys, strict=True))
-    den = sum((x - mean_x) ** 2 for x in xs)
-    if den == 0:
-        return None
-    slope = num / den
-    if slope < MIN_CHARGE_PER_DAY:
-        return None
-    return max(0.0, (100.0 - current_pct) / slope)
+    fitted_rows = rows
+    if len(rows) > MAX_THEIL_SEN_SAMPLES:
+        last = len(rows) - 1
+        indices = {
+            round(i * last / (MAX_THEIL_SEN_SAMPLES - 1)) for i in range(MAX_THEIL_SEN_SAMPLES)
+        }
+        fitted_rows = [rows[i] for i in sorted(indices)]
+
+    slopes: list[float] = []
+    for i, left in enumerate(fitted_rows[:-1]):
+        for right in fitted_rows[i + 1 :]:
+            elapsed_days = (right.timestamp - left.timestamp) / 86400.0
+            if elapsed_days == 0:
+                continue
+            slopes.append((right.pct - left.pct) / elapsed_days)
+    return float(statistics.median(slopes)) if slopes else None

--- a/templates/device_battery.html
+++ b/templates/device_battery.html
@@ -5,7 +5,7 @@
 {% block main %}
 <header class="page-head">
   <h1><i class="ph ph-battery-medium"></i> Device batteries</h1>
-  <p class="lede">Drain trends and projected days-to-empty for every battery-powered display.</p>
+  <p class="lede">Charging and drain trends for every battery-powered display.</p>
 </header>
 
 {# Window picker as the v0.56 filter chip strip, page-level above the
@@ -21,7 +21,7 @@
 </nav>
 
 {% call section_card(icon='battery-medium', title='Device batteries',
-                     description='Each card shows a ' ~ window_days ~ '-day drain curve plus current state, projected days to 20% / 0%, and sample count.') %}
+                     description='Each card separates active charging from the latest clean drain phase across the selected ' ~ window_days ~ '-day window.') %}
   {% if not cards %}
   <div class="dx-empty">
     <div class="dx-empty-icon"><i class="ph ph-battery-low" aria-hidden="true"></i></div>
@@ -69,10 +69,52 @@
           <div class="dx-stat-value">{{ c.samples }}</div>
           <div class="dx-stat-sub">in window</div>
         </div>
+        {% if c.prediction and c.prediction.is_charging %}
+        <div class="dx-stat-tile">
+          <div class="dx-stat-label">Charging</div>
+          <div class="dx-stat-value">active</div>
+          <div class="dx-stat-sub">live phase</div>
+        </div>
+        <div class="dx-stat-tile">
+          <div class="dx-stat-label">Charge rate</div>
+          <div class="dx-stat-value">
+            {{ '%+.1f' % c.prediction.charge_rate_per_day }}
+          </div>
+          <div class="dx-stat-sub">%/day</div>
+        </div>
+        <div class="dx-stat-tile">
+          <div class="dx-stat-label">Full in</div>
+          <div class="dx-stat-value">
+            {% if c.prediction.days_to_full == 0 %}
+              now
+            {% elif c.prediction.days_to_full < 1 %}
+              {{ '%.1f' % (c.prediction.days_to_full * 24) }}
+            {% else %}
+              {{ '%.1f' % c.prediction.days_to_full }}
+            {% endif %}
+          </div>
+          <div class="dx-stat-sub">
+            {% if c.prediction.days_to_full == 0 %}charged
+            {% elif c.prediction.days_to_full < 1 %}hours
+            {% else %}days{% endif %}
+          </div>
+        </div>
+        <div class="dx-stat-tile">
+          <div class="dx-stat-label">Last drain rate</div>
+          <div class="dx-stat-value">
+            {% if c.prediction.slope_per_day is not none %}
+              {{ '%+.1f' % c.prediction.slope_per_day }}
+            {% else %}—{% endif %}
+          </div>
+          <div class="dx-stat-sub">%/day</div>
+        </div>
+        {% else %}
         <div class="dx-stat-tile">
           <div class="dx-stat-label">Drain rate</div>
           <div class="dx-stat-value">
-            {% if c.prediction %}{{ '%+.1f' % c.prediction.slope_per_day }}{% else %}—{% endif %}
+            {% if c.prediction and c.prediction.slope_per_day is not none %}
+              {{ '%+.1f' % c.prediction.slope_per_day }}
+            {% else %}—{% endif %}
           </div>
           <div class="dx-stat-sub">%/day</div>
         </div>
@@ -93,28 +135,6 @@
             {% else %}—{% endif %}
           </div>
           <div class="dx-stat-sub">days</div>
-        </div>
-        {# When the latest samples show sustained charging, this tile
-           replaces "Reaches 0%" in the user's mental model: an actively
-           charging battery doesn't drain, so the empty-projection is
-           meaningless, and "Full in Xh" is the genuinely useful number. #}
-        {% if c.prediction and c.prediction.days_to_full is not none %}
-        <div class="dx-stat-tile">
-          <div class="dx-stat-label">Full in</div>
-          <div class="dx-stat-value">
-            {% if c.prediction.days_to_full == 0 %}
-              now
-            {% elif c.prediction.days_to_full < 1 %}
-              {{ '%.1f' % (c.prediction.days_to_full * 24) }}
-            {% else %}
-              {{ '%.1f' % c.prediction.days_to_full }}
-            {% endif %}
-          </div>
-          <div class="dx-stat-sub">
-            {% if c.prediction.days_to_full == 0 %}charged
-            {% elif c.prediction.days_to_full < 1 %}hours
-            {% else %}days{% endif %}
-          </div>
         </div>
         {% endif %}
       </div>

--- a/tests/test_battery_history.py
+++ b/tests/test_battery_history.py
@@ -1,4 +1,4 @@
-"""BatteryHistory store + linear regression coverage."""
+"""BatteryHistory store + phase-aware robust regression coverage."""
 
 from __future__ import annotations
 
@@ -162,7 +162,12 @@ def test_predict_returns_days_to_full_on_a_sustained_charge(
         store.record("esp32_charging", pct=round(pct), timestamp=now - days_ago * 86400)
     pred = store.predict("esp32_charging", window_days=7)
     assert pred is not None
-    assert pred.slope_per_day > 0
+    assert pred.is_charging is True
+    assert pred.charge_rate_per_day is not None
+    assert pred.charge_rate_per_day > 0
+    # No prior clean discharge exists, so charging must not leak its
+    # positive slope into the drain-rate field.
+    assert pred.slope_per_day is None
     assert pred.days_to_full is not None
     # current 90%, slope 10 %/day → 1 day to 100%
     assert pred.days_to_full == pytest.approx(1.0, abs=0.3)
@@ -220,7 +225,102 @@ def test_predict_days_to_full_zero_when_already_at_or_above_100(
     pred = store.predict("esp32_topup", window_days=7)
     assert pred is not None
     assert pred.current_pct >= 100.0
+    assert pred.is_charging is True
     assert pred.days_to_full == 0.0
+
+
+def test_predict_separates_frequent_charge_ramp_from_last_drain(
+    store: BatteryHistory,
+) -> None:
+    """Regression for Discussion #137's live E1004 shape.
+
+    A long clean discharge ends at 68%, then a charge jump and nine
+    frequent rising samples follow. The old heuristic fitted those
+    nine samples as +475%/day and labelled that value Drain rate.
+    """
+    now = time.time()
+    drain_start = now - 2.2 * 86400
+    drain_span = 45.5 * 3600
+    for i in range(500):
+        fraction = i / 499
+        store.record(
+            "e1004",
+            pct=round(76 - 8 * fraction),
+            timestamp=drain_start + drain_span * fraction,
+        )
+
+    charge_start = drain_start + drain_span + 300
+    for i, pct in enumerate((76, 77, 78, 79, 79, 80, 81, 81, 82)):
+        store.record("e1004", pct=pct, timestamp=charge_start + i * 128)
+
+    pred = store.predict("e1004", window_days=7)
+    assert pred is not None
+    assert pred.is_charging is True
+    assert pred.charge_rate_per_day is not None
+    assert pred.charge_rate_per_day > 100
+    assert pred.slope_per_day == pytest.approx(-4.2, abs=0.8)
+    assert pred.slope_per_day < 0
+    assert pred.days_to_20pct is None
+    assert pred.days_to_empty is None
+    assert pred.days_to_full is not None
+
+
+def test_predict_charge_rate_excludes_pre_charge_plateau(
+    store: BatteryHistory,
+) -> None:
+    """A 68-69% plateau before plug-in must not dilute Full in."""
+    now = time.time()
+    start = now - 2 * 86400
+    for i in range(16):
+        store.record(
+            "plateau",
+            pct=80 - round(11 * i / 15),
+            timestamp=start + i * 2 * 3600,
+        )
+    plateau_start = start + 32 * 3600
+    for i in range(24):
+        store.record(
+            "plateau",
+            pct=68 + (i % 2),
+            timestamp=plateau_start + i * 15 * 60,
+        )
+    charge_start = plateau_start + 24 * 15 * 60
+    for i, pct in enumerate((76, 77, 78, 79, 80, 81, 82)):
+        store.record("plateau", pct=pct, timestamp=charge_start + i * 5 * 60)
+
+    pred = store.predict("plateau", window_days=7)
+    assert pred is not None
+    assert pred.is_charging is True
+    assert pred.charge_rate_per_day == pytest.approx(288.0, abs=5.0)
+    assert pred.days_to_full == pytest.approx(0.0625, abs=0.01)
+
+
+def test_theil_sen_ignores_single_post_unplug_relaxation_drop(
+    store: BatteryHistory,
+) -> None:
+    """One immediate voltage correction must not steepen normal drain."""
+    now = time.time()
+    points = [
+        (6.0, 70),
+        (5.0, 60),
+        (4.0, 50),
+        (3.0, 40),
+        (2.1, 85),  # charge event
+        (2.0, 76),  # immediate unplug relaxation
+        (1.5, 75),
+        (1.0, 73),
+        (0.5, 72),
+        (0.0, 70),
+    ]
+    for days_ago, pct in points:
+        store.record("relaxation", pct=pct, timestamp=now - days_ago * 86400)
+
+    pred = store.predict("relaxation", window_days=7)
+    assert pred is not None
+    assert pred.is_charging is False
+    assert pred.slope_per_day == pytest.approx(-3.0, abs=1.0)
+    assert pred.slope_per_day > -6.0
+    assert pred.days_to_empty is not None
 
 
 def test_device_ids_returns_distinct_devices(store: BatteryHistory) -> None:

--- a/tests/test_device_battery_routes.py
+++ b/tests/test_device_battery_routes.py
@@ -65,6 +65,32 @@ def test_index_renders_card_with_history_and_prediction(app: Flask, tmp_path: Pa
     assert "Drain rate" in body or "Need at least 8 samples" in body
 
 
+def test_index_labels_live_charge_and_historical_drain_separately(app: Flask) -> None:
+    store: BatteryHistory = app.config["BATTERY_HISTORY"]
+    client = app.test_client()
+    _sign_in(client)
+    client.post(
+        "/settings/devices/add",
+        data={"id": "e1004", "kind": "esp32_client", "name": "E1004"},
+    )
+    now = time.time()
+    for i in range(12):
+        store.record(
+            "e1004",
+            pct=76 - round(8 * i / 11),
+            timestamp=now - (36 - i) * 3600,
+        )
+    for i, pct in enumerate((76, 77, 78, 79, 80, 81, 82)):
+        store.record("e1004", pct=pct, timestamp=now - (6 - i) * 5 * 60)
+
+    body = client.get("/devices/battery?window=7").get_data(as_text=True)
+    assert '<div class="dx-stat-label">Charging</div>' in body
+    assert '<div class="dx-stat-label">Charge rate</div>' in body
+    assert '<div class="dx-stat-label">Full in</div>' in body
+    assert '<div class="dx-stat-label">Last drain rate</div>' in body
+    assert '<div class="dx-stat-label">Drain rate</div>' not in body
+
+
 def test_index_hides_orphan_history_for_unregistered_devices(app: Flask, tmp_path: Path) -> None:
     """Historical battery rows for a device that's no longer in the
     registry must not render. The previous logic was
@@ -101,6 +127,29 @@ def test_series_json_returns_points_and_prediction(app: Flask) -> None:
     # 12 samples * 4% drop = strong negative slope, prediction populated.
     assert payload["prediction"] is not None
     assert payload["prediction"]["slope_per_day"] < 0
+
+
+def test_series_json_exposes_phase_aware_charge_fields(app: Flask) -> None:
+    store: BatteryHistory = app.config["BATTERY_HISTORY"]
+    now = time.time()
+    for i in range(12):
+        store.record(
+            "e1004",
+            pct=76 - round(8 * i / 11),
+            timestamp=now - (36 - i) * 3600,
+        )
+    for i, pct in enumerate((76, 77, 78, 79, 80, 81, 82)):
+        store.record("e1004", pct=pct, timestamp=now - (6 - i) * 5 * 60)
+
+    client = app.test_client()
+    _sign_in(client)
+    payload = client.get("/devices/battery/e1004/series.json?window=7").get_json()
+    prediction = payload["prediction"]
+    assert prediction["is_charging"] is True
+    assert prediction["charge_rate_per_day"] > 0
+    assert prediction["slope_per_day"] < 0
+    assert prediction["days_to_full"] is not None
+    assert prediction["days_to_empty"] is None
 
 
 def test_window_query_param_clamps(app: Flask) -> None:


### PR DESCRIPTION
## Summary

- separate an active charging phase from the latest clean discharge phase
- expose live `is_charging` / `charge_rate_per_day` values while retaining a historical `slope_per_day` only for drain data
- replace OLS fits with a Theil-Sen median slope, deterministically subsampling long windows to 300 points
- update the Device batteries page and JSON endpoint to show `Charging`, `Charge rate`, `Full in`, and `Last drain rate`
- keep every raw sample unchanged in the chart

## Root cause

`_last_discharge_segment()` treated every sample after a charge jump as discharge. With frequent telemetry during an active charge, that suffix is the rising charge ramp, so the UI could render a large positive value under `Drain rate`.

The inverse `_last_charging_segment()` only stopped on drops greater than one percentage point. At a five-minute cadence, it could absorb a long preceding discharge or plateau and dilute the time-to-full estimate.

## Behavior

While charging:

- the trailing rising phase supplies `Charge rate` and `Full in`
- the preceding clean discharge phase supplies `Last drain rate`, when available
- discharge projections stay blank
- a positive slope can never render under a drain label

While flat or discharging, the existing drain labels and projections remain in place.

## Validation

- `2504 passed` in the full test suite
- `33 passed, 75 deselected` in the focused battery/widget/REST selection
- Ruff formatting and lint checks
- mypy on the changed application modules
- replayed the original 1,957-sample E1004 history through the patched container: the 82% charge ramp classified as charging, with separate live charge and historical drain rates

## Discussion

Implements the semantics and test coverage agreed in:

- https://github.com/dmellok/tesserae/discussions/137
- https://github.com/dmellok/tesserae/discussions/137#discussioncomment-17742398
