### PR TITLE
fix: preserve Companion History identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Fixed
 
+- **Companion Activity now keeps exact History and display identity.** Multi-panel
+  dashboard pushes preserve every canonical History event ID in their terminal
+  Job, and button-triggered fetch rows snapshot the originating device ID, so
+  clients no longer need title/time heuristics to suppress duplicate Activity
+  cards or identify the display that fetched a frame.
+
 - **Companion display previews now match each display's selected photo layout.**
   The server retains a separate logical-screen PNG after Fit, Fill, Blur,
   Stretch, or Center and device underscan are applied, so portrait displays no

--- a/app/button_service.py
+++ b/app/button_service.py
@@ -1767,6 +1767,7 @@ class ButtonService:
                 duration_s=0.0,
                 extra={
                     **origin_extra,
+                    "device_ids": [result.device_id],
                     "action_spec": result.action_spec,
                     "action_description": result.action_description,
                     "rotation_id": result.rotation_id,

--- a/app/companion_api.py
+++ b/app/companion_api.py
@@ -553,10 +553,18 @@ _PUBLISHED_STATUSES = frozenset({"sent", "no_change"})
 
 def _history_event_ids(result: Any) -> list[str] | None:
     """Exact canonical History correlation for a successful push result."""
+    correlated: list[str] = []
+    raw_event_ids = getattr(result, "event_ids", ())
+    if isinstance(raw_event_ids, (list, tuple)):
+        correlated.extend(
+            str(event_id)
+            for event_id in raw_event_ids
+            if isinstance(event_id, int) and event_id > 0
+        )
     event_id = getattr(result, "event_id", None)
     if isinstance(event_id, int) and event_id > 0:
-        return [str(event_id)]
-    return None
+        correlated.append(str(event_id))
+    return list(dict.fromkeys(correlated)) or None
 
 
 def _job_response(job: Any, status_code: int) -> Any:

--- a/app/push.py
+++ b/app/push.py
@@ -355,6 +355,7 @@ class PushResult:
     error: str | None = None
     renderers: list[RendererResult] = field(default_factory=list)
     event_id: int | None = None
+    event_ids: tuple[int, ...] = ()
 
 
 class PushManager:
@@ -1724,6 +1725,16 @@ class PushManager:
         else:
             status = "sent"
         digest = next((r.composition_digest for r in group_results if r.composition_digest), "")
+        event_ids = tuple(
+            dict.fromkeys(
+                event_id
+                for result in group_results
+                for event_id in (
+                    result.event_ids or ((result.event_id,) if result.event_id is not None else ())
+                )
+                if event_id > 0
+            )
+        )
         return PushResult(
             status=status,
             page_id=page_id,
@@ -1731,6 +1742,8 @@ class PushManager:
             duration_s=time.monotonic() - started,
             renderers=all_renderers,
             error=None if status == "sent" else "one or more panels failed to render/publish",
+            event_id=event_ids[0] if len(event_ids) == 1 else None,
+            event_ids=event_ids,
         )
 
     def _push_bytes_locked(
@@ -2110,6 +2123,7 @@ class PushManager:
             error=error,
             renderers=results,
             event_id=event_id,
+            event_ids=(event_id,),
         )
 
     def _overlay_low_battery_if_needed(self, composition_png: bytes, device_id: str) -> bytes:

--- a/tests/companion/test_companion_jobs.py
+++ b/tests/companion/test_companion_jobs.py
@@ -176,6 +176,15 @@ def test_dashboard_push_creates_job_that_publishes(app: Flask) -> None:
     assert fake.push_calls == [{"page_id": "pantry", "device_ids": {device}}]
 
 
+def test_history_event_ids_preserve_multi_panel_aggregate() -> None:
+    result = SimpleNamespace(
+        event_id=None,
+        event_ids=(101, 102, 101),
+    )
+
+    assert companion_api._history_event_ids(result) == ["101", "102"]
+
+
 def test_dashboard_push_unknown_dashboard_is_404(app: Flask) -> None:
     _install_fake_push(app)
     token = _token(app)

--- a/tests/test_button_service.py
+++ b/tests/test_button_service.py
@@ -846,6 +846,7 @@ def test_fetch_latest_press_emits_fetched_history_row(
     assert len(rows) == 1
     assert rows[0].status == "fetched"
     assert rows[0].digest is None
+    assert rows[0].extra["device_ids"] == ["kitchen"]
     assert rows[0].extra["action_spec"] == "fetch_latest"
     assert rows[0].extra["composition_digest"] == "composition456"
     assert rows[0].extra["pushed_page_id"] is None
@@ -877,6 +878,7 @@ def test_fetch_latest_without_existing_frame_keeps_preview_empty(
     row = _button_rows(event_log)[0]
     assert row.status == "fetched"
     assert row.digest is None
+    assert row.extra["device_ids"] == ["kitchen"]
     assert "composition_digest" not in row.extra
 
 

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -681,6 +681,10 @@ def test_multi_device_page_renders_once_per_panel_and_routes(
         "esp32_bin__esp32_land",
         "esp32_bin__esp32_port",
     }
+    assert result.event_id is None
+    assert len(result.event_ids) == 2
+    assert len(set(result.event_ids)) == 2
+    assert all(manager._event_log.get(event_id) is not None for event_id in result.event_ids)
 
 
 def test_push_device_filter_targets_single_display(tmp_path: Path, composition_png: bytes) -> None:


### PR DESCRIPTION
## Summary

- preserve every canonical History event ID produced by a multi-panel dashboard push
- expose those IDs through the existing terminal Job `history_event_ids` field
- snapshot the originating display ID on button-triggered History rows
- retain the existing singular `event_id` behavior for single-panel callers

## Why

Follow-up to Discussion #147.

The iOS Companion shows an accepted/running Job immediately, then replaces it
with canonical server History once the terminal Job identifies the History rows
it created. `PushManager.push()` renders once per distinct panel and each
`_fan_out()` call records its own canonical push event, but the aggregate
`PushResult` discarded those per-panel event IDs. A successful dashboard Job
therefore omitted `history_event_ids`, leaving clients with both the local Job
and server History card.

Button `fetch_latest` History had a related identity gap: the service knew the
originating device, but did not include it in the row's `device_ids` snapshot,
so Companion clients displayed “No displays”.

This keeps the public API shape unchanged. The new plural collection is
internal to `PushResult`; the Companion Job continues to return the existing
optional `history_event_ids` array.

## Validation

- `pytest tests/test_push.py tests/test_button_service.py tests/companion` — 159 passed
- `ruff check` on all changed Python files
- `ruff format` on all changed Python files
- `mypy --python-version 3.12 app/push.py app/companion_api.py app/button_service.py`
- `git diff --check`
