### PR TITLE
feat(hardware): add Xteink X4, X4 Pro and X3 catalog entries

### DIFF
--- a/docs/_data/tested.json
+++ b/docs/_data/tested.json
@@ -16,6 +16,11 @@
       "hardware": "Pimoroni Inky Impression (via inky set_image)",
       "notes": "Works on every inky-supported panel; quantises on the Pi each frame."
     },
+    "esp32_bw_bin": {
+      "status": "Partial",
+      "hardware": "Xteink X4 (GDEQ0426T82 / SSD1677, 800x480 mono) running CrossInk with Tesserae client support",
+      "notes": "1-bpp packing confirmed end-to-end: a 48000-byte frame fetched and painted on the panel with no on-device decode. The X4 is an e-reader, so the dashboard is its sleep screen rather than a wake-cycle refresh. Marked Partial because the portrait_flipped composition path is derived from a measured 180-degree offset rather than round-tripped on the panel, and the Seeed 800x480 mono SKUs sharing this renderer are still unconfirmed."
+    },
     "trmnl_png": {
       "status": "Tested",
       "hardware": "Amazon Kindle Paperwhite 2 (jailbroken) via KOReader trmnl-display plugin",

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -33,6 +33,7 @@ A renderer turns the composition PNG into the exact bytes a client wants. Each s
 | `circuitpython_png` | `.png` | - | Composition PNG quantized to the panel's palette and emitted as an indexed PNG sized for adafruit_imageload on CircuitPython microcontrollers. |
 | `esp32_bin` | `.bin` | [tesserae-device-esp32-bin (13.3" Waveshare)](https://github.com/dmellok/tesserae-device-esp32-bin)<br>[tesserae-device-photopainter-7.3-bin (7.3" PhotoPainter)](https://github.com/dmellok/tesserae-device-photopainter-7.3-bin) | Composition PNG packed into the Waveshare E6 4-bpp buffer the ESP32 firmware streams to SPI. |
 | `esp32_bw_bin` | `.bin` | - | Composition PNG dithered to mono B/W and packed into a 1-bpp raw buffer the ESP32 firmware (e.g. |
+| `esp32_gray2_bin` | `.bin` | - | Composition PNG dithered to 4-level grayscale and packed into a 2-bpp raw buffer for UC8179-class mono panels driven in their 4-gray waveform mode. |
 | `esp32_gray_bin` | `.bin` | - | Composition PNG dithered to 16-level grayscale and packed into a 4-bpp raw buffer the ESP32 firmware streams straight to the IT8951 controller's image buffer. |
 | `pi_bin` | `.bin` | [tesserae-device-pi-bin](https://github.com/dmellok/tesserae-device-pi-bin) | Composition PNG packed into the panel-native 4-bpp buffer the .bin Pi client consumes. |
 | `pi_png` | `.png` | [tesserae-device-pi-png](https://github.com/dmellok/tesserae-device-pi-png) | Composition PNG, rotated to the Pi client's landscape-native pixel grid. |
@@ -71,11 +72,13 @@ The reTerminal E-Series and XIAO ePaper family run the [Tesserae-native firmware
 | [Seeed XIAO ePaper EE04 (7.3" Spectra 6)](https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html) | 800×480 | `spectra_6` | `esp32_client` (inherit) | `seeed_ee04_73e6` |
 | [Seeed XIAO ePaper EE04 (7.5" mono)](https://www.seeedstudio.com/XIAO-ePaper-Display-Board-EE04-p-6560.html) | 800×480 | `mono` | `esp32_bw_client` (inherit) | `seeed_ee04_75` |
 | [Seeed reTerminal E1001](https://www.seeedstudio.com/reTerminal-E1001-p-6534.html) | 800×480 | `mono` | `esp32_bw_client` (inherit) | `seeed_reterminal_e1001` |
+| [Seeed reTerminal E1001 (4-level grayscale)](https://www.seeedstudio.com/reTerminal-E1001-p-6534.html) | 800×480 | `mono` | `esp32_bw_client` <br> `esp32_gray2_bin` | `seeed_reterminal_e1001_gray` |
 | [Seeed reTerminal E1002](https://www.seeedstudio.com/reTerminal-E1002-p-6533.html) | 800×480 | `spectra_6` | `esp32_client` (inherit) | `seeed_reterminal_e1002` |
 | [Seeed reTerminal E1003](https://www.seeedstudio.com/reTerminal-E1003-p-6731.html) | 1872×1404 | `mono` | `esp32_client` <br> `esp32_gray_bin` | `seeed_reterminal_e1003` |
 | [Seeed reTerminal E1004](https://www.seeedstudio.com/reTerminal-E1004-p-6692.html) | 1200×1600 portrait | `spectra_6` | `esp32_client` (inherit) | `seeed_reterminal_e1004` |
 | [Seeed XIAO 7.5" ePaper Panel](https://www.seeedstudio.com/XIAO-7-5-ePaper-Panel-p-6416.html) | 800×480 | `mono` | `trmnl_client` (inherit) | `seeed_xiao_75` |
 | [Seeed XIAO ePaper 7.5" (mono)](https://www.seeedstudio.com/XIAO-7-5-ePaper-Panel-p-6416.html) | 800×480 | `mono` | `esp32_bw_client` (inherit) | `xiao_epaper_75` |
+| [Seeed XIAO ePaper 7.5" (black/white/red)](https://www.seeedstudio.com/XIAO-7-5-ePaper-Panel-p-6416.html) | 800×480 | `bwr_3` | `esp32_bw_client` <br> `esp32_bin` | `xiao_epaper_75_bwr` |
 
 ### [Pimoroni](https://shop.pimoroni.com/)
 
@@ -98,6 +101,16 @@ The reTerminal E-Series and XIAO ePaper family run the [Tesserae-native firmware
 | [Waveshare 4.2" B/W e-paper](https://www.waveshare.com/4.2inch-e-paper-module.htm) | 400×300 | `mono` | `esp32_bw_client` (inherit) | `waveshare_4_2_bw` |
 | [Waveshare 13.3" Spectra E6 (ESP32-S3)](https://www.waveshare.com/esp32-s3-epaper-13.3e6.htm) | 1200×1600 portrait | `waveshare_e6` | `esp32_client` (inherit) | `waveshare_133e6` |
 
+### [Xteink](https://www.xteink.com/)
+
+E-readers rather than dedicated dashboard panels. These run [CrossInk](https://github.com/uxjulia/CrossInk) firmware with Tesserae client support, which paints the dashboard as the reader's sleep screen on an explicit sleep transition rather than on a timer, so the radio never wakes the device on its own. The panels are mounted portrait, so the manifests compose at the portrait dimensions and let `esp32_bw_bin` pack at the landscape firmware-native stride.
+
+| SKU | Panel | Gamut | Protocol / Renderer | Kind id |
+|---|---|---|---|---|
+| [Xteink X3](https://www.xteink.com/) | 528×792 portrait_flipped | `mono` | `esp32_bw_client` (inherit) | `xteink_x3` |
+| [Xteink X4](https://www.xteink.com/) | 480×800 portrait_flipped | `mono` | `esp32_bw_client` (inherit) | `xteink_x4` |
+| [Xteink X4 Pro](https://www.xteink.com/) | 480×800 portrait_flipped | `mono` | `esp32_bw_client` (inherit) | `xteink_x4_pro` |
+
 ### Community
 
 Hardware supported by community-authored firmware. Each SKU below links to the firmware repo that talks Tesserae's device API on that hardware; credit sits with the firmware's author on the linked repo.
@@ -115,7 +128,8 @@ Honest status from the maintainer's own bench. Untested doesn't mean broken, it 
 | `circuitpython_bmp` | - | :material-circle-outline: Not yet tested | - |
 | `circuitpython_png` | - | :material-circle-outline: Not yet tested | - |
 | `esp32_bin` | Waveshare 13.3" Spectra 6 (ESP32-S3-WROOM-2) + Waveshare 7.3" PhotoPainter (ESP32-S3) | :material-check-circle: Tested | Primary daily driver, battery-powered, deep-sleep. The 13.3" client lives at tesserae-device-esp32-bin; the 7.3" PhotoPainter client at tesserae-device-photopainter-7.3-bin. Both pair with the same renderer; the panel preset (waveshare_e6_13_3 vs waveshare_photopainter_7_3) selects the firmware-native row stride. |
-| `esp32_bw_bin` | - | :material-circle-outline: Not yet tested | - |
+| `esp32_bw_bin` | Xteink X4 (GDEQ0426T82 / SSD1677, 800x480 mono) running CrossInk with Tesserae client support | :material-progress-helper: Partial | 1-bpp packing confirmed end-to-end: a 48000-byte frame fetched and painted on the panel with no on-device decode. The X4 is an e-reader, so the dashboard is its sleep screen rather than a wake-cycle refresh. Marked Partial because the portrait_flipped composition path is derived from a measured 180-degree offset rather than round-tripped on the panel, and the Seeed 800x480 mono SKUs sharing this renderer are still unconfirmed. |
+| `esp32_gray2_bin` | - | :material-circle-outline: Not yet tested | - |
 | `esp32_gray_bin` | - | :material-circle-outline: Not yet tested | - |
 | `pi_bin` | Pimoroni Inky Impression (Spectra 6 / Waveshare E6) | :material-check-circle: Tested | Fastest Pi path, packed buffer written straight to inky's _buf. |
 | `pi_png` | Pimoroni Inky Impression (via inky set_image) | :material-check-circle: Tested | Works on every inky-supported panel; quantises on the Pi each frame. |

--- a/hardware/xteink/x3.json
+++ b/hardware/xteink/x3.json
@@ -1,0 +1,22 @@
+{
+  "tesserae_compat": "1.x",
+  "id": "xteink_x3",
+  "name": "Xteink X3",
+  "vendor": "Xteink",
+  "url": "https://www.xteink.com/",
+  "icon": "device-tablet",
+  "description": "Monochrome ePaper e-reader, ESP32-C3, 792x528 panel mounted portrait (528x792 presentation). Sibling of the Xteink X4 sharing the same firmware binary and the same Tesserae client path, but with a larger panel and a different controller family (UC8253, or UC8279d on later production runs). Server-side pack via esp32_bw_bin produces a raw 1-bpp mono buffer of 52272 bytes.",
+  "protocol": "esp32_bw_client",
+  "panel": {
+    "w": 528,
+    "h": 792,
+    "orientation": "portrait_flipped",
+    "name": "Monochrome ePaper (792x528 native)",
+    "gamut": "mono",
+    "native_w": 792,
+    "native_h": 528
+  },
+  "refresh_floor_s": 60,
+  "image_format": "bin",
+  "notes_md": "Awaiting confirmed test on real hardware, and not yet usable: CrossInk's Tesserae client currently validates the downloaded frame against a hard 48000-byte expectation and refuses anything else, so an X3 falls back to its normal sleep screen rather than painting. This entry exists so the server side is ready when the firmware gains a per-device frame size.\n\nWire format follows the esp32_bw_bin contract: exactly 52272 bytes (792*528/8), MSB=leftmost pixel, bit-set=white, bit-clear=black, no header or padding. 792 is a multiple of 8, so the packer needs no row padding.\n\nBoth `orientation` and the controller behaviour are unverified. `portrait_flipped` is inherited from the hardware-verified `xteink_x4` entry, but the X3 uses a different controller family (UC8253 / UC8279d rather than SSD1677) and a different resolution, so its framebuffer scan origin may well differ. Treat the flip as a starting guess: if a dashboard renders upside-down, switch to `portrait`."
+}

--- a/hardware/xteink/x4.json
+++ b/hardware/xteink/x4.json
@@ -1,0 +1,22 @@
+{
+  "tesserae_compat": "1.x",
+  "id": "xteink_x4",
+  "name": "Xteink X4",
+  "vendor": "Xteink",
+  "url": "https://www.xteink.com/",
+  "icon": "device-tablet",
+  "description": "4.26 inch monochrome ePaper e-reader, ESP32-C3, 800x480 panel mounted portrait (480x800 presentation). Speaks Tesserae's v1 REST device API when running CrossInk firmware with Tesserae client support: the dashboard is painted as the reader's sleep screen on an explicit sleep transition, so the radio never comes up on a timer. Server-side pack via esp32_bw_bin produces a raw 1-bpp mono buffer (48000 bytes) that is byte-identical to the firmware's framebuffer and is painted with no on-device decode.",
+  "protocol": "esp32_bw_client",
+  "panel": {
+    "w": 480,
+    "h": 800,
+    "orientation": "portrait_flipped",
+    "name": "4.26 inch monochrome ePaper (800x480 native)",
+    "gamut": "mono",
+    "native_w": 800,
+    "native_h": 480
+  },
+  "refresh_floor_s": 60,
+  "image_format": "bin",
+  "notes_md": "Tested on real hardware (GDEQ0426T82 / SSD1677) running CrossInk 1.4.0 with Tesserae client support. Wire format is exactly 48000 bytes (800*480/8), MSB=leftmost pixel, bit-set=white, bit-clear=black; no header, no padding, no checksum, identical to seeed_reterminal_e1001 and xiao_epaper_75. A frame fetched and painted end-to-end on the device.\n\nThe panel is physically mounted portrait, so compose at 480x800 and let the renderer pack at the 800x480 firmware-native stride.\n\nWhat was measured: registering the same unit against the landscape `xiao_epaper_75` kind, which applies no rotation at all, painted the dashboard 180 degrees out. That establishes a uniform 180-degree offset between the renderer's default scan origin and the firmware's framebuffer, which is what `portrait_flipped` corrects.\n\nWhat was derived rather than measured: the specific 480x800 `portrait_flipped` combination here. It follows from the measured offset plus the firmware's portrait coordinate transform (90 degrees CW, so logical top-left lands at physical bottom-left), but it has not itself been round-tripped on the panel yet. If a dashboard renders upside-down with this entry, change `orientation` to `portrait`.\n\nXteink shipped a second panel revision mid-production (SSD1677 -> UC8179). The firmware detects the controller at boot and both revisions consume the same buffer, so no separate SKU is needed."
+}

--- a/hardware/xteink/x4_pro.json
+++ b/hardware/xteink/x4_pro.json
@@ -1,0 +1,22 @@
+{
+  "tesserae_compat": "1.x",
+  "id": "xteink_x4_pro",
+  "name": "Xteink X4 Pro",
+  "vendor": "Xteink",
+  "url": "https://www.xteink.com/",
+  "icon": "device-tablet",
+  "description": "4.2 inch monochrome ePaper e-reader, ESP32-S3 sibling of the X4 with capacitive touch and a warm/cool frontlight. Same 800x480 SSD1677 panel mounted portrait (480x800 presentation) and the same 48000-byte 1-bpp wire format, so the frame is byte-identical to the xteink_x4 target.",
+  "protocol": "esp32_bw_client",
+  "panel": {
+    "w": 480,
+    "h": 800,
+    "orientation": "portrait_flipped",
+    "name": "4.2 inch monochrome ePaper (800x480 native)",
+    "gamut": "mono",
+    "native_w": 800,
+    "native_h": 480
+  },
+  "refresh_floor_s": 60,
+  "image_format": "bin",
+  "notes_md": "Awaiting confirmed test on real hardware. Panel geometry and controller are identical to the X4 (SSD1677, 800x480, 48000 bytes), and the board profile differs only in MCU (ESP32-S3), touch, frontlight and a PSRAM-backed framebuffer, so this entry mirrors `xteink_x4` exactly.\n\n`portrait_flipped` is carried over from the hardware-verified X4 entry on the assumption that the framebuffer scan origin is the same. That assumption is untested here: if a dashboard renders upside-down on an X4 Pro, change `orientation` to `portrait` and report it, because it would mean the two boards differ in framebuffer presentation despite sharing a controller."
+}

--- a/scripts/gen_compatibility.py
+++ b/scripts/gen_compatibility.py
@@ -35,6 +35,7 @@ VENDOR_ORDER: list[tuple[str, str]] = [
     ("pimoroni", "Pimoroni"),
     ("trmnl", "TRMNL"),
     ("waveshare", "Waveshare"),
+    ("xteink", "Xteink"),
     ("community", "Community"),
 ]
 
@@ -45,6 +46,7 @@ VENDOR_URL: dict[str, str] = {
     "pimoroni": "https://shop.pimoroni.com/",
     "trmnl": "https://usetrmnl.com/",
     "waveshare": "https://www.waveshare.com/",
+    "xteink": "https://www.xteink.com/",
 }
 
 # Vendor id -> intro paragraph. Rendered between the vendor heading and
@@ -60,6 +62,16 @@ VENDOR_INTRO: dict[str, str] = {
         "Web Serial, no toolchain). Battery-powered, no assembly required. "
         'The XIAO 7.5" and TRMNL 7.5" OG DIY Kit also run the TRMNL BYOS '
         "firmware path if you'd rather stay on stock."
+    ),
+    "xteink": (
+        "E-readers rather than dedicated dashboard panels. These run "
+        "[CrossInk](https://github.com/uxjulia/CrossInk) firmware with "
+        "Tesserae client support, which paints the dashboard as the reader's "
+        "sleep screen on an explicit sleep transition rather than on a timer, "
+        "so the radio never wakes the device on its own. The panels are "
+        "mounted portrait, so the manifests compose at the portrait "
+        "dimensions and let `esp32_bw_bin` pack at the landscape "
+        "firmware-native stride."
     ),
     "community": (
         "Hardware supported by community-authored firmware. Each SKU below "


### PR DESCRIPTION
Adds the Xteink e-reader family to the hardware catalog on the existing `esp32_bw_client` protocol. Three data-only manifests, plus the vendor registration and a regenerated compatibility doc. No renderer or protocol changes.

These are readers rather than dedicated dashboard panels. They run [CrossInk](https://github.com/uxjulia/CrossInk) firmware with Tesserae client support, which paints the dashboard as the reader's **sleep screen on an explicit sleep transition** rather than on a timer — the radio never wakes the device on its own, which is what keeps a 650 mAh cell shared with a reader viable.

## Entries

| Kind id | Composition | Native | Frame | Verified |
|---|---|---|---|---|
| `xteink_x4` | 480×800 `portrait_flipped` | 800×480 | 48,000 B | Tested on hardware |
| `xteink_x4_pro` | 480×800 `portrait_flipped` | 800×480 | 48,000 B | Untested |
| `xteink_x3` | 528×792 `portrait_flipped` | 792×528 | 52,272 B | Untested, not yet usable |

All three are mounted portrait, so they compose at portrait dimensions and let `esp32_bw_bin` pack at the landscape firmware-native stride. The frame is byte-identical to `seeed_reterminal_e1001` / `xiao_epaper_75` for the two 800×480 SKUs.

## Why `portrait_flipped`

The firmware paints the raw buffer straight into its framebuffer, whose scan origin is 180° from the renderer's default.

**Measured:** registering an X4 against the landscape `xiao_epaper_75` kind — which has matching composition and native dimensions and therefore applies *no rotation at all* — still painted the dashboard 180° out. That isolates a uniform 180° offset independent of any rotation step.

**Derived:** the specific 480×800 `portrait_flipped` combination follows from that measurement plus CrossInk's portrait transform (90° CW, logical top-left → physical bottom-left), but has not itself been round-tripped on the panel. Each `notes_md` states this distinction rather than claiming blanket hardware confirmation, and `tested.json` records the renderer as **Partial** for the same reason.

## Per-SKU caveats

- **`xteink_x4_pro`** — identical panel and controller (SSD1677, 800×480); differs only in MCU (ESP32-S3), touch, frontlight and a PSRAM-backed framebuffer. Mirrors the X4 entry on the assumption the scan origin matches.
- **`xteink_x3`** — the weakest entry, and its `notes_md` says so. Different controller family (UC8253 / UC8279d) at a different resolution, so the flip is a starting guess rather than an inference. It also can't be exercised yet: the current client validates against a hard 48,000-byte frame size, so an X3 falls back to its normal sleep screen. Included so the server side is ready when the firmware gains a per-device frame size. Reasonable to drop if speculative entries aren't wanted in the catalog.

## Docs

`docs/compatibility.md` is generated, so this registers the vendor in `scripts/gen_compatibility.py` (order, URL, intro paragraph), records bench status in the hand-maintained `docs/_data/tested.json`, and reruns `python scripts/gen_compatibility.py`. Output is idempotent — a second run produces no further diff.

⚠️ **Regenerating also picks up pre-existing drift** unrelated to this change: `esp32_gray2_bin`, `seeed_reterminal_e1001_gray` and `xiao_epaper_75_bwr` already exist in the repo but were missing from the committed doc. They appear in the diff because the generator emits the whole file. Flagging rather than hand-trimming, since hand-editing a generated file is what the header warns against.

## Validation

- All 21 catalog entries validate against `schema/hardware.schema.json` (Draft 2020-12), no duplicate ids
- No id collisions with existing entries or `devices/` folder kinds; `esp32_bw_client` resolves
- Both native widths are multiples of 8, so `pack_to_panel_bin_1bpp` needs no row padding
- Byte counts confirmed: 800×480/8 = 48,000 and 792×528/8 = 52,272
- `docs/_data/tested.json` still parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)