### PR TITLE
Add logical Companion device previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Fixed
 
+- **Companion display previews now match each display's selected photo layout.**
+  The server retains a separate logical-screen PNG after Fit, Fill, Blur,
+  Stretch, or Center and device underscan are applied, so portrait displays no
+  longer show the unfitted source composition in the iOS app. Hardware-only
+  row-stride rotation and mount compensation remain confined to the device
+  artifact, while preview ETags, upgrade backfill, and artifact pruning track
+  the logical frame independently.
+
 - **The Webpage widget captures JavaScript pages after their data loads.** It was
   screenshotting the moment the embedded page fired its `load` event, before a data-driven
   page (a weather dashboard, an SPA) ran its post-load fetch and painted, so the panel showed a

--- a/app/companion_api.py
+++ b/app/companion_api.py
@@ -51,6 +51,7 @@ from app.companion_history import (
 )
 from app.companion_jobs import CompanionJobs, JobOutcome
 from app.device_loader import Device, DeviceRegistry
+from app.device_preview import retained_device_preview
 from app.panel import device_panel, resolve_settings_panel
 from app.quiet_hours import device_is_quiet
 from app.state.companion_token_store import COMPANION_SCOPES, CompanionTokenStore
@@ -935,32 +936,35 @@ def get_job(job_id: str) -> Any:
 @bp.get("/devices/<device_id>/preview")
 @_require_companion("devices:read")
 def device_preview(device_id: str) -> Any:
-    """Latest full composition PNG for a display. ETag is the composition
-    digest (content-addressed), so `If-None-Match` short-circuits to 304.
-    404 when the display is unknown or nothing has rendered for it yet.
+    """Latest logical full-frame PNG for a display.
 
-    This is the composition (what the renderer drew), not the on-glass
-    patched frame, so a live tap overlay may be newer than what's served."""
+    The preview includes the selected image-fit mode and logical panel
+    geometry, but excludes hardware-only row-stride and mount compensation.
+    A live partial-refresh patch may be newer than this last full frame.
+    """
     device = _devices().get(device_id)
     if device is None or device.kind_of is None:
         return _error("not_found", "No display with that id.", 404)
     manager = _push_manager()
     latest = manager.latest_render_for(device_id) if manager is not None else None
-    digest = latest.get("composition_digest") if isinstance(latest, dict) else None
-    if not digest:
+    if not isinstance(latest, dict):
         return _error("not_found", "No frame has been rendered for this display yet.", 404)
+    digest = latest.get("preview_digest")
+    if digest is None:
+        return _error("not_found", "No preview is available for the latest frame yet.", 404)
 
-    etag = str(digest)
-    if request.if_none_match and etag in request.if_none_match:
+    retained = retained_device_preview(Path(current_app.config["RENDERS_DIR"]), digest)
+    if retained is None:
+        return _error("not_found", "The rendered frame is no longer available.", 404)
+
+    if request.if_none_match and request.if_none_match.contains_weak(retained.etag):
         resp = current_app.response_class(status=304)
-        resp.set_etag(etag)
+        resp.set_etag(retained.etag)
+        resp.headers["Cache-Control"] = "private, no-cache"
         return resp
 
-    png_path = Path(current_app.config["RENDERS_DIR"]) / f"{etag}.png"
-    if not png_path.exists():
-        return _error("not_found", "The rendered frame is no longer available.", 404)
-    resp = current_app.response_class(png_path.read_bytes(), mimetype="image/png")
-    resp.set_etag(etag)
+    resp = current_app.response_class(retained.path.read_bytes(), mimetype="image/png")
+    resp.set_etag(retained.etag)
     # Content-addressed by digest, but the "latest" pointer moves, so the
     # client must revalidate rather than hold it blindly.
     resp.headers["Cache-Control"] = "private, no-cache"

--- a/app/device_preview.py
+++ b/app/device_preview.py
@@ -1,0 +1,133 @@
+"""Logical, device-specific previews for Companion display cards.
+
+Renderer artifacts are device wire formats.  Some are viewable PNG/BMP files,
+while others are packed binary buffers whose orientation includes native row
+stride and mount compensation.  Companion previews instead represent the
+logical on-wall view: the selected image-fit mode at ``panel.w x panel.h``,
+with logical underscan, but without exposing hardware-only rotation/flip.
+
+The generated PNG is content-addressed and retained beside renderer artifacts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from PIL import Image
+
+from app.quantizer import fit_to_panel, underscan_image
+from app.state.page_store import Panel
+
+_DIGEST_RE = re.compile(r"^[0-9a-f]{16}$")
+_IMAGE_FIT_MODES = frozenset(("fit", "fill", "blur", "stretch", "center"))
+_BACKGROUND_COLOURS = frozenset(("white", "black", "red", "green", "blue", "yellow", "orange"))
+
+
+@dataclass(frozen=True)
+class RetainedDevicePreview:
+    path: Path
+    etag: str
+
+
+def build_device_preview_png(
+    composition_png: bytes,
+    *,
+    panel: Panel,
+    settings: dict[str, Any],
+) -> bytes:
+    """Return an upright logical-screen PNG for one device render.
+
+    ``composition_png`` is the same source the renderer receives, including
+    any server-side low-battery overlay.  Fit and underscan intentionally run
+    in logical panel coordinates.  Physical mount compensation (``flip`` /
+    ``vflip``) and firmware-native row-stride rotation belong only in the wire
+    artifact and must not make the phone preview sideways or upside down.
+    """
+
+    with Image.open(io.BytesIO(composition_png)) as source:
+        image = source.convert("RGB")
+
+    fit_value = settings.get("image_fit", settings.get("scale", "fit"))
+    fit = fit_value if isinstance(fit_value, str) and fit_value in _IMAGE_FIT_MODES else "fit"
+    bg_value = settings.get("bg", "white")
+    background = (
+        bg_value if isinstance(bg_value, str) and bg_value in _BACKGROUND_COLOURS else "white"
+    )
+    if image.size != (panel.w, panel.h):
+        image = fit_to_panel(
+            image,
+            target_w=panel.w,
+            target_h=panel.h,
+            scale=fit,
+            bg=background,
+        )
+    if panel.underscan:
+        image = underscan_image(image, underscan=panel.underscan)
+
+    output = io.BytesIO()
+    image.save(output, format="PNG", optimize=True)
+    return output.getvalue()
+
+
+def write_device_preview(
+    renders_dir: Path,
+    composition_png: bytes,
+    *,
+    panel: Panel,
+    settings: dict[str, Any],
+) -> str:
+    """Atomically retain a logical preview and return its content digest."""
+
+    preview_png = build_device_preview_png(composition_png, panel=panel, settings=settings)
+    digest = hashlib.sha256(preview_png).hexdigest()[:16]
+    renders_dir.mkdir(parents=True, exist_ok=True)
+    destination = renders_dir / f"{digest}.png"
+    if destination.exists():
+        destination.touch()
+        return digest
+
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=renders_dir,
+            prefix=f".{digest}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            handle.write(preview_png)
+            temporary = Path(handle.name)
+        temporary.replace(destination)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+    return digest
+
+
+def retained_device_preview(
+    renders_dir: Path,
+    digest: object,
+) -> RetainedDevicePreview | None:
+    """Safely resolve a retained ``<digest>.png`` without symlink escape."""
+
+    if not isinstance(digest, str) or _DIGEST_RE.fullmatch(digest) is None:
+        return None
+
+    root = renders_dir.resolve()
+    candidate = root / f"{digest}.png"
+    try:
+        if candidate.is_symlink():
+            return None
+        resolved = candidate.resolve(strict=True)
+        resolved.relative_to(root)
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+    if not resolved.is_file():
+        return None
+    return RetainedDevicePreview(path=resolved, etag=digest)

--- a/app/push.py
+++ b/app/push.py
@@ -51,6 +51,7 @@ from typing import Any, Literal
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from app.device_loader import DeviceRegistry
+from app.device_preview import retained_device_preview, write_device_preview
 from app.dither_regions import has_nearest_region, regions_from_page
 from app.net_guard import BlockedURLError, assert_operator_url, fetch_bytes
 from app.palette_profiles import (
@@ -334,6 +335,7 @@ class RendererResult:
     digest: str
     url: str
     bytes_written: int
+    preview_digest: str | None = None
     error: str | None = None
     # v0.71.x (r/eink launch feedback): True when the composition_digest
     # matched the device's last-served digest and publish was skipped
@@ -582,13 +584,14 @@ class PushManager:
 
     def latest_render_for(self, device_id: str) -> dict[str, Any] | None:
         """The most recently published render for a device, or ``None``
-         if nothing has been pushed since startup.
+        if nothing has been pushed since startup.
 
-         Returns a dict ``{digest, ext, filename, timestamp, renderer_id}``
-        , same shape ``_fan_out`` writes into the in-memory map. Used
-         by pull-based transports (``app.trmnl_api.display``) so a TRMNL
-         client polling ``/api/display`` gets the URL of the actual
-         frame the renderer just wrote, not a stale guess."""
+        Returns a dict ``{digest, ext, filename, preview_digest, timestamp,
+        renderer_id}``, same shape ``_fan_out`` writes into the in-memory
+        map. Used
+        by pull-based transports (``app.trmnl_api.display``) so a TRMNL
+        client polling ``/api/display`` gets the URL of the actual
+        frame the renderer just wrote, not a stale guess."""
         return self._latest_renders.get(device_id)
 
     def consume_force_refetch(self, device_id: str) -> None:
@@ -1473,11 +1476,12 @@ class PushManager:
         return result
 
     def _live_digests(self) -> set[str]:
-        """Digests that must survive any artifact GC: the latest render
-        for every device (artifact digest + composition digest). Deleting
-        these while the frame is still on a panel kills its thumbnail and
-        its touch-region sidecar, after which every tap resolves
-        ``no_target`` and the touch monitor has nothing to overlay."""
+        """Digests that must survive artifact GC for every live frame.
+
+        This includes the device artifact, source composition, and logical
+        Companion preview. Deleting them while a frame is live breaks device
+        fetches, phone thumbnails, or touch-region resolution.
+        """
         live: set[str] = set()
         # Shallow copy: callers may or may not hold self._lock.
         entries = list(self._latest_renders.values())
@@ -1491,7 +1495,7 @@ class PushManager:
         for per_page in list(self._deck_renders.values()):
             entries.extend(per_page.values())
         for entry in entries:
-            for key in ("digest", "composition_digest"):
+            for key in ("digest", "composition_digest", "preview_digest"):
                 value = entry.get(key)
                 if isinstance(value, str) and value:
                     live.add(value)
@@ -1875,12 +1879,36 @@ class PushManager:
             )
             last = self._latest_renders.get(renderer.device)
             if not force_publish and last and last.get("render_signature") == signature:
+                # Upgrade/backfill path for servers whose latest-render record
+                # predates logical device previews, or whose preview PNG was
+                # pruned independently.  Do not repaint the e-ink panel merely
+                # to restore a phone thumbnail.
+                retained_preview = retained_device_preview(
+                    self._renders_dir, last.get("preview_digest")
+                )
+                if retained_preview is None:
+                    preview_source = self._overlay_low_battery_if_needed(
+                        composition_png, renderer.device
+                    )
+                    preview_digest = self._write_device_preview_best_effort(
+                        renderer,
+                        preview_source,
+                        panel,
+                        settings=render_settings,
+                    )
+                    if preview_digest is not None:
+                        last["preview_digest"] = preview_digest
                 result = RendererResult(
                     renderer_id=renderer.id,
                     topic=renderer.topic,
                     digest=str(last.get("digest") or ""),
                     url="",
                     bytes_written=0,
+                    preview_digest=(
+                        str(last.get("preview_digest"))
+                        if isinstance(last.get("preview_digest"), str)
+                        else None
+                    ),
                     unchanged=True,
                 )
                 results.append(result)
@@ -1943,6 +1971,7 @@ class PushManager:
                     # URL that always serves a viewable frame, even when
                     # the per-renderer artifact is a packed binary buffer.
                     "composition_digest": comp_digest,
+                    "preview_digest": result.preview_digest,
                     # Full render-input fingerprint (composition + panel +
                     # settings). The next push skips re-rendering only when
                     # this matches, so a gamut / calibration change repaints
@@ -2334,13 +2363,48 @@ class PushManager:
                 qos=1,
                 retain=renderer.retain,
             )
+        # Keep a separate logical-screen PNG for Companion display cards.
+        # This is deliberately best-effort: a disk/PNG failure must never
+        # turn a successful physical-device publish into a failed send.
+        preview_digest = self._write_device_preview_best_effort(
+            renderer,
+            composition_png,
+            panel,
+            settings=settings,
+        )
         return RendererResult(
             renderer_id=renderer.id,
             topic=renderer.topic,
             digest=digest,
             url=url,
             bytes_written=len(artifact),
+            preview_digest=preview_digest,
         )
+
+    def _write_device_preview_best_effort(
+        self,
+        renderer: Renderer,
+        composition_png: bytes,
+        panel: Panel,
+        *,
+        settings: dict[str, Any],
+    ) -> str | None:
+        """Retain a logical device preview without affecting delivery."""
+
+        try:
+            return write_device_preview(
+                self._renders_dir,
+                composition_png,
+                panel=panel,
+                settings=settings,
+            )
+        except Exception:
+            logger.exception(
+                "logical device preview failed for renderer=%s device=%s",
+                renderer.id,
+                renderer.device,
+            )
+            return None
 
     def _renderer_is_http_polled(self, renderer: Renderer) -> bool:
         """Return True when the renderer's bound device fetches frames

--- a/tests/companion/test_companion_previews.py
+++ b/tests/companion/test_companion_previews.py
@@ -1,7 +1,7 @@
 """Companion API previews (additive `previews` feature, discussion #147).
 
 Two read-only PNG endpoints, exercised through the real Flask app. No
-Playwright: the device preview serves an existing composition PNG (seeded
+Playwright: the device preview serves an existing logical-screen PNG (seeded
 on disk + a fake PushManager pointing at it), and the dashboard preview's
 cached path is pre-seeded while the cache-miss path only needs to return
 202 (the background render is a no-op without a browser pool).
@@ -74,15 +74,20 @@ def _seed_device(app: Flask, device_id: str = "kitchen") -> str:
 
 
 class _FakePush:
-    """Returns a fixed latest-render pointing at a seeded composition PNG."""
+    """Returns a fixed latest-render pointing at a seeded device preview."""
 
-    def __init__(self, composition_digest: str | None) -> None:
-        self._digest = composition_digest
+    def __init__(self, preview_digest: object | None) -> None:
+        self._digest = preview_digest
 
     def latest_render_for(self, device_id: str) -> Any:
         if self._digest is None:
             return None
-        return {"composition_digest": self._digest}
+        return {"preview_digest": self._digest}
+
+
+class _FakeLegacyPush:
+    def latest_render_for(self, device_id: str) -> Any:
+        return {"composition_digest": "deadbeefcafe0000"}
 
 
 def _seed_render(app: Flask, digest: str) -> None:
@@ -94,7 +99,7 @@ def _seed_render(app: Flask, digest: str) -> None:
 # -- device preview ------------------------------------------------------
 
 
-def test_device_preview_serves_composition_with_etag(app: Flask) -> None:
+def test_device_preview_serves_logical_frame_with_etag(app: Flask) -> None:
     device = _seed_device(app)
     _seed_render(app, "deadbeefcafe0001")
     app.config["PUSH_MANAGER"] = _FakePush("deadbeefcafe0001")
@@ -104,23 +109,72 @@ def test_device_preview_serves_composition_with_etag(app: Flask) -> None:
     assert resp.mimetype == "image/png"
     assert resp.get_data() == _PNG
     assert resp.headers["ETag"].strip('"') == "deadbeefcafe0001"
+    assert resp.headers["Cache-Control"] == "private, no-cache"
 
 
-def test_device_preview_304_on_matching_etag(app: Flask) -> None:
+@pytest.mark.parametrize(
+    "if_none_match",
+    ['"deadbeefcafe0002"', 'W/"deadbeefcafe0002"', '"other", "deadbeefcafe0002"', "*"],
+)
+def test_device_preview_304_on_matching_etag(app: Flask, if_none_match: str) -> None:
     device = _seed_device(app)
     _seed_render(app, "deadbeefcafe0002")
     app.config["PUSH_MANAGER"] = _FakePush("deadbeefcafe0002")
     token = _token(app)
     resp = app.test_client().get(
         f"/api/app/v1/devices/{device}/preview",
-        headers={**_auth(token), "If-None-Match": '"deadbeefcafe0002"'},
+        headers={**_auth(token), "If-None-Match": if_none_match},
     )
     assert resp.status_code == 304
+    assert resp.headers["ETag"].strip('"') == "deadbeefcafe0002"
+    assert resp.headers["Cache-Control"] == "private, no-cache"
+
+
+def test_device_preview_missing_file_is_404_even_when_etag_matches(app: Flask) -> None:
+    device = _seed_device(app)
+    app.config["PUSH_MANAGER"] = _FakePush("deadbeefcafe0003")
+    token = _token(app)
+    resp = app.test_client().get(
+        f"/api/app/v1/devices/{device}/preview",
+        headers={**_auth(token), "If-None-Match": '"deadbeefcafe0003"'},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.parametrize("digest", ["../deadbeefcafe0004", "not-a-digest", 42])
+def test_device_preview_rejects_untrusted_digest_metadata(app: Flask, digest: object) -> None:
+    device = _seed_device(app)
+    app.config["PUSH_MANAGER"] = _FakePush(digest)
+    token = _token(app)
+    resp = app.test_client().get(f"/api/app/v1/devices/{device}/preview", headers=_auth(token))
+    assert resp.status_code == 404
+
+
+def test_device_preview_rejects_symlink(app: Flask, tmp_path: Path) -> None:
+    device = _seed_device(app)
+    renders = Path(app.config["RENDERS_DIR"])
+    outside = tmp_path / "outside.png"
+    outside.write_bytes(_PNG)
+    (renders / "deadbeefcafe0005.png").symlink_to(outside)
+    app.config["PUSH_MANAGER"] = _FakePush("deadbeefcafe0005")
+    token = _token(app)
+    resp = app.test_client().get(f"/api/app/v1/devices/{device}/preview", headers=_auth(token))
+    assert resp.status_code == 404
 
 
 def test_device_preview_404_when_no_frame(app: Flask) -> None:
     device = _seed_device(app)
     app.config["PUSH_MANAGER"] = _FakePush(None)
+    token = _token(app)
+    resp = app.test_client().get(f"/api/app/v1/devices/{device}/preview", headers=_auth(token))
+    assert resp.status_code == 404
+    assert resp.get_json()["error"]["code"] == "not_found"
+
+
+def test_device_preview_404_for_legacy_latest_without_logical_preview(app: Flask) -> None:
+    device = _seed_device(app)
+    _seed_render(app, "deadbeefcafe0000")
+    app.config["PUSH_MANAGER"] = _FakeLegacyPush()
     token = _token(app)
     resp = app.test_client().get(f"/api/app/v1/devices/{device}/preview", headers=_auth(token))
     assert resp.status_code == 404

--- a/tests/test_device_preview.py
+++ b/tests/test_device_preview.py
@@ -1,0 +1,113 @@
+"""Logical device-preview generation and retention."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from app.device_preview import (
+    build_device_preview_png,
+    retained_device_preview,
+    write_device_preview,
+)
+from app.state.page_store import Panel
+
+
+def _source_png() -> bytes:
+    image = Image.new("RGB", (4, 2), "red")
+    for y in range(image.height):
+        for x in range(2, image.width):
+            image.putpixel((x, y), (0, 0, 255))
+    output = io.BytesIO()
+    image.save(output, format="PNG")
+    return output.getvalue()
+
+
+def _preview(*, fit: str, panel: Panel | None = None) -> Image.Image:
+    raw = build_device_preview_png(
+        _source_png(),
+        panel=panel or Panel(w=8, h=8),
+        settings={"image_fit": fit},
+    )
+    with Image.open(io.BytesIO(raw)) as image:
+        return image.convert("RGB")
+
+
+@pytest.mark.parametrize("fit", ["fit", "fill", "blur", "stretch", "center"])
+def test_all_photo_fit_modes_produce_exact_logical_panel_size(fit: str) -> None:
+    assert _preview(fit=fit).size == (8, 8)
+
+
+def test_fit_modes_preserve_their_distinct_layout_semantics() -> None:
+    fit = _preview(fit="fit")
+    fill = _preview(fit="fill")
+    blur = _preview(fit="blur")
+    stretch = _preview(fit="stretch")
+    center = _preview(fit="center")
+
+    assert fit.getpixel((0, 0)) == (255, 255, 255)
+    assert center.getpixel((0, 0)) == (255, 255, 255)
+    assert fill.getpixel((0, 0)) != (255, 255, 255)
+    assert stretch.getpixel((0, 0)) != (255, 255, 255)
+    assert blur.getpixel((0, 0)) != (255, 255, 255)
+
+    # Fit scales the full source up; Center keeps the original 4x2 pixels.
+    fit_nonwhite = sum(pixel != (255, 255, 255) for pixel in fit.getdata())
+    center_nonwhite = sum(pixel != (255, 255, 255) for pixel in center.getdata())
+    assert fit_nonwhite > center_nonwhite
+
+
+def test_preview_stays_upright_when_wire_artifact_needs_mount_compensation() -> None:
+    normal = _preview(fit="stretch", panel=Panel(w=3, h=5))
+    compensated = _preview(
+        fit="stretch",
+        panel=Panel(
+            w=3,
+            h=5,
+            flip=True,
+            vflip=True,
+            native_w=5,
+            native_h=3,
+        ),
+    )
+
+    assert compensated.size == (3, 5)
+    assert list(compensated.getdata()) == list(normal.getdata())
+    assert compensated.getpixel((0, 0))[0] > compensated.getpixel((0, 0))[2]
+    assert compensated.getpixel((2, 0))[2] > compensated.getpixel((2, 0))[0]
+
+
+def test_preview_applies_logical_underscan() -> None:
+    preview = _preview(fit="stretch", panel=Panel(w=8, h=8, underscan=2))
+
+    assert preview.getpixel((0, 0)) == (255, 255, 255)
+    assert preview.getpixel((2, 2)) != (255, 255, 255)
+
+
+def test_preview_uses_renderer_letterbox_background() -> None:
+    raw = build_device_preview_png(
+        _source_png(),
+        panel=Panel(w=8, h=8),
+        settings={"scale": "fit", "bg": "black"},
+    )
+    with Image.open(io.BytesIO(raw)) as image:
+        assert image.convert("RGB").getpixel((0, 0)) == (0, 0, 0)
+
+
+def test_content_addressed_preview_round_trip_and_safe_lookup(tmp_path: Path) -> None:
+    digest = write_device_preview(
+        tmp_path,
+        _source_png(),
+        panel=Panel(w=8, h=8),
+        settings={"image_fit": "fill"},
+    )
+    retained = retained_device_preview(tmp_path, digest)
+
+    assert len(digest) == 16
+    assert retained is not None
+    assert retained.etag == digest
+    assert retained.path == (tmp_path / f"{digest}.png").resolve()
+    assert retained_device_preview(tmp_path, f"../{digest}") is None

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -163,6 +163,10 @@ def test_push_fans_out_to_every_renderer(tmp_path: Path, composition_png: bytes)
     assert result.status == "sent"
     assert {r.renderer_id for r in result.renderers} == {"pi_png", "esp32_bin"}
     assert all(r.error is None for r in result.renderers)
+    assert all(r.preview_digest is not None for r in result.renderers)
+    assert all(
+        (tmp_path / "renders" / f"{r.preview_digest}.png").exists() for r in result.renderers
+    )
 
     # Both renderers' artifacts on disk.
     written = sorted(p.name for p in (tmp_path / "renders").iterdir())
@@ -206,6 +210,52 @@ def test_push_skips_publish_when_composition_matches_last_served(
     assert all(r.unchanged and r.error is None for r in second.renderers)
     # No additional publish for the same digest.
     assert len(mqtt_client.published) == publishes_after_first
+
+
+def test_no_change_backfills_missing_device_preview_without_repaint(
+    tmp_path: Path, composition_png: bytes
+) -> None:
+    renderers = [_make_renderer(tmp_path, "pi_png", "png", retain=False)]
+    manager, mqtt_client, png = _wired(tmp_path, composition_png, renderers)
+
+    with patch("app.push.capture_composed", return_value=(png, [])):
+        first = manager.push("home")
+    assert first.status == "sent"
+    latest = manager.latest_render_for("pi_png")
+    assert latest is not None
+    old_preview = str(latest.pop("preview_digest"))
+    (manager._renders_dir / f"{old_preview}.png").unlink()
+    publishes = len(mqtt_client.published)
+
+    with patch("app.push.capture_composed", return_value=(png, [])):
+        second = manager.push("home")
+
+    assert second.status == "no_change"
+    latest = manager.latest_render_for("pi_png")
+    assert latest is not None
+    preview_digest = str(latest["preview_digest"])
+    assert (manager._renders_dir / f"{preview_digest}.png").exists()
+    assert len(mqtt_client.published) == publishes
+
+
+def test_device_preview_failure_does_not_fail_physical_delivery(
+    tmp_path: Path, composition_png: bytes
+) -> None:
+    renderers = [_make_renderer(tmp_path, "pi_png", "png", retain=False)]
+    manager, mqtt_client, png = _wired(tmp_path, composition_png, renderers)
+
+    with (
+        patch("app.push.capture_composed", return_value=(png, [])),
+        patch("app.push.write_device_preview", side_effect=OSError("disk full")),
+    ):
+        result = manager.push("home")
+
+    assert result.status == "sent"
+    assert len(mqtt_client.published) == 1
+    assert result.renderers[0].preview_digest is None
+    latest = manager.latest_render_for("pi_png")
+    assert latest is not None
+    assert latest["preview_digest"] is None
 
 
 def test_push_force_publish_bypasses_content_skip(tmp_path: Path, composition_png: bytes) -> None:
@@ -1145,9 +1195,11 @@ def test_prune_keeps_live_frame_artifacts_without_event_rows(
         "ext": "bin",
         "filename": "liveart123456.bin",
         "composition_digest": "livecomp12345",
+        "preview_digest": "liveprev123456",
     }
     (renders / "liveart123456.bin").write_bytes(b"x")
     (renders / "livecomp12345.png").write_bytes(b"x")
+    (renders / "liveprev123456.png").write_bytes(b"x")
     (renders / "livecomp12345.regions.json").write_text('{"v":1,"regions":[]}')
     (renders / "orphan99999999.png").write_bytes(b"x")
 
@@ -1155,6 +1207,7 @@ def test_prune_keeps_live_frame_artifacts_without_event_rows(
     assert removed == 1
     assert (renders / "liveart123456.bin").exists()
     assert (renders / "livecomp12345.png").exists()
+    assert (renders / "liveprev123456.png").exists()
     assert (renders / "livecomp12345.regions.json").exists(), (
         "the live frame's touch-region sidecar must survive the prune"
     )


### PR DESCRIPTION
## Summary

- retain a content-addressed logical-screen PNG for each device's latest full render
- apply the selected Fit, Fill, Blur, Stretch, or Center layout in logical panel coordinates
- preserve device underscan and renderer letterbox background without exposing firmware-native rotation, mount flip, or vertical scan compensation
- serve that preview from the existing Companion endpoint with its own ETag and safe retained-file lookup
- backfill previews for pre-upgrade latest-render records on the next unchanged render without repainting the e-ink panel
- keep live, previous, and warmed Deck previews protected by the existing artifact GC

## Why

`GET /api/app/v1/devices/{device_id}/preview` currently serves the original composition PNG. For photo sends that means the iOS Displays card always looks like the source image, even when the display actually used Fill, Blur, Stretch, or Center. It can also misrepresent portrait displays because renderer wire artifacts include firmware-native row-stride and mount compensation that should not appear in a phone preview.

This implements the OpenAPI 0.4 logical device-preview contract discussed in #147. It deliberately stops at accurate fit, geometry, underscan, low-battery overlay, and supported letterbox background. Renderer palette, quantisation, tone, dither, and client-side saturation remain a renderer-specific follow-up rather than being presented as byte-exact on-glass output.

## Dependency

#153 has merged. This branch is rebased onto `main` after its `v0.211.0` version bump, so the PR now contains only the logical device-preview commit.

## Validation

- `pytest -q`: 2582 passed before the dependency rebase
- focused preview/push tests after rebasing onto current `main`: 70 passed
- `ruff check .`
- `ruff format --check .`
- `mypy --python-version 3.12 app/device_preview.py app/push.py app/companion_api.py`
- `git range-diff` confirmed the rebased commit is patch-equivalent to the reviewed implementation
- three independent read-only reviews of the renderer pipeline, OpenAPI/iOS contract, and security/lifecycle behavior found no blocking issues

Local mypy with the repository's configured Python 3.11 target is currently blocked before project code by the installed NumPy stub using Python 3.12 `type` syntax; the changed strict modules pass when checked against the active Python 3.12 environment.
