### PR TITLE
Add Companion 0.4 History and photo layout modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Added
 
+- **Companion API 0.4 adds canonical History and all five photo layout modes.**
+  Community clients can page through the same push History shown in the web UI,
+  fetch retained composition previews, and idempotently resend an entry to its
+  original display snapshot while respecting quiet hours. Successful jobs may
+  include the exact new History event IDs, and image uploads now advertise and
+  accept Fit, Fill, Blur, Stretch, and Center.
+
 - **The opt-in daily heartbeat now includes a bucketed count of paired companion apps.** Same
   `0`/`1`/`2-3`/… bucketing as the device count, derived server-side from the live companion
   tokens (never a client name, install id, or app version), so adoption of the community

--- a/app/companion_api.py
+++ b/app/companion_api.py
@@ -10,14 +10,14 @@ or Flask session cookies.
 
 This module covers the discovery, pairing, session, read-model, and write
 surfaces of the contract: capability probe, pairing, session revocation,
-device + dashboard read models, the two async write routes (dashboard
-push, image push), and job polling. Writes return ``202`` with a persisted
+device + dashboard read models, canonical History reads and resend, the
+async write routes, and job polling. Writes return ``202`` with a persisted
 job the client polls; quiet-hours suppression surfaces as a *successful*
 ``quiet`` outcome, never a failure. ``_tesserae._tcp`` discovery lives in
 app.mdns.
 
 Contract: ``charmmmz/tesserae-companion-ios`` ``Contracts/app-v1.openapi.yaml``
-(OpenAPI 0.2.0). The vendored copy + fixtures under ``tests/companion/``
+(OpenAPI 0.4.0). The vendored copy + fixtures under ``tests/companion/``
 guard these shapes.
 
 mypy --strict applies to this module, see pyproject.toml.
@@ -40,11 +40,21 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from flask import Blueprint, Flask, current_app, g, jsonify, request
 from werkzeug.wrappers import Response
 
+from app.companion_history import (
+    DEFAULT_HISTORY_LIMIT,
+    MAX_HISTORY_LIMIT,
+    InvalidHistoryCursor,
+    list_history,
+    parse_history_id,
+    retained_composition_for_history,
+    retained_resend_composition_for_row,
+)
 from app.companion_jobs import CompanionJobs, JobOutcome
 from app.device_loader import Device, DeviceRegistry
 from app.panel import device_panel, resolve_settings_panel
 from app.quiet_hours import device_is_quiet
 from app.state.companion_token_store import COMPANION_SCOPES, CompanionTokenStore
+from app.state.event_log import EventLog, EventRow
 from app.state.idempotency_store import IdempotencyStore
 from app.state.idempotency_store import fingerprint as _idempotency_fingerprint
 from app.state.job_store import JobKind, JobStore
@@ -76,15 +86,17 @@ bp = Blueprint("companion_api", __name__, url_prefix="/api/app/v1")
 IMAGE_UPLOAD_BYTES = 26_214_400  # 25 MiB
 IMAGE_MAX_EDGE = 8192
 IMAGE_CONTENT_TYPES = ("image/jpeg", "image/png", "image/heic", "image/heif", "image/webp")
+IMAGE_FIT_MODES = ("fit", "fill", "blur", "stretch", "center")
 JOB_RETENTION_SECONDS = 86_400
 IDEMPOTENCY_RETENTION_SECONDS = 86_400
 
 # Features this server serves. The client gates on this list rather than
 # assuming the full set, so unshipped surfaces degrade cleanly.
-FEATURES = ("devices", "dashboards", "dashboard_push", "image_push", "jobs")
+FEATURES = ("devices", "dashboards", "dashboard_push", "image_push", "jobs", "history")
 
 _PAIRING_CODE_RE = re.compile(r"^[0-9]{6,12}$")
 _IMAGE_CONTENT_TYPES = frozenset(IMAGE_CONTENT_TYPES)
+_IMAGE_FIT_MODES = frozenset(IMAGE_FIT_MODES)
 
 
 # -- CORS ----------------------------------------------------------------
@@ -154,6 +166,10 @@ def _job_runner() -> CompanionJobs:
 
 def _push_manager() -> Any:
     return current_app.config.get("PUSH_MANAGER")
+
+
+def _events() -> EventLog:
+    return current_app.config["EVENT_LOG"]  # type: ignore[no-any-return]
 
 
 # -- error envelope ------------------------------------------------------
@@ -274,6 +290,7 @@ def _capabilities() -> dict[str, Any]:
             "image_upload_bytes": IMAGE_UPLOAD_BYTES,
             "image_max_edge": IMAGE_MAX_EDGE,
             "image_content_types": list(IMAGE_CONTENT_TYPES),
+            "image_fit_modes": list(IMAGE_FIT_MODES),
             "job_retention_seconds": JOB_RETENTION_SECONDS,
             "idempotency_retention_seconds": IDEMPOTENCY_RETENTION_SECONDS,
         },
@@ -533,6 +550,14 @@ def _partition_quiet(target_ids: list[str], *, override: bool) -> tuple[list[str
 _PUBLISHED_STATUSES = frozenset({"sent", "no_change"})
 
 
+def _history_event_ids(result: Any) -> list[str] | None:
+    """Exact canonical History correlation for a successful push result."""
+    event_id = getattr(result, "event_id", None)
+    if isinstance(event_id, int) and event_id > 0:
+        return [str(event_id)]
+    return None
+
+
 def _job_response(job: Any, status_code: int) -> Any:
     resp = jsonify({"job": job.public_dict()})
     resp.status_code = status_code
@@ -625,7 +650,7 @@ def push_dashboard(dashboard_id: str) -> Any:
             bypass_coalesce=True,
         )
         if result.status in _PUBLISHED_STATUSES:
-            return JobOutcome.published(active)
+            return JobOutcome.published(active, history_event_ids=_history_event_ids(result))
         return JobOutcome.failed("render_failed", result.error or f"push {result.status}")
 
     return _reserve_and_run(
@@ -684,15 +709,18 @@ def push_image() -> Any:
         return _error("invalid_request", "The 'request' part must be JSON.", 400)
     if not isinstance(spec, dict):
         return _error("invalid_request", "The 'request' part must be a JSON object.", 400)
-    if spec.get("fit") not in ("fit", "fill") or not isinstance(
-        spec.get("override_quiet_hours"), bool
+    fit_value = spec.get("fit")
+    if (
+        not isinstance(fit_value, str)
+        or fit_value not in _IMAGE_FIT_MODES
+        or not isinstance(spec.get("override_quiet_hours"), bool)
     ):
         return _error("invalid_request", "fit and override_quiet_hours are required.", 400)
     targets = _valid_target_ids(spec.get("device_ids"))
     if targets is None:
         return _error("invalid_target", "One or more target displays are unknown.", 400)
 
-    fit = str(spec["fit"])
+    fit = fit_value
     override = bool(spec["override_quiet_hours"])
     resolved_targets = list(targets)
     payload = image_bytes + b"\x00" + request_raw.encode("utf-8")
@@ -705,6 +733,7 @@ def push_image() -> Any:
         if manager is None:
             return JobOutcome.failed("temporarily_unavailable", "The push pipeline is offline.")
         published: list[str] = []
+        history_event_ids: list[str] = []
         for did in active:
             result = manager.push_image(
                 image_bytes,
@@ -716,8 +745,12 @@ def push_image() -> Any:
             )
             if result.status in _PUBLISHED_STATUSES:
                 published.append(did)
+                history_event_ids.extend(_history_event_ids(result) or [])
         if published:
-            return JobOutcome.published(published)
+            return JobOutcome.published(
+                published,
+                history_event_ids=history_event_ids or None,
+            )
         return JobOutcome.failed("render_failed", "The image could not be published.")
 
     return _reserve_and_run(
@@ -726,6 +759,151 @@ def push_image() -> Any:
         payload=payload,
         target_ids=resolved_targets,
         label="Shared photo",
+        work=_work,
+    )
+
+
+# -- History -------------------------------------------------------------
+
+
+def _history_label(row: EventRow) -> str:
+    """Resolve the same friendly target labels the admin History page uses."""
+    if row.source == "button":
+        device = _devices().get(row.target)
+        if device is not None and device.kind_of is not None:
+            return device.display_name
+    page = _pages().get(row.target)
+    if page is not None:
+        return page.name or page.id
+    return row.target or row.source
+
+
+def _history_row(history_id: str) -> EventRow | None:
+    try:
+        event_id = parse_history_id(history_id)
+    except InvalidHistoryCursor:
+        return None
+    row = _events().get(event_id)
+    return row if row is not None and row.type == "push" else None
+
+
+@bp.get("/history")
+@_require_companion("devices:read")
+def get_history() -> Any:
+    before_id = request.args.get("before_id")
+    raw_limit = request.args.get("limit")
+    limit = DEFAULT_HISTORY_LIMIT
+    if raw_limit is not None:
+        try:
+            limit = int(raw_limit)
+        except ValueError:
+            return _error("invalid_request", "limit must be an integer from 1 to 100.", 400)
+        if limit < 1 or limit > MAX_HISTORY_LIMIT:
+            return _error("invalid_request", "limit must be an integer from 1 to 100.", 400)
+    try:
+        body = list_history(
+            _events(),
+            Path(current_app.config["RENDERS_DIR"]),
+            before_id=before_id,
+            limit=limit,
+            label_resolver=_history_label,
+        )
+    except InvalidHistoryCursor:
+        return _error("invalid_request", "before_id is not a valid History cursor.", 400)
+    return jsonify(body)
+
+
+@bp.get("/history/<history_id>/preview")
+@_require_companion("devices:read")
+def history_preview(history_id: str) -> Any:
+    retained = retained_composition_for_history(
+        _events(),
+        Path(current_app.config["RENDERS_DIR"]),
+        history_id,
+    )
+    if retained is None:
+        return _error("not_found", "No retained preview for that History row.", 404)
+    if request.if_none_match and retained.etag in request.if_none_match:
+        resp = current_app.response_class(status=304)
+    else:
+        try:
+            payload = retained.path.read_bytes()
+        except OSError:
+            return _error("not_found", "The retained preview is no longer available.", 404)
+        resp = current_app.response_class(payload, mimetype="image/png")
+    resp.set_etag(retained.etag)
+    resp.headers["Cache-Control"] = "private, no-cache"
+    return resp
+
+
+@bp.post("/history/<history_id>/resend")
+@_require_companion("push:write")
+def resend_history(history_id: str) -> Any:
+    key, err = _require_idempotency_key()
+    if err is not None:
+        return err
+    assert key is not None
+
+    raw = request.get_data(cache=True)
+    body = request.get_json(silent=True)
+    if (
+        not isinstance(body, dict)
+        or set(body) != {"override_quiet_hours"}
+        or not isinstance(body.get("override_quiet_hours"), bool)
+    ):
+        return _error("invalid_request", "override_quiet_hours (boolean) is required.", 400)
+
+    row = _history_row(history_id)
+    if row is None:
+        return _error("not_found", "No History row with that id.", 404)
+    retained = retained_resend_composition_for_row(
+        row,
+        Path(current_app.config["RENDERS_DIR"]),
+    )
+    original_targets = list(
+        dict.fromkeys(
+            value for value in row.extra.get("device_ids", []) if isinstance(value, str) and value
+        )
+    )
+    if retained is None or not original_targets:
+        return _error(
+            "not_resendable",
+            "The original composition or target snapshot is no longer available.",
+            409,
+        )
+    targets = _valid_target_ids(original_targets)
+    if targets is None:
+        return _error(
+            "not_resendable",
+            "One or more original target displays are no longer available.",
+            409,
+        )
+
+    override = bool(body["override_quiet_hours"])
+    event_id = row.id
+    resolved_targets = list(targets)
+
+    def _work() -> JobOutcome:
+        active, _quiet = _partition_quiet(resolved_targets, override=override)
+        if not active:
+            return JobOutcome.quiet(resolved_targets, "all_targets_in_quiet_hours")
+        manager = _push_manager()
+        if manager is None:
+            return JobOutcome.failed("temporarily_unavailable", "The push pipeline is offline.")
+        result = manager.republish(event_id, device_ids=set(active))
+        if result.status in _PUBLISHED_STATUSES:
+            return JobOutcome.published(
+                active,
+                history_event_ids=_history_event_ids(result),
+            )
+        return JobOutcome.failed("render_failed", result.error or f"resend {result.status}")
+
+    return _reserve_and_run(
+        kind="history_resend",
+        key=key,
+        payload=raw,
+        target_ids=resolved_targets,
+        label=_history_label(row),
         work=_work,
     )
 

--- a/app/companion_history.py
+++ b/app/companion_history.py
@@ -1,0 +1,222 @@
+"""Read-only adapter from the internal EventLog to Companion History.
+
+The admin History page and the Companion API intentionally read the same
+canonical ``type="push"`` rows.  This module keeps the wire shaping and
+retained-composition lookup independent from Flask so routes can stay small
+and the retention behaviour is testable without an application context.
+
+History rows outlive render artifacts.  Once a composition PNG has been
+pruned, the row remains visible but both ``preview_available`` and
+``resendable`` become false.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from app.state.event_log import EventLog, EventRow
+
+DEFAULT_HISTORY_LIMIT = 30
+MAX_HISTORY_LIMIT = 100
+
+_DIGEST_RE = re.compile(r"^[0-9a-fA-F]{16,64}$")
+_IMAGE_FIT_MODES = frozenset(("fit", "fill", "blur", "stretch", "center"))
+
+HistoryLabelResolver = Callable[[EventRow], str]
+
+
+class InvalidHistoryCursor(ValueError):
+    """Raised when a client supplies a cursor outside this server's format."""
+
+
+@dataclass(frozen=True)
+class RetainedComposition:
+    """A safe, retained composition artifact for a canonical History row."""
+
+    path: Path
+    etag: str
+
+
+def parse_history_id(raw: str | int) -> int:
+    """Parse the current EventLog-backed opaque id.
+
+    The public contract treats ids as opaque strings so a future server can
+    change its storage without changing clients.  This implementation uses
+    positive SQLite row ids and deliberately rejects signs, whitespace and
+    alternate numeric spellings.
+    """
+
+    value = str(raw)
+    if not value.isascii() or not value.isdecimal() or value.startswith("0"):
+        raise InvalidHistoryCursor("history id must be a positive decimal row id")
+    event_id = int(value)
+    if event_id <= 0:
+        raise InvalidHistoryCursor("history id must be a positive decimal row id")
+    return event_id
+
+
+def list_history(
+    event_log: EventLog,
+    renders_dir: Path,
+    *,
+    before_id: str | None = None,
+    limit: int = DEFAULT_HISTORY_LIMIT,
+    label_resolver: HistoryLabelResolver | None = None,
+) -> dict[str, Any]:
+    """Return one contract-shaped page of canonical push History.
+
+    The response page is always clamped to 1...100.  One extra row determines
+    whether a next cursor exists without counting or scanning the full log.
+    """
+
+    cursor = parse_history_id(before_id) if before_id is not None else None
+    page_limit = max(1, min(int(limit), MAX_HISTORY_LIMIT))
+
+    rows = event_log.list(type="push", before_id=cursor, limit=page_limit + 1)
+
+    has_more = len(rows) > page_limit
+    selected = rows[:page_limit]
+    items = [
+        history_item(
+            row,
+            renders_dir,
+            label_resolver=label_resolver,
+        )
+        for row in selected
+    ]
+    next_before_id = str(selected[-1].id) if has_more and selected else None
+    return {"items": items, "next_before_id": next_before_id}
+
+
+def history_item(
+    row: EventRow,
+    renders_dir: Path,
+    *,
+    label_resolver: HistoryLabelResolver | None = None,
+) -> dict[str, Any]:
+    """Shape one canonical push row for the Companion 0.4 contract."""
+
+    preview = retained_composition_for_row(row, renders_dir)
+    resend = retained_resend_composition_for_row(row, renders_dir)
+    fit = _fit_mode(row.extra)
+    label = label_resolver(row) if label_resolver is not None else row.target
+    if not isinstance(label, str) or not label:
+        label = row.target or row.source
+
+    return {
+        "id": str(row.id),
+        "created_at": _utc_timestamp(row.timestamp),
+        "source": row.source,
+        "label": label,
+        "device_ids": _device_ids(row.extra),
+        "status": row.status,
+        "duration_seconds": max(0.0, row.duration_s),
+        "error": row.error,
+        "preview_available": preview is not None,
+        "resendable": resend is not None,
+        "fit": fit,
+    }
+
+
+def retained_composition_for_history(
+    event_log: EventLog,
+    renders_dir: Path,
+    history_id: str | int,
+) -> RetainedComposition | None:
+    """Locate a canonical row's preview PNG, or return None when unavailable."""
+
+    try:
+        event_id = parse_history_id(history_id)
+    except InvalidHistoryCursor:
+        return None
+    row = event_log.get(event_id)
+    if row is None or row.type != "push":
+        return None
+    return retained_composition_for_row(row, renders_dir)
+
+
+def retained_composition_for_row(
+    row: EventRow,
+    renders_dir: Path,
+) -> RetainedComposition | None:
+    """Locate the preview composition for a row.
+
+    Normal pushes keep the composition digest in ``digest``.  Preview-only
+    button/fetch rows intentionally leave that field empty and snapshot a
+    ``composition_digest`` in ``extra``; those may be viewed but not resent.
+    """
+
+    digest = _nonempty_string(row.digest)
+    if digest is None:
+        digest = _nonempty_string(row.extra.get("composition_digest"))
+    return retained_composition(renders_dir, digest)
+
+
+def retained_resend_composition_for_row(
+    row: EventRow,
+    renders_dir: Path,
+) -> RetainedComposition | None:
+    """Locate the artifact that makes this row resendable.
+
+    Only the top-level digest carries resend/source identity.  A preview-only
+    ``extra.composition_digest`` must never silently become resendable.
+    Companion V1 also promises a faithful resend to the original target
+    snapshot, so legacy rows without ``device_ids`` remain previewable but are
+    not exposed as resendable.
+    """
+
+    if not _device_ids(row.extra):
+        return None
+    return retained_composition(renders_dir, _nonempty_string(row.digest))
+
+
+def retained_composition(
+    renders_dir: Path,
+    digest: str | None,
+) -> RetainedComposition | None:
+    """Resolve ``<digest>.png`` without permitting traversal or symlink escape."""
+
+    if digest is None or _DIGEST_RE.fullmatch(digest) is None:
+        return None
+
+    root = renders_dir.resolve()
+    candidate = root / f"{digest}.png"
+    try:
+        if candidate.is_symlink():
+            return None
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(root)
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+    if not resolved.is_file():
+        return None
+    return RetainedComposition(path=resolved, etag=digest.lower())
+
+
+def _fit_mode(extra: dict[str, Any]) -> str | None:
+    # Current pushes store ``fit``. Read the earlier ``image_fit`` spelling
+    # first so retained development rows remain useful after upgrading.
+    raw = extra.get("image_fit")
+    if raw is None:
+        raw = extra.get("fit")
+    return raw if isinstance(raw, str) and raw in _IMAGE_FIT_MODES else None
+
+
+def _device_ids(extra: dict[str, Any]) -> list[str]:
+    raw = extra.get("device_ids")
+    if not isinstance(raw, list):
+        return []
+    return list(dict.fromkeys(value for value in raw if isinstance(value, str) and value))
+
+
+def _nonempty_string(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _utc_timestamp(epoch: float) -> str:
+    return datetime.fromtimestamp(epoch, tz=UTC).isoformat().replace("+00:00", "Z")

--- a/app/companion_jobs.py
+++ b/app/companion_jobs.py
@@ -39,13 +39,26 @@ class JobOutcome:
     ok: bool
     result_status: ResultStatus = "published"
     device_ids: tuple[str, ...] = ()
+    history_event_ids: tuple[str, ...] | None = None
     reason: str | None = None
     code: str = ""
     message: str = ""
 
     @classmethod
-    def published(cls, device_ids: list[str]) -> JobOutcome:
-        return cls(ok=True, result_status="published", device_ids=tuple(device_ids))
+    def published(
+        cls,
+        device_ids: list[str],
+        *,
+        history_event_ids: list[str] | None = None,
+    ) -> JobOutcome:
+        return cls(
+            ok=True,
+            result_status="published",
+            device_ids=tuple(device_ids),
+            history_event_ids=(
+                tuple(dict.fromkeys(history_event_ids)) if history_event_ids is not None else None
+            ),
+        )
 
     @classmethod
     def quiet(cls, device_ids: list[str], reason: str) -> JobOutcome:
@@ -86,6 +99,11 @@ class CompanionJobs:
                 result_status=outcome.result_status,
                 device_ids=list(outcome.device_ids),
                 reason=outcome.reason,
+                history_event_ids=(
+                    list(outcome.history_event_ids)
+                    if outcome.history_event_ids is not None
+                    else None
+                ),
             )
         else:
             self._jobs.mark_failed(job_id, code=outcome.code, message=outcome.message)

--- a/app/push.py
+++ b/app/push.py
@@ -94,6 +94,7 @@ from app.transport import MqttTransport
 # hundred KB).
 _PRECOMPOSE_TTL_S = 60.0
 _PRECOMPOSE_CAP = 6
+_IMAGE_FIT_MODES = frozenset({"fit", "fill", "blur", "stretch", "center"})
 
 
 def _resolve_full_profile(
@@ -1377,10 +1378,20 @@ class PushManager:
         self._notify(result)
         return result
 
-    def republish(self, event_id: int) -> PushResult:
+    def republish(
+        self,
+        event_id: int,
+        *,
+        device_ids: set[str] | None = None,
+    ) -> PushResult:
         """Re-publish a past push from its stored composition PNG. No
         re-render, no re-download. Records a new event row tagged
-        ``source="resend"`` so history keeps the link to the original."""
+        ``source="resend"`` so history keeps the link to the original.
+
+        ``device_ids`` optionally narrows the original target snapshot. The
+        Companion resend route uses that to respect per-device quiet hours;
+        callers that omit it retain the History page's existing behaviour.
+        """
         record = self._event_log.get(event_id)
         if record is None:
             result = PushResult(status="not_found", page_id="", error="history record not found")
@@ -1408,9 +1419,28 @@ class PushManager:
                 # device's latest-render entry never updates and its
                 # /frame poll keeps 304-ing on the OLD frame (#119).
                 extra = record.extra if isinstance(record.extra, dict) else {}
-                device_ids = [
+                original_device_ids = [
                     d for d in (extra.get("device_ids") or []) if isinstance(d, str) and d
                 ]
+                if device_ids is not None:
+                    selected_ids = [d for d in original_device_ids if d in device_ids]
+                    if not selected_ids:
+                        result = PushResult(
+                            status="failed",
+                            page_id=record.target,
+                            composition_digest=record.digest,
+                            error="no original targets remain eligible for resend",
+                        )
+                        self._notify(result)
+                        return result
+                else:
+                    selected_ids = original_device_ids
+                fit_candidate = extra.get("fit", extra.get("image_fit"))
+                original_fit = (
+                    fit_candidate
+                    if isinstance(fit_candidate, str) and fit_candidate in _IMAGE_FIT_MODES
+                    else None
+                )
                 # Republish is a user-initiated resend from the History
                 # page; treat it as user intent (bypass coalescing) so
                 # the user's re-send never gets silently superseded.
@@ -1428,11 +1458,12 @@ class PushManager:
                     # virtual panel, same as the original unbound push).
                     result = self._fan_out(
                         comp_path.read_bytes(),
-                        self._panel_dims_for_send(device_ids[0] if device_ids else None),
+                        self._panel_dims_for_send(selected_ids[0] if selected_ids else None),
                         source="resend",
                         target=record.target,
                         started=time.monotonic(),
-                        device_filters=set(device_ids) if device_ids else None,
+                        device_filters=set(selected_ids) if selected_ids else None,
+                        image_fit=original_fit,
                         force_publish=True,
                         force_client_refetch=True,
                     )
@@ -2016,6 +2047,12 @@ class PushManager:
                 }
                 - {""}
             )
+        event_extra: dict[str, Any] = {
+            "renderers": [asdict(r) for r in results],
+            "device_ids": targeted_ids,
+        }
+        if image_fit in _IMAGE_FIT_MODES:
+            event_extra["fit"] = image_fit
         event_id = self._event_log.record(
             type="push",
             source=source,
@@ -2024,10 +2061,7 @@ class PushManager:
             digest=comp_digest,
             error=error,
             duration_s=duration,
-            extra={
-                "renderers": [asdict(r) for r in results],
-                "device_ids": targeted_ids,
-            },
+            extra=event_extra,
         )
 
         # Roll the orphan-render sweep on a cadence (the just-written

--- a/app/state/event_log.py
+++ b/app/state/event_log.py
@@ -290,6 +290,7 @@ class EventLog:
         *,
         type: str | None = None,
         source: str | None = None,
+        before_id: int | None = None,
         exclude_statuses: tuple[str, ...] | None = None,
         limit: int = 100,
     ) -> list[EventRow]:
@@ -302,6 +303,9 @@ class EventLog:
         if source is not None:
             clauses.append("source = ?")
             params.append(source)
+        if before_id is not None:
+            clauses.append("id < ?")
+            params.append(before_id)
         if exclude_statuses:
             placeholders = ",".join("?" * len(exclude_statuses))
             clauses.append(f"status NOT IN ({placeholders})")

--- a/app/state/job_store.py
+++ b/app/state/job_store.py
@@ -1,9 +1,9 @@
 """Async job records for the Companion API write routes.
 
-A companion dashboard push or image push takes 5-15 seconds to render and
-publish, longer than an iOS Share Extension survives, so the write routes
-return ``202 accepted`` with a persisted job the client polls at
-``GET /api/app/v1/jobs/{id}`` until it reaches a terminal state.
+A companion dashboard push, image push, or history resend takes 5-15
+seconds to render and publish, longer than an iOS Share Extension survives,
+so the write routes return ``202 accepted`` with a persisted job the client
+polls at ``GET /api/app/v1/jobs/{id}`` until it reaches a terminal state.
 
 Two orthogonal axes, kept deliberately separate (discussion #147):
 
@@ -35,7 +35,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
-JobKind = Literal["dashboard_push", "image_push"]
+JobKind = Literal["dashboard_push", "image_push", "history_resend"]
 JobStatus = Literal["accepted", "running", "succeeded", "failed"]
 ResultStatus = Literal["published", "quiet"]
 
@@ -148,15 +148,23 @@ class JobStore:
         result_status: ResultStatus,
         device_ids: list[str],
         reason: str | None = None,
+        history_event_ids: list[str] | None = None,
     ) -> None:
+        result: dict[str, Any] = {
+            "status": result_status,
+            "reason": reason,
+            "device_ids": list(device_ids),
+        }
+        # Optional so persisted jobs written before Companion 0.4 retain
+        # exactly their old public shape. New write paths include the IDs
+        # only when the server can correlate a terminal job with the
+        # canonical EventLog rows it created.
+        if history_event_ids is not None:
+            result["history_event_ids"] = list(dict.fromkeys(history_event_ids))
         self._transition(
             job_id,
             status="succeeded",
-            result={
-                "status": result_status,
-                "reason": reason,
-                "device_ids": list(device_ids),
-            },
+            result=result,
         )
 
     def mark_failed(self, job_id: str, *, code: str, message: str) -> None:

--- a/tests/companion/_schema.py
+++ b/tests/companion/_schema.py
@@ -1,5 +1,5 @@
 """Shared helpers for validating Companion API payloads against the
-vendored OpenAPI 0.2.0 contract.
+vendored OpenAPI 0.4.0 contract.
 
 The spec + fixtures under ``contract/`` are a verbatim copy of
 ``charmmmz/tesserae-companion-ios`` ``Contracts/``. Keeping them in-tree

--- a/tests/companion/contract/Fixtures/capabilities-extended.json
+++ b/tests/companion/contract/Fixtures/capabilities-extended.json
@@ -1,0 +1,43 @@
+{
+  "product": "tesserae",
+  "server_version": "0.210.0",
+  "api": {
+    "name": "companion",
+    "version": 1
+  },
+  "pairing": {
+    "supported": true,
+    "code_length": 6,
+    "ttl_seconds": 600
+  },
+  "features": [
+    "devices",
+    "dashboards",
+    "dashboard_push",
+    "image_push",
+    "jobs",
+    "previews",
+    "history"
+  ],
+  "limits": {
+    "image_upload_bytes": 26214400,
+    "image_max_edge": 8192,
+    "image_content_types": [
+      "image/jpeg",
+      "image/png",
+      "image/heic",
+      "image/heif",
+      "image/webp"
+    ],
+    "image_fit_modes": [
+      "fit",
+      "fill",
+      "blur",
+      "stretch",
+      "center"
+    ],
+    "job_retention_seconds": 86400,
+    "idempotency_retention_seconds": 86400
+  },
+  "web_url": "/"
+}

--- a/tests/companion/contract/Fixtures/capabilities-previews.json
+++ b/tests/companion/contract/Fixtures/capabilities-previews.json
@@ -1,0 +1,35 @@
+{
+  "product": "tesserae",
+  "server_version": "0.208.0",
+  "api": {
+    "name": "companion",
+    "version": 1
+  },
+  "pairing": {
+    "supported": true,
+    "code_length": 6,
+    "ttl_seconds": 600
+  },
+  "features": [
+    "devices",
+    "dashboards",
+    "dashboard_push",
+    "image_push",
+    "jobs",
+    "previews"
+  ],
+  "limits": {
+    "image_upload_bytes": 26214400,
+    "image_max_edge": 8192,
+    "image_content_types": [
+      "image/jpeg",
+      "image/png",
+      "image/heic",
+      "image/heif",
+      "image/webp"
+    ],
+    "job_retention_seconds": 86400,
+    "idempotency_retention_seconds": 86400
+  },
+  "web_url": "/"
+}

--- a/tests/companion/contract/Fixtures/history-resend-request.json
+++ b/tests/companion/contract/Fixtures/history-resend-request.json
@@ -1,0 +1,3 @@
+{
+  "override_quiet_hours": false
+}

--- a/tests/companion/contract/Fixtures/history-response.json
+++ b/tests/companion/contract/Fixtures/history-response.json
@@ -1,0 +1,35 @@
+{
+  "items": [
+    {
+      "id": "history_0102",
+      "created_at": "2026-07-29T00:12:08Z",
+      "source": "companion",
+      "label": "Shared photo",
+      "device_ids": [
+        "e1004-desk"
+      ],
+      "status": "sent",
+      "duration_seconds": 8.2,
+      "error": null,
+      "preview_available": true,
+      "resendable": true,
+      "fit": "blur"
+    },
+    {
+      "id": "history_0101",
+      "created_at": "2026-07-28T23:45:00Z",
+      "source": "scheduler",
+      "label": "Pantry",
+      "device_ids": [
+        "picpak-kitchen"
+      ],
+      "status": "sent",
+      "duration_seconds": 2.4,
+      "error": null,
+      "preview_available": true,
+      "resendable": true,
+      "fit": null
+    }
+  ],
+  "next_before_id": "history_0100"
+}

--- a/tests/companion/contract/Fixtures/image-push-request.json
+++ b/tests/companion/contract/Fixtures/image-push-request.json
@@ -2,6 +2,6 @@
   "device_ids": [
     "picpak-kitchen"
   ],
-  "fit": "fill",
+  "fit": "blur",
   "override_quiet_hours": false
 }

--- a/tests/companion/contract/Fixtures/job-history-resend.json
+++ b/tests/companion/contract/Fixtures/job-history-resend.json
@@ -1,0 +1,24 @@
+{
+  "job": {
+    "id": "job_01JRESEND",
+    "kind": "history_resend",
+    "status": "succeeded",
+    "label": "Shared photo",
+    "target_device_ids": [
+      "e1004-desk"
+    ],
+    "created_at": "2026-07-29T00:15:00Z",
+    "updated_at": "2026-07-29T00:15:07Z",
+    "result": {
+      "status": "published",
+      "reason": null,
+      "device_ids": [
+        "e1004-desk"
+      ],
+      "history_event_ids": [
+        "history_0103"
+      ]
+    },
+    "error": null
+  }
+}

--- a/tests/companion/contract/app-v1.openapi.yaml
+++ b/tests/companion/contract/app-v1.openapi.yaml
@@ -1,10 +1,11 @@
 openapi: 3.0.3
 info:
   title: Tesserae Companion API
-  version: 0.2.0
+  version: 0.4.0
   description: >-
-    Proposed minimal stable API for community-built companion clients. This
-    document is a contract proposal, not evidence that an endpoint is deployed.
+    Companion API contract for community-built clients. Previews, History,
+    resend, and server-advertised image fit modes are optional additive
+    extensions over the five-feature compatibility floor.
 servers:
   - url: /
 tags:
@@ -14,6 +15,7 @@ tags:
   - name: Dashboards
   - name: Images
   - name: Jobs
+  - name: History
 paths:
   /api/app/v1:
     get:
@@ -75,6 +77,38 @@ paths:
                 $ref: "#/components/schemas/DevicesResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
+  /api/app/v1/devices/{device_id}/preview:
+    parameters:
+      - $ref: "#/components/parameters/DeviceID"
+    get:
+      tags: [Displays]
+      operationId: getCompanionDevicePreview
+      summary: Read the latest device-specific viewable preview
+      parameters:
+        - $ref: "#/components/parameters/IfNoneMatch"
+      responses:
+        "200":
+          description: >-
+            Latest viewable PNG after image fit and device geometry have been
+            applied. Renderer-specific palette and quantisation should be
+            represented when a reusable PNG can be produced from that stage.
+          headers:
+            ETag:
+              $ref: "#/components/headers/ETag"
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+        "304":
+          description: The cached device preview is still current
+          headers:
+            ETag:
+              $ref: "#/components/headers/ETag"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/app/v1/dashboards:
     get:
       tags: [Dashboards]
@@ -89,6 +123,51 @@ paths:
                 $ref: "#/components/schemas/DashboardsResponse"
         "401":
           $ref: "#/components/responses/Unauthorized"
+  /api/app/v1/dashboards/{dashboard_id}/preview:
+    parameters:
+      - $ref: "#/components/parameters/DashboardID"
+    get:
+      tags: [Dashboards]
+      operationId: getCompanionDashboardPreview
+      summary: Read or asynchronously prepare a cached dashboard preview
+      parameters:
+        - $ref: "#/components/parameters/IfNoneMatch"
+        - in: query
+          name: device_id
+          required: false
+          description: Optional target display whose panel dimensions should be used
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Cached dashboard composition PNG
+          headers:
+            ETag:
+              $ref: "#/components/headers/ETag"
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+        "202":
+          description: A background preview render has been accepted
+          headers:
+            Retry-After:
+              description: Suggested retry delay in seconds
+              schema:
+                type: integer
+                minimum: 1
+        "304":
+          description: The cached composition is still current
+          headers:
+            ETag:
+              $ref: "#/components/headers/ETag"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/app/v1/dashboards/{dashboard_id}/push:
     parameters:
       - $ref: "#/components/parameters/DashboardID"
@@ -183,6 +262,95 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+  /api/app/v1/history:
+    get:
+      tags: [History]
+      operationId: listCompanionHistory
+      summary: List canonical server push History, newest first
+      parameters:
+        - in: query
+          name: before_id
+          required: false
+          description: Opaque cursor returned as next_before_id by the previous page
+          schema:
+            type: string
+        - in: query
+          name: limit
+          required: false
+          description: Requested page size, bounded by the server
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 30
+      responses:
+        "200":
+          description: Canonical push History page
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HistoryResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+  /api/app/v1/history/{history_id}/preview:
+    parameters:
+      - $ref: "#/components/parameters/HistoryID"
+    get:
+      tags: [History]
+      operationId: getCompanionHistoryPreview
+      summary: Read the retained composition thumbnail for a History row
+      parameters:
+        - $ref: "#/components/parameters/IfNoneMatch"
+      responses:
+        "200":
+          description: >-
+            Stored composition PNG identifying what was sent. This is not a
+            device-final preview.
+          headers:
+            ETag:
+              $ref: "#/components/headers/ETag"
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+        "304":
+          description: The cached History composition is still current
+          headers:
+            ETag:
+              $ref: "#/components/headers/ETag"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/app/v1/history/{history_id}/resend:
+    parameters:
+      - $ref: "#/components/parameters/HistoryID"
+    post:
+      tags: [History]
+      operationId: resendCompanionHistory
+      summary: Republish a retained composition to its original target snapshot
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HistoryResendRequest"
+      responses:
+        "202":
+          $ref: "#/components/responses/JobAccepted"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
 components:
   securitySchemes:
     CompanionBearer:
@@ -190,6 +358,12 @@ components:
       scheme: bearer
       bearerFormat: opaque
   parameters:
+    DeviceID:
+      in: path
+      name: device_id
+      required: true
+      schema:
+        type: string
     DashboardID:
       in: path
       name: dashboard_id
@@ -199,6 +373,12 @@ components:
     JobID:
       in: path
       name: job_id
+      required: true
+      schema:
+        type: string
+    HistoryID:
+      in: path
+      name: history_id
       required: true
       schema:
         type: string
@@ -214,6 +394,18 @@ components:
         type: string
         minLength: 16
         maxLength: 128
+    IfNoneMatch:
+      in: header
+      name: If-None-Match
+      required: false
+      description: ETag from a previously returned preview
+      schema:
+        type: string
+  headers:
+    ETag:
+      description: Content-addressed preview validator
+      schema:
+        type: string
   responses:
     JobAccepted:
       description: Job persisted for asynchronous execution
@@ -296,7 +488,7 @@ components:
           uniqueItems: true
           items:
             type: string
-            enum: [devices, dashboards, dashboard_push, image_push, jobs]
+            enum: [devices, dashboards, dashboard_push, image_push, jobs, previews, history]
         limits:
           $ref: "#/components/schemas/Limits"
         web_url:
@@ -329,6 +521,15 @@ components:
               - image/heic
               - image/heif
               - image/webp
+        image_fit_modes:
+          description: >-
+            Image layout modes accepted by POST /images. When absent, clients
+            must assume only fit and fill for compatibility with contract 0.2.0.
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/ImageFitMode"
         job_retention_seconds:
           type: integer
           minimum: 60
@@ -514,8 +715,79 @@ components:
           items:
             type: string
         fit:
+          $ref: "#/components/schemas/ImageFitMode"
+        override_quiet_hours:
+          type: boolean
+          default: false
+    ImageFitMode:
+      type: string
+      enum: [fit, fill, blur, stretch, center]
+    HistoryResponse:
+      type: object
+      additionalProperties: false
+      required: [items, next_before_id]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/HistoryItem"
+        next_before_id:
+          description: Opaque cursor for the next older page, or null at the end
           type: string
-          enum: [fit, fill]
+          nullable: true
+    HistoryItem:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - created_at
+        - source
+        - label
+        - device_ids
+        - status
+        - preview_available
+        - resendable
+      properties:
+        id:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        source:
+          description: Stable server source identifier, additive over time
+          type: string
+        label:
+          type: string
+        device_ids:
+          description: Snapshot of the original delivery targets
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+        status:
+          description: Stable push outcome identifier, additive over time
+          type: string
+        duration_seconds:
+          type: number
+          minimum: 0
+          nullable: true
+        error:
+          type: string
+          nullable: true
+        preview_available:
+          type: boolean
+        resendable:
+          type: boolean
+        fit:
+          description: Original image fit mode when the source was arbitrary media
+          allOf:
+            - $ref: "#/components/schemas/ImageFitMode"
+          nullable: true
+    HistoryResendRequest:
+      type: object
+      additionalProperties: false
+      required: [override_quiet_hours]
+      properties:
         override_quiet_hours:
           type: boolean
           default: false
@@ -541,7 +813,7 @@ components:
           type: string
         kind:
           type: string
-          enum: [dashboard_push, image_push]
+          enum: [dashboard_push, image_push, history_resend]
         status:
           description: Execution lifecycle only; quiet is a successful result
           type: string
@@ -584,6 +856,14 @@ components:
           uniqueItems: true
           items:
             type: string
+        history_event_ids:
+          description: >-
+            Optional exact correlation to canonical History rows produced by
+            this job. Clients may otherwise refresh History after termination.
+          type: array
+          uniqueItems: true
+          items:
+            type: string
     JobFailure:
       type: object
       additionalProperties: false
@@ -615,6 +895,7 @@ components:
                 - unsupported_image
                 - image_too_large
                 - idempotency_conflict
+                - not_resendable
                 - temporarily_unavailable
             message:
               type: string

--- a/tests/companion/test_companion_api.py
+++ b/tests/companion/test_companion_api.py
@@ -18,6 +18,7 @@ import jsonschema
 import pytest
 from flask import Flask
 
+from app import companion_api
 from app.main import REPO_ROOT, create_app
 from app.state.page_store import Page
 
@@ -100,9 +101,9 @@ def _seed_page(app: Flask, device_id: str) -> str:
 
 
 def test_capabilities_probe_is_unauthenticated_and_valid(app: Flask) -> None:
-    # Validate against the frozen 0.2.0 contract, whose features enum is the
-    # five baseline surfaces. The additive `previews` feature (gated on the
-    # browser pool) is covered separately in test_companion_previews.
+    # The additive `previews` feature is gated on the browser pool and covered
+    # separately in test_companion_previews. Canonical History is available
+    # whenever Companion 0.4 is served.
     app.config["BROWSER_POOL"] = None
     resp = app.test_client().get("/api/app/v1")
     assert resp.status_code == 200
@@ -120,7 +121,9 @@ def test_capabilities_probe_is_unauthenticated_and_valid(app: Flask) -> None:
         "dashboard_push",
         "image_push",
         "jobs",
+        "history",
     }
+    assert body["limits"]["image_fit_modes"] == list(companion_api.IMAGE_FIT_MODES)
     # No household content leaks from the unauthenticated probe.
     assert "devices" not in body and "dashboards" not in body
 

--- a/tests/companion/test_companion_history.py
+++ b/tests/companion/test_companion_history.py
@@ -1,0 +1,247 @@
+"""Unit tests for the EventLog-backed Companion History adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.companion_history import (
+    MAX_HISTORY_LIMIT,
+    InvalidHistoryCursor,
+    history_item,
+    list_history,
+    parse_history_id,
+    retained_composition,
+    retained_composition_for_history,
+)
+from app.state.event_log import EventLog
+
+_DIGEST_A = "0123456789abcdef"
+_DIGEST_B = "fedcba9876543210"
+
+
+def _log(tmp_path: Path, *, cap: int = 500) -> EventLog:
+    return EventLog(tmp_path / "events.db", cap=cap)
+
+
+def _retain(renders_dir: Path, digest: str, payload: bytes = b"\x89PNG\r\n") -> Path:
+    renders_dir.mkdir(parents=True, exist_ok=True)
+    path = renders_dir / f"{digest}.png"
+    path.write_bytes(payload)
+    return path
+
+
+def test_list_is_newest_first_push_only_and_contract_shaped(tmp_path: Path) -> None:
+    log = _log(tmp_path)
+    renders = tmp_path / "renders"
+    _retain(renders, _DIGEST_A)
+    first = log.record(
+        type="push",
+        source="page",
+        target="pantry",
+        status="sent",
+        digest=_DIGEST_A,
+        duration_s=2.4,
+        extra={"device_ids": ["kitchen", "kitchen"], "image_fit": "blur"},
+    )
+    log.record(type="renderer", source="pi_bin", target="topic", status="sent")
+    second = log.record(
+        type="push",
+        source="companion",
+        target="Shared photo",
+        status="failed",
+        error="panel unavailable",
+        duration_s=-1,
+        extra={"device_ids": ["desk", 42, ""], "fit": "center"},
+    )
+
+    body = list_history(
+        log,
+        renders,
+        label_resolver=lambda row: (
+            f"Dashboard: {row.target}" if row.source == "page" else row.target
+        ),
+    )
+
+    assert [item["id"] for item in body["items"]] == [str(second), str(first)]
+    assert body["next_before_id"] is None
+    latest, oldest = body["items"]
+    assert latest == {
+        "id": str(second),
+        "created_at": latest["created_at"],
+        "source": "companion",
+        "label": "Shared photo",
+        "device_ids": ["desk"],
+        "status": "failed",
+        "duration_seconds": 0.0,
+        "error": "panel unavailable",
+        "preview_available": False,
+        "resendable": False,
+        "fit": "center",
+    }
+    assert latest["created_at"].endswith("Z")
+    assert oldest["label"] == "Dashboard: pantry"
+    assert oldest["device_ids"] == ["kitchen"]
+    assert oldest["preview_available"] is True
+    assert oldest["resendable"] is True
+    assert oldest["fit"] == "blur"
+
+
+def test_before_id_pages_without_overlap_and_limit_is_bounded(tmp_path: Path) -> None:
+    log = _log(tmp_path, cap=MAX_HISTORY_LIMIT + 20)
+    renders = tmp_path / "renders"
+    ids = [
+        log.record(type="push", source="page", target=f"page-{index}", status="sent")
+        for index in range(MAX_HISTORY_LIMIT + 5)
+    ]
+
+    first = list_history(log, renders, limit=MAX_HISTORY_LIMIT + 500)
+    assert len(first["items"]) == MAX_HISTORY_LIMIT
+    assert first["next_before_id"] == str(ids[5])
+
+    second = list_history(log, renders, before_id=first["next_before_id"], limit=3)
+    assert [item["id"] for item in second["items"]] == [
+        str(ids[4]),
+        str(ids[3]),
+        str(ids[2]),
+    ]
+    assert second["next_before_id"] == str(ids[2])
+
+    final = list_history(log, renders, before_id=second["next_before_id"], limit=10)
+    assert [item["id"] for item in final["items"]] == [str(ids[1]), str(ids[0])]
+    assert final["next_before_id"] is None
+
+
+def test_event_log_before_id_filters_in_sql_and_preserves_other_filters(tmp_path: Path) -> None:
+    log = _log(tmp_path)
+    first = log.record(type="push", source="page", target="one", status="sent")
+    log.record(type="renderer", source="page", target="not-a-push", status="sent")
+    second = log.record(type="push", source="page", target="two", status="sent")
+    log.record(type="push", source="file", target="other-source", status="sent")
+
+    rows = log.list(type="push", source="page", before_id=second, limit=10)
+
+    assert [row.id for row in rows] == [first]
+
+
+@pytest.mark.parametrize("raw", ["", "0", "-1", "+1", " 1", "01", "1.0", "one"])
+def test_history_cursor_rejects_noncanonical_values(raw: str) -> None:
+    with pytest.raises(InvalidHistoryCursor):
+        parse_history_id(raw)
+
+
+def test_preview_only_composition_is_visible_but_not_resendable(tmp_path: Path) -> None:
+    log = _log(tmp_path)
+    renders = tmp_path / "renders"
+    path = _retain(renders, _DIGEST_B)
+    event_id = log.record(
+        type="push",
+        source="button",
+        target="kitchen",
+        status="fetched",
+        digest=None,
+        extra={"composition_digest": _DIGEST_B, "device_ids": ["kitchen"]},
+    )
+    row = log.get(event_id)
+    assert row is not None
+
+    item = history_item(row, renders)
+    preview = retained_composition_for_history(log, renders, str(event_id))
+
+    assert item["preview_available"] is True
+    assert item["resendable"] is False
+    assert preview is not None
+    assert preview.path == path.resolve()
+    assert preview.etag == _DIGEST_B
+
+
+def test_missing_original_target_snapshot_disables_only_resend(tmp_path: Path) -> None:
+    log = _log(tmp_path)
+    renders = tmp_path / "renders"
+    _retain(renders, _DIGEST_A)
+    log.record(
+        type="push",
+        source="file",
+        target="legacy-photo.png",
+        status="sent",
+        digest=_DIGEST_A,
+        extra={},
+    )
+
+    item = list_history(log, renders)["items"][0]
+
+    assert item["preview_available"] is True
+    assert item["resendable"] is False
+
+
+def test_pruned_composition_leaves_row_but_disables_preview_and_resend(tmp_path: Path) -> None:
+    log = _log(tmp_path)
+    renders = tmp_path / "renders"
+    artifact = _retain(renders, _DIGEST_A)
+    event_id = log.record(
+        type="push",
+        source="file",
+        target="photo.png",
+        status="sent",
+        digest=_DIGEST_A,
+        extra={"device_ids": ["desk"], "image_fit": "fill"},
+    )
+
+    before = list_history(log, renders)["items"][0]
+    artifact.unlink()
+    after = list_history(log, renders)["items"][0]
+
+    assert before["preview_available"] is True
+    assert before["resendable"] is True
+    assert after["id"] == str(event_id)
+    assert after["preview_available"] is False
+    assert after["resendable"] is False
+    assert after["fit"] == "fill"
+    assert retained_composition_for_history(log, renders, event_id) is None
+
+
+def test_artifact_lookup_rejects_traversal_malformed_digest_and_symlink(
+    tmp_path: Path,
+) -> None:
+    renders = tmp_path / "renders"
+    renders.mkdir()
+    outside = tmp_path / f"{_DIGEST_A}.png"
+    outside.write_bytes(b"outside")
+    (renders / f"{_DIGEST_B}.png").symlink_to(outside)
+
+    assert retained_composition(renders, "../0123456789abcdef") is None
+    assert retained_composition(renders, "not-a-content-digest") is None
+    assert retained_composition(renders, _DIGEST_B) is None
+
+
+def test_preview_lookup_rejects_non_push_and_unknown_rows(tmp_path: Path) -> None:
+    log = _log(tmp_path)
+    renders = tmp_path / "renders"
+    _retain(renders, _DIGEST_A)
+    renderer_id = log.record(
+        type="renderer",
+        source="pi_bin",
+        target="topic",
+        status="sent",
+        digest=_DIGEST_A,
+    )
+
+    assert retained_composition_for_history(log, renders, str(renderer_id)) is None
+    assert retained_composition_for_history(log, renders, "999999") is None
+    assert retained_composition_for_history(log, renders, "../1") is None
+
+
+def test_unknown_fit_mode_is_not_exposed(tmp_path: Path) -> None:
+    log = _log(tmp_path)
+    event_id = log.record(
+        type="push",
+        source="file",
+        target="photo.png",
+        status="sent",
+        extra={"image_fit": "tile"},
+    )
+    row = log.get(event_id)
+    assert row is not None
+
+    assert history_item(row, tmp_path / "renders")["fit"] is None

--- a/tests/companion/test_companion_history_api.py
+++ b/tests/companion/test_companion_history_api.py
@@ -1,0 +1,246 @@
+"""Live route coverage for Companion 0.4 History and resend."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import jsonschema
+import pytest
+from flask import Flask
+
+from app.companion_jobs import JobOutcome
+from app.main import REPO_ROOT, create_app
+
+from ._schema import schema_for
+from .test_companion_api import _seed_device, _token
+
+_DIGEST = "0123456789abcdef"
+_IDEMPOTENCY_KEY = "history-resend-test-key"
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> Flask:
+    instance = create_app(
+        testing=False,
+        data_root=tmp_path,
+        plugins_dir=REPO_ROOT / "plugins",
+        renderers_dir=REPO_ROOT / "renderers",
+        devices_dir=REPO_ROOT / "devices",
+    )
+    instance.config["TESTING"] = True
+    return instance
+
+
+def _auth(app: Flask) -> dict[str, str]:
+    return {"Authorization": f"Bearer {_token(app)}"}
+
+
+def _record_history(app: Flask, *, device_id: str, fit: str = "blur") -> int:
+    renders = Path(app.config["RENDERS_DIR"])
+    renders.mkdir(parents=True, exist_ok=True)
+    (renders / f"{_DIGEST}.png").write_bytes(b"\x89PNG\r\n\x1a\nhistory")
+    return int(
+        app.config["EVENT_LOG"].record(
+            type="push",
+            source="companion",
+            target="Shared photo",
+            status="sent",
+            digest=_DIGEST,
+            duration_s=1.25,
+            extra={"device_ids": [device_id], "fit": fit},
+        )
+    )
+
+
+class _InlineJobs:
+    """Run route work immediately while preserving the real JobStore shape."""
+
+    def __init__(self, store: Any) -> None:
+        self._store = store
+
+    def enqueue(self, job_id: str, work: Any) -> None:
+        self._store.mark_running(job_id)
+        outcome: JobOutcome = work()
+        if outcome.ok:
+            self._store.mark_succeeded(
+                job_id,
+                result_status=outcome.result_status,
+                device_ids=list(outcome.device_ids),
+                reason=outcome.reason,
+                history_event_ids=(
+                    list(outcome.history_event_ids)
+                    if outcome.history_event_ids is not None
+                    else None
+                ),
+            )
+        else:
+            self._store.mark_failed(job_id, code=outcome.code, message=outcome.message)
+
+
+class _Republisher:
+    def __init__(self, app: Flask) -> None:
+        self._app = app
+        self.calls: list[tuple[int, set[str]]] = []
+
+    def republish(self, event_id: int, *, device_ids: set[str]) -> Any:
+        self.calls.append((event_id, device_ids))
+        original = self._app.config["EVENT_LOG"].get(event_id)
+        assert original is not None
+        new_id = self._app.config["EVENT_LOG"].record(
+            type="push",
+            source="resend",
+            target=original.target,
+            status="sent",
+            digest=original.digest,
+            extra={
+                "device_ids": sorted(device_ids),
+                "fit": original.extra.get("fit"),
+            },
+        )
+        return SimpleNamespace(status="sent", error=None, event_id=new_id)
+
+
+def test_history_list_and_preview_are_authenticated_and_contract_valid(app: Flask) -> None:
+    device_id = _seed_device(app)
+    event_id = _record_history(app, device_id=device_id)
+    client = app.test_client()
+
+    assert client.get("/api/app/v1/history").status_code == 401
+    auth = _auth(app)
+    listing = client.get("/api/app/v1/history?limit=30", headers=auth)
+    assert listing.status_code == 200
+    body = listing.get_json()
+    jsonschema.validate(body, schema_for("HistoryResponse"))
+    item = body["items"][0]
+    assert item["id"] == str(event_id)
+    assert item["fit"] == "blur"
+    assert item["preview_available"] is True
+    assert item["resendable"] is True
+
+    preview = client.get(f"/api/app/v1/history/{event_id}/preview", headers=auth)
+    assert preview.status_code == 200
+    assert preview.mimetype == "image/png"
+    assert preview.headers["Cache-Control"] == "private, no-cache"
+    etag = preview.headers["ETag"]
+    cached = client.get(
+        f"/api/app/v1/history/{event_id}/preview",
+        headers={**auth, "If-None-Match": etag},
+    )
+    assert cached.status_code == 304
+    assert cached.headers["ETag"] == etag
+
+
+@pytest.mark.parametrize("query", ["?limit=0", "?limit=101", "?limit=nope", "?before_id=01"])
+def test_history_list_rejects_invalid_pagination(app: Flask, query: str) -> None:
+    response = app.test_client().get(f"/api/app/v1/history{query}", headers=_auth(app))
+    assert response.status_code == 400
+    assert response.get_json()["error"]["code"] == "invalid_request"
+
+
+def test_history_resend_preserves_targets_and_reports_exact_new_event(app: Flask) -> None:
+    device_id = _seed_device(app)
+    event_id = _record_history(app, device_id=device_id, fit="center")
+    republisher = _Republisher(app)
+    app.config["PUSH_MANAGER"] = republisher
+    app.config["COMPANION_JOBS"] = _InlineJobs(app.config["JOB_STORE"])
+    client = app.test_client()
+    auth = {
+        **_auth(app),
+        "Idempotency-Key": _IDEMPOTENCY_KEY,
+        "Content-Type": "application/json",
+    }
+
+    response = client.post(
+        f"/api/app/v1/history/{event_id}/resend",
+        headers=auth,
+        data=json.dumps({"override_quiet_hours": False}),
+    )
+
+    assert response.status_code == 202
+    body = response.get_json()
+    jsonschema.validate(body, schema_for("JobResponse"))
+    job = body["job"]
+    assert job["kind"] == "history_resend"
+    assert job["status"] == "succeeded"
+    assert job["result"]["status"] == "published"
+    assert job["result"]["device_ids"] == [device_id]
+    new_event_id = job["result"]["history_event_ids"][0]
+    assert int(new_event_id) > event_id
+    assert republisher.calls == [(event_id, {device_id})]
+    replay = app.config["EVENT_LOG"].get(int(new_event_id))
+    assert replay is not None
+    assert replay.source == "resend"
+    assert replay.extra["fit"] == "center"
+
+    # An uncertain client retry resolves to the same terminal job and does not
+    # refresh the e-ink display twice.
+    retried = client.post(
+        f"/api/app/v1/history/{event_id}/resend",
+        headers=auth,
+        data=json.dumps({"override_quiet_hours": False}),
+    )
+    assert retried.status_code == 202
+    assert retried.get_json()["job"]["id"] == job["id"]
+    assert republisher.calls == [(event_id, {device_id})]
+
+
+def test_history_resend_respects_quiet_hours(app: Flask) -> None:
+    device_id = _seed_device(app)
+    event_id = _record_history(app, device_id=device_id)
+    republisher = _Republisher(app)
+    app.config["PUSH_MANAGER"] = republisher
+    app.config["COMPANION_JOBS"] = _InlineJobs(app.config["JOB_STORE"])
+    now = datetime.now(UTC)
+    app.config["SETTINGS_STORE"].patch_section(
+        "app",
+        {
+            "quiet_hours_enabled": True,
+            "quiet_hours_start": (now - timedelta(minutes=5)).strftime("%H:%M"),
+            "quiet_hours_end": (now + timedelta(minutes=5)).strftime("%H:%M"),
+        },
+    )
+
+    response = app.test_client().post(
+        f"/api/app/v1/history/{event_id}/resend",
+        headers={
+            **_auth(app),
+            "Idempotency-Key": _IDEMPOTENCY_KEY,
+            "Content-Type": "application/json",
+        },
+        data=json.dumps({"override_quiet_hours": False}),
+    )
+
+    assert response.status_code == 202
+    result = response.get_json()["job"]["result"]
+    assert result == {
+        "status": "quiet",
+        "reason": "all_targets_in_quiet_hours",
+        "device_ids": [device_id],
+    }
+    assert republisher.calls == []
+
+
+def test_history_resend_rejects_rows_without_retained_target_snapshot(app: Flask) -> None:
+    event_id = app.config["EVENT_LOG"].record(
+        type="push",
+        source="file",
+        target="legacy.png",
+        status="sent",
+        digest=_DIGEST,
+        extra={},
+    )
+    response = app.test_client().post(
+        f"/api/app/v1/history/{event_id}/resend",
+        headers={
+            **_auth(app),
+            "Idempotency-Key": _IDEMPOTENCY_KEY,
+            "Content-Type": "application/json",
+        },
+        data=json.dumps({"override_quiet_hours": False}),
+    )
+    assert response.status_code == 409
+    assert response.get_json()["error"]["code"] == "not_resendable"

--- a/tests/companion/test_companion_history_jobs.py
+++ b/tests/companion/test_companion_history_jobs.py
@@ -1,0 +1,137 @@
+"""Companion 0.4 History resend job persistence and correlation."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from flask import Flask
+
+from app.companion_jobs import CompanionJobs, JobOutcome
+from app.state.job_store import JobStore
+
+
+def _wait_for_terminal(store: JobStore, job_id: str, timeout_s: float = 2.0) -> None:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        job = store.get(job_id)
+        if job is not None and job.terminal:
+            return
+        time.sleep(0.01)
+    raise AssertionError(f"job {job_id} did not reach a terminal state")
+
+
+def test_history_resend_job_persists_correlated_event_ids(tmp_path: Path) -> None:
+    path = tmp_path / "jobs.json"
+    store = JobStore(path)
+    job = store.create(
+        kind="history_resend",
+        target_device_ids=["kitchen"],
+        label="Shared photo",
+    )
+
+    store.mark_succeeded(
+        job.id,
+        result_status="published",
+        device_ids=["kitchen"],
+        history_event_ids=["42", "42", "43"],
+    )
+
+    # Read through a fresh store to prove the 0.4 result survives the
+    # file-backed boundary used by a later Companion job poll.
+    reloaded = JobStore(path).get(job.id)
+    assert reloaded is not None
+    assert reloaded.kind == "history_resend"
+    assert reloaded.result == {
+        "status": "published",
+        "reason": None,
+        "device_ids": ["kitchen"],
+        "history_event_ids": ["42", "43"],
+    }
+
+
+def test_pre_04_job_without_history_ids_remains_compatible(tmp_path: Path) -> None:
+    path = tmp_path / "jobs.json"
+    path.write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "id": "job_legacy",
+                        "kind": "image_push",
+                        "status": "succeeded",
+                        "target_device_ids": ["kitchen"],
+                        "created_at": "2026-07-29T00:00:00Z",
+                        "updated_at": "2026-07-29T00:00:01Z",
+                        "label": "Shared photo",
+                        "result": {
+                            "status": "published",
+                            "reason": None,
+                            "device_ids": ["kitchen"],
+                        },
+                        "error": None,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    job = JobStore(path).get("job_legacy")
+    assert job is not None
+    assert job.public_dict()["result"] == {
+        "status": "published",
+        "reason": None,
+        "device_ids": ["kitchen"],
+    }
+
+
+def test_async_runner_carries_exact_republish_event_id(tmp_path: Path) -> None:
+    app = Flask(__name__)
+    store = JobStore(tmp_path / "jobs.json")
+    runner = CompanionJobs(app, store, max_workers=1)
+    job = store.create(
+        kind="history_resend",
+        target_device_ids=["kitchen"],
+        label="Shared photo",
+    )
+
+    try:
+        # The resend route supplies PushManager.republish(...).event_id here;
+        # the runner must preserve that exact canonical EventLog ID.
+        runner.enqueue(
+            job.id,
+            lambda: JobOutcome.published(
+                ["kitchen"],
+                history_event_ids=["731"],
+            ),
+        )
+        _wait_for_terminal(store, job.id)
+    finally:
+        runner.shutdown()
+
+    completed = store.get(job.id)
+    assert completed is not None
+    assert completed.status == "succeeded"
+    assert completed.result is not None
+    assert completed.result["history_event_ids"] == ["731"]
+
+
+def test_existing_published_outcome_omits_optional_history_ids(tmp_path: Path) -> None:
+    store = JobStore(tmp_path / "jobs.json")
+    job = store.create(
+        kind="dashboard_push",
+        target_device_ids=["kitchen"],
+        label="Pantry",
+    )
+    store.mark_succeeded(
+        job.id,
+        result_status="published",
+        device_ids=["kitchen"],
+    )
+
+    completed = store.get(job.id)
+    assert completed is not None
+    assert completed.result is not None
+    assert "history_event_ids" not in completed.result

--- a/tests/companion/test_companion_jobs.py
+++ b/tests/companion/test_companion_jobs.py
@@ -38,14 +38,17 @@ class _FakePush:
         self.status = status
         self.push_calls: list[dict[str, Any]] = []
         self.image_calls: list[dict[str, Any]] = []
+        self._next_event_id = 100
 
     def push(self, page_id: str, **kwargs: Any) -> Any:
         self.push_calls.append({"page_id": page_id, "device_ids": set(kwargs["device_ids"])})
-        return SimpleNamespace(status=self.status, error=None)
+        self._next_event_id += 1
+        return SimpleNamespace(status=self.status, error=None, event_id=self._next_event_id)
 
     def push_image(self, image_bytes: bytes, **kwargs: Any) -> Any:
         self.image_calls.append({"device_id": kwargs["device_id"], "fit": kwargs["fit"]})
-        return SimpleNamespace(status=self.status, error=None)
+        self._next_event_id += 1
+        return SimpleNamespace(status=self.status, error=None, event_id=self._next_event_id)
 
 
 @pytest.fixture
@@ -169,6 +172,7 @@ def test_dashboard_push_creates_job_that_publishes(app: Flask) -> None:
     assert job["status"] == "succeeded"
     assert job["result"]["status"] == "published"
     assert job["result"]["device_ids"] == [device]
+    assert job["result"]["history_event_ids"] == ["101"]
     assert fake.push_calls == [{"page_id": "pantry", "device_ids": {device}}]
 
 
@@ -307,15 +311,14 @@ def test_reused_key_with_different_payload_conflicts(app: Flask) -> None:
 # -- image push ----------------------------------------------------------
 
 
-def test_image_push_creates_job_that_publishes(app: Flask) -> None:
+@pytest.mark.parametrize("fit", companion_api.IMAGE_FIT_MODES)
+def test_image_push_accepts_every_advertised_fit_mode(app: Flask, fit: str) -> None:
     fake = _install_fake_push(app)
     device = _seed_device(app)
     token = _token(app)
     data = {
         "image": (BytesIO(_png_bytes()), "photo.png", "image/png"),
-        "request": json.dumps(
-            {"device_ids": [device], "fit": "fill", "override_quiet_hours": True}
-        ),
+        "request": json.dumps({"device_ids": [device], "fit": fit, "override_quiet_hours": True}),
     }
     resp = app.test_client().post(
         "/api/app/v1/images",
@@ -332,7 +335,29 @@ def test_image_push_creates_job_that_publishes(app: Flask) -> None:
     assert job["status"] == "succeeded"
     assert job["result"]["status"] == "published"
     assert job["result"]["device_ids"] == [device]
-    assert fake.image_calls == [{"device_id": device, "fit": "fill"}]
+    assert job["result"]["history_event_ids"] == ["101"]
+    assert fake.image_calls == [{"device_id": device, "fit": fit}]
+
+
+@pytest.mark.parametrize("invalid_fit", ["tile", ["fit"]], ids=["unknown", "non-string"])
+def test_image_push_rejects_unadvertised_fit_mode(app: Flask, invalid_fit: Any) -> None:
+    _install_fake_push(app)
+    device = _seed_device(app)
+    token = _token(app)
+    data = {
+        "image": (BytesIO(_png_bytes()), "photo.png", "image/png"),
+        "request": json.dumps(
+            {"device_ids": [device], "fit": invalid_fit, "override_quiet_hours": True}
+        ),
+    }
+    resp = app.test_client().post(
+        "/api/app/v1/images",
+        data=data,
+        content_type="multipart/form-data",
+        headers=_auth(token, "idem-image-invalid-fit"),
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"]["code"] == "invalid_request"
 
 
 def test_image_push_rejects_unsupported_media_type(app: Flask) -> None:

--- a/tests/companion/test_contract_fixtures.py
+++ b/tests/companion/test_contract_fixtures.py
@@ -18,32 +18,42 @@ from ._schema import FIXTURES_DIR, SPEC, schema_for
 
 CASES = {
     "capabilities.json": "Capabilities",
+    "capabilities-previews.json": "Capabilities",
+    "capabilities-extended.json": "Capabilities",
     "pair-request.json": "PairingRequest",
     "pair-response.json": "PairingResponse",
     "devices-response.json": "DevicesResponse",
     "dashboards-response.json": "DashboardsResponse",
     "dashboard-push-request.json": "DashboardPushRequest",
     "image-push-request.json": "ImagePushRequest",
+    "history-response.json": "HistoryResponse",
+    "history-resend-request.json": "HistoryResendRequest",
     "job-accepted.json": "JobResponse",
     "job-published.json": "JobResponse",
     "job-quiet.json": "JobResponse",
     "job-failed.json": "JobResponse",
+    "job-history-resend.json": "JobResponse",
     "error-response.json": "ErrorResponse",
 }
 
 
 def test_openapi_shape_and_operation_ids_are_stable() -> None:
     assert SPEC["openapi"] == "3.0.3"
-    assert SPEC["info"]["version"] == "0.2.0"
+    assert SPEC["info"]["version"] == "0.4.0"
     assert set(SPEC["paths"]) == {
         "/api/app/v1",
         "/api/app/v1/pair",
         "/api/app/v1/session",
         "/api/app/v1/devices",
+        "/api/app/v1/devices/{device_id}/preview",
         "/api/app/v1/dashboards",
+        "/api/app/v1/dashboards/{dashboard_id}/preview",
         "/api/app/v1/dashboards/{dashboard_id}/push",
         "/api/app/v1/images",
         "/api/app/v1/jobs/{job_id}",
+        "/api/app/v1/history",
+        "/api/app/v1/history/{history_id}/preview",
+        "/api/app/v1/history/{history_id}/resend",
     }
     operation_ids = [
         operation["operationId"]
@@ -78,3 +88,83 @@ def test_job_lifecycle_and_business_outcome_are_separate() -> None:
     assert quiet["result"]["status"] == "quiet"
     assert failed["status"] == "failed"
     assert failed["error"]["code"]
+
+
+def test_all_write_operations_require_idempotency_key() -> None:
+    paths = SPEC["paths"]
+    write_operations = [
+        paths["/api/app/v1/dashboards/{dashboard_id}/push"]["post"],
+        paths["/api/app/v1/images"]["post"],
+        paths["/api/app/v1/history/{history_id}/resend"]["post"],
+    ]
+    for operation in write_operations:
+        refs = [parameter.get("$ref") for parameter in operation["parameters"]]
+        assert "#/components/parameters/IdempotencyKey" in refs
+
+
+def test_preview_endpoints_are_read_only_and_conditional() -> None:
+    paths = SPEC["paths"]
+    device = paths["/api/app/v1/devices/{device_id}/preview"]
+    dashboard = paths["/api/app/v1/dashboards/{dashboard_id}/preview"]
+    history = paths["/api/app/v1/history/{history_id}/preview"]
+
+    assert set(device) == {"parameters", "get"}
+    assert set(dashboard) == {"parameters", "get"}
+    assert set(history) == {"parameters", "get"}
+    assert set(device["get"]["responses"]) == {"200", "304", "401", "404"}
+    assert set(dashboard["get"]["responses"]) == {
+        "200",
+        "202",
+        "304",
+        "400",
+        "401",
+        "404",
+    }
+    assert set(history["get"]["responses"]) == {"200", "304", "401", "404"}
+    features = SPEC["components"]["schemas"]["Capabilities"]["properties"]["features"]["items"][
+        "enum"
+    ]
+    assert "previews" in features
+
+    base = json.loads((FIXTURES_DIR / "capabilities.json").read_text())
+    extension = json.loads((FIXTURES_DIR / "capabilities-previews.json").read_text())
+    assert "previews" not in base["features"]
+    assert "previews" in extension["features"]
+
+
+def test_extended_capabilities_advertise_history_and_all_image_fit_modes() -> None:
+    base = json.loads((FIXTURES_DIR / "capabilities.json").read_text())
+    extension = json.loads((FIXTURES_DIR / "capabilities-extended.json").read_text())
+
+    assert "image_fit_modes" not in base["limits"]
+    assert extension["limits"]["image_fit_modes"] == [
+        "fit",
+        "fill",
+        "blur",
+        "stretch",
+        "center",
+    ]
+    assert "history" in extension["features"]
+    assert SPEC["components"]["schemas"]["ImageFitMode"]["enum"] == [
+        "fit",
+        "fill",
+        "blur",
+        "stretch",
+        "center",
+    ]
+
+
+def test_history_contract_keeps_composition_preview_and_resend_correlatable() -> None:
+    history = json.loads((FIXTURES_DIR / "history-response.json").read_text())
+    photo = history["items"][0]
+    resend = json.loads((FIXTURES_DIR / "job-history-resend.json").read_text())["job"]
+
+    assert photo["preview_available"] is True
+    assert photo["fit"] == "blur"
+    assert resend["kind"] == "history_resend"
+    assert resend["result"]["history_event_ids"]
+
+    preview_description = SPEC["paths"]["/api/app/v1/history/{history_id}/preview"]["get"][
+        "responses"
+    ]["200"]["description"]
+    assert "not a device-final preview" in preview_description

--- a/tests/test_push_extras.py
+++ b/tests/test_push_extras.py
@@ -162,6 +162,9 @@ def test_republish_reuses_stored_composition(tmp_path: Path, panel_png: bytes) -
     rows = event_log.list(type="push")
     assert rows[0].source == "resend"
     assert rows[0].target == "src.png"
+    # Companion 0.4 job correlation can use this exact returned ID; it
+    # never needs to infer the new row from timestamps or composition data.
+    assert resend.event_id == rows[0].id
     # The original target is preserved as the resend's target.
     assert len(client.published) == 1
 
@@ -194,6 +197,38 @@ def test_republish_replays_original_device_targets(tmp_path: Path, panel_png: by
     rows = event_log.list(type="push")
     assert rows[0].source == "resend"
     assert rows[0].extra["device_ids"] == ["dev1"]
+
+
+def test_republish_preserves_image_fit_and_can_narrow_original_targets(
+    tmp_path: Path, panel_png: bytes
+) -> None:
+    renderers = [
+        _stub_renderer(tmp_path, "pi_png__dev1", "png", False, device="dev1"),
+        _stub_renderer(tmp_path, "pi_png__dev2", "png", False, device="dev2"),
+    ]
+    manager, event_log, _client, _ = _wire(tmp_path, panel_png, renderers=renderers)
+
+    first = manager._fan_out(
+        panel_png,
+        {"w": 100, "h": 80},
+        source="file",
+        target="shared.png",
+        started=0.0,
+        device_filters={"dev1", "dev2"},
+        image_fit="blur",
+    )
+    assert first.status == "sent"
+    original = event_log.get(first.event_id)  # type: ignore[arg-type]
+    assert original is not None
+    assert original.extra["fit"] == "blur"
+
+    resend = manager.republish(first.event_id, device_ids={"dev2"})  # type: ignore[arg-type]
+    assert resend.status == "sent"
+    replay = event_log.get(resend.event_id)  # type: ignore[arg-type]
+    assert replay is not None
+    assert replay.source == "resend"
+    assert replay.extra["device_ids"] == ["dev2"]
+    assert replay.extra["fit"] == "blur"
 
 
 def test_republish_fails_when_thumbnail_evicted(tmp_path: Path, panel_png: bytes) -> None:


### PR DESCRIPTION
## Summary

Implements the first server batch of the accepted Companion 0.4 contract from
[Discussion #147](https://github.com/dmellok/tesserae/discussions/147):

- advertise and accept all five server image layout modes (`fit`, `fill`,
  `blur`, `stretch`, and `center`);
- expose paginated canonical push History from the existing `EventLog`;
- serve retained composition PNGs with ETag revalidation;
- idempotently resend retained entries to their original target snapshot while
  respecting per-device quiet hours;
- correlate successful dashboard, photo, and resend jobs to exact
  `history_event_ids` when available;
- preserve the original fit mode and target snapshot on photo resend.

The OpenAPI 0.4 contract and fixtures are synced byte-for-byte from the
[community iOS Companion PR](https://github.com/charmmmz/tesserae-companion-ios/pull/1).

## Why

The iOS app currently has a local Activity feed, but it cannot recover server
History after reinstalling or observe pushes made by schedules, the web UI, or
other clients. Using Tesserae's existing `EventLog` as the canonical source
gives all clients one honest timeline without introducing a second store.

Resend reuses the retained composition rather than re-rendering its source. This
keeps the operation faithful, fast, and suitable for an iOS background job, while
the idempotency key prevents an uncertain retry from refreshing an e-ink panel
twice.

## Compatibility and boundaries

- History is additive and advertised through the `history` feature.
- `limits.image_fit_modes` is optional for older clients; clients that do not
  see it can continue to assume Fit and Fill.
- Existing persisted jobs remain readable because `history_event_ids` is
  optional.
- Existing web History resend behavior is unchanged when no target subset is
  supplied.
- This batch intentionally serves the retained composition for History preview.
  A device-final, post-fit preview for the Displays screen remains the agreed
  follow-up batch and is not implemented here.

## Validation

- `2563 passed` — full Tesserae test suite
- Ruff check and format check
- strict mypy on the changed Companion, History, job-store, EventLog, and push
  modules
- `git diff --check`
- vendored OpenAPI and fixtures compared byte-for-byte with the iOS repository
