### PR TITLE
feat(companion): track last-served device previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Added
 
+- **Companion display cards distinguish served and pending frames.** REST
+  `/frame` polls now retain the last frame handed to each device, including
+  matching `304 Not Modified` confirmations. The Companion device preview uses
+  that served frame while `has_pending_render` reports when a newer render is
+  waiting for the panel's next wake; MQTT and push transports continue to use
+  the latest server render.
+
 - **Companion API 0.4 adds canonical History and all five photo layout modes.**
   Community clients can page through the same push History shown in the web UI,
   fetch retained composition previews, and idempotently resend an entry to its

--- a/app/companion_api.py
+++ b/app/companion_api.py
@@ -17,7 +17,7 @@ job the client polls; quiet-hours suppression surfaces as a *successful*
 app.mdns.
 
 Contract: ``charmmmz/tesserae-companion-ios`` ``Contracts/app-v1.openapi.yaml``
-(OpenAPI 0.4.0). The vendored copy + fixtures under ``tests/companion/``
+(OpenAPI 0.4.1). The vendored copy + fixtures under ``tests/companion/``
 guard these shapes.
 
 mypy --strict applies to this module, see pyproject.toml.
@@ -415,7 +415,11 @@ def _nullable_int(value: Any, *, lo: int | None = None, hi: int | None = None) -
     return out
 
 
-def _device_view(device: Device, status: dict[str, Any] | None) -> dict[str, Any]:
+def _device_view(
+    device: Device,
+    status: dict[str, Any] | None,
+    push_manager: Any,
+) -> dict[str, Any]:
     panel = device_panel(device) or resolve_settings_panel(_settings())
     parsed = status.get("parsed", {}) if isinstance(status, dict) else {}
     received_at = status.get("received_at") if isinstance(status, dict) else None
@@ -430,6 +434,11 @@ def _device_view(device: Device, status: dict[str, Any] | None) -> dict[str, Any
         freshness = "fresh" if age <= _freshness_threshold_s(device) else "stale"
 
     fw = parsed.get("fw_version") if isinstance(parsed, dict) else None
+    has_pending_render = False
+    if device.transport == "rest" and push_manager is not None:
+        pending_lookup = getattr(push_manager, "has_pending_render", None)
+        if callable(pending_lookup):
+            has_pending_render = bool(pending_lookup(device.id))
 
     return {
         "id": device.id,
@@ -448,6 +457,7 @@ def _device_view(device: Device, status: dict[str, Any] | None) -> dict[str, Any
         ),
         "rssi_dbm": _nullable_int(parsed.get("rssi") if isinstance(parsed, dict) else None),
         "firmware_version": (str(fw) if isinstance(fw, (str, int, float)) else None),
+        "has_pending_render": has_pending_render,
     }
 
 
@@ -455,8 +465,9 @@ def _device_view(device: Device, status: dict[str, Any] | None) -> dict[str, Any
 @_require_companion("devices:read")
 def list_devices() -> Any:
     status_cache = _device_status()
+    manager = _push_manager()
     devices = [
-        _device_view(d, status_cache.get(d.id))
+        _device_view(d, status_cache.get(d.id), manager)
         for d in _devices().all()
         if d.kind_of is not None  # instances only, never built-in kinds
     ]
@@ -944,22 +955,36 @@ def get_job(job_id: str) -> Any:
 @bp.get("/devices/<device_id>/preview")
 @_require_companion("devices:read")
 def device_preview(device_id: str) -> Any:
-    """Latest logical full-frame PNG for a display.
+    """Last-served logical full-frame PNG for a display.
 
-    The preview includes the selected image-fit mode and logical panel
-    geometry, but excludes hardware-only row-stride and mount compensation.
-    A live partial-refresh patch may be newer than this last full frame.
+    REST polling devices use the frame most recently returned by ``/frame``;
+    transports without a reliable served signal fall back to server-latest.
+    The preview includes the selected image-fit mode and logical panel geometry,
+    but excludes hardware-only row-stride and mount compensation. A live
+    partial-refresh patch may be newer than this last full frame.
     """
     device = _devices().get(device_id)
     if device is None or device.kind_of is None:
         return _error("not_found", "No display with that id.", 404)
     manager = _push_manager()
-    latest = manager.latest_render_for(device_id) if manager is not None else None
-    if not isinstance(latest, dict):
-        return _error("not_found", "No frame has been rendered for this display yet.", 404)
-    digest = latest.get("preview_digest")
+    render: dict[str, Any] | None = None
+    if manager is not None:
+        if device.transport == "rest":
+            served_lookup = getattr(manager, "last_served_render_for", None)
+            if callable(served_lookup):
+                render = served_lookup(device_id)
+        else:
+            render = manager.latest_render_for(device_id)
+    if not isinstance(render, dict):
+        message = (
+            "No frame has been served to this display yet."
+            if device.transport == "rest"
+            else "No frame has been rendered for this display yet."
+        )
+        return _error("not_found", message, 404)
+    digest = render.get("preview_digest")
     if digest is None:
-        return _error("not_found", "No preview is available for the latest frame yet.", 404)
+        return _error("not_found", "No preview is available for the served frame yet.", 404)
 
     retained = retained_device_preview(Path(current_app.config["RENDERS_DIR"]), digest)
     if retained is None:

--- a/app/push.py
+++ b/app/push.py
@@ -595,6 +595,81 @@ class PushManager:
         frame the renderer just wrote, not a stale guess."""
         return self._latest_renders.get(device_id)
 
+    def last_served_render_for(self, device_id: str) -> dict[str, Any] | None:
+        """The full frame most recently handed to a REST device.
+
+        This is deliberately a delivery-side snapshot, not a claim that the
+        physical panel completed its download or refresh.  The fields live on
+        the persisted latest-render entry so they survive restarts without a
+        second state store.
+        """
+        entry = self._latest_renders.get(device_id)
+        if not isinstance(entry, dict):
+            return None
+        digest = entry.get("last_served_digest")
+        if not isinstance(digest, str) or not digest:
+            return None
+        return {
+            "digest": digest,
+            "preview_digest": entry.get("last_served_preview_digest"),
+        }
+
+    def record_frame_served(self, device_id: str, render: dict[str, Any]) -> None:
+        """Persist the render snapshot returned by a REST ``/frame`` poll.
+
+        ``render`` is the response's captured latest-render entry.  A newer
+        render may land while that response is being assembled, so record the
+        captured digest on the current entry rather than assuming it is still
+        the current digest.
+        """
+        digest = render.get("digest")
+        if not isinstance(digest, str) or not digest:
+            return
+        preview_digest = render.get("preview_digest")
+        with self._lock:
+            current = self._latest_renders.get(device_id)
+            if current is None:
+                return
+            changed = current.get("last_served_digest") != digest
+            current["last_served_digest"] = digest
+            if isinstance(preview_digest, str) and preview_digest:
+                changed = changed or current.get("last_served_preview_digest") != preview_digest
+                current["last_served_preview_digest"] = preview_digest
+            else:
+                changed = changed or "last_served_preview_digest" in current
+                current.pop("last_served_preview_digest", None)
+            if changed:
+                self._save_latest_renders()
+
+    def has_pending_render(self, device_id: str) -> bool:
+        """Whether the latest render differs from the last REST-served frame."""
+        entry = self._latest_renders.get(device_id)
+        if not isinstance(entry, dict):
+            return False
+        latest_digest = entry.get("digest")
+        if not isinstance(latest_digest, str) or not latest_digest:
+            return False
+        return latest_digest != entry.get("last_served_digest")
+
+    def _replace_latest_render_locked(self, device_id: str, info: dict[str, Any]) -> None:
+        """Replace a live render while carrying its delivery-side snapshot.
+
+        Callers hold ``_lock``.  A render promotion changes what the server
+        wants to serve next; it must not rewrite what the device fetched last.
+        """
+        previous = self._latest_renders.get(device_id)
+        replacement = dict(info)
+        for key in (
+            "last_served_digest",
+            "last_served_preview_digest",
+        ):
+            replacement.pop(key, None)
+            if previous is not None and key in previous:
+                replacement[key] = previous[key]
+        self._retire_live_locked(device_id, str(replacement.get("digest") or ""))
+        self._latest_renders[device_id] = replacement
+        self._save_latest_renders()
+
     def consume_force_refetch(self, device_id: str) -> None:
         """Clear the one-shot resend refetch flag (#119) after a REST
         client has been served a 200 for it, so subsequent polls of the
@@ -674,9 +749,7 @@ class PushManager:
             info = self._deck_renders.get(device_id, {}).get(page_id)
             if info is None:
                 return False
-            self._retire_live_locked(device_id, str(info.get("digest") or ""))
-            self._latest_renders[device_id] = dict(info)
-            self._save_latest_renders()
+            self._replace_latest_render_locked(device_id, info)
             # The live frame changed; a patch anchored to the old frame
             # must not survive it.
             self._drop_patches_locked(device_id, keep_digest=str(info.get("digest") or ""))
@@ -768,9 +841,7 @@ class PushManager:
             cur = self._latest_renders.get(device_id)
             if cur is not None and cur.get("digest") != anchor_digest:
                 return "superseded"
-            self._retire_live_locked(device_id, str(info.get("digest") or ""))
-            self._latest_renders[device_id] = dict(info)
-            self._save_latest_renders()
+            self._replace_latest_render_locked(device_id, info)
             self._drop_patches_locked(device_id, keep_digest=str(info.get("digest") or ""))
         return "promoted"
 
@@ -1496,7 +1567,12 @@ class PushManager:
         for per_page in list(self._deck_renders.values()):
             entries.extend(per_page.values())
         for entry in entries:
-            for key in ("digest", "composition_digest", "preview_digest"):
+            for key in (
+                "digest",
+                "composition_digest",
+                "preview_digest",
+                "last_served_preview_digest",
+            ):
                 value = entry.get(key)
                 if isinstance(value, str) and value:
                     live.add(value)
@@ -2025,9 +2101,7 @@ class PushManager:
                         self._latest_renders.get(renderer.device, {}).get("digest"),
                     )
                 else:
-                    self._retire_live_locked(renderer.device, result.digest)
-                    self._latest_renders[renderer.device] = render_info
-                    self._save_latest_renders()
+                    self._replace_latest_render_locked(renderer.device, render_info)
                     # The live frame changed; a pending patch document
                     # anchored to the previous frame must not survive it.
                     self._drop_patches_locked(renderer.device, keep_digest=result.digest)

--- a/app/rest_api.py
+++ b/app/rest_api.py
@@ -832,6 +832,11 @@ def get_frame(device_id: str) -> Response:
         resp = Response(status=304)
         resp.headers["ETag"] = etag
         resp.headers["Content-Location"] = image_url
+        if push_mgr is not None:
+            # A matching 304 confirms the device already holds this frame.
+            # Advancing last-served here clears Companion's pending badge
+            # without forcing an otherwise unnecessary download.
+            push_mgr.record_frame_served(device.id, latest)
         return resp
     if force_refetch and push_mgr is not None:
         push_mgr.consume_force_refetch(device.id)
@@ -902,6 +907,8 @@ def get_frame(device_id: str) -> Response:
     resp.headers["ETag"] = etag
     resp.headers["Content-Location"] = image_url
     resp.headers["Cache-Control"] = "no-cache"
+    if push_mgr is not None:
+        push_mgr.record_frame_served(device.id, latest)
     return resp
 
 

--- a/tests/companion/_schema.py
+++ b/tests/companion/_schema.py
@@ -1,5 +1,5 @@
 """Shared helpers for validating Companion API payloads against the
-vendored OpenAPI 0.4.0 contract.
+vendored OpenAPI 0.4.1 contract.
 
 The spec + fixtures under ``contract/`` are a verbatim copy of
 ``charmmmz/tesserae-companion-ios`` ``Contracts/``. Keeping them in-tree

--- a/tests/companion/contract/Fixtures/devices-response.json
+++ b/tests/companion/contract/Fixtures/devices-response.json
@@ -14,7 +14,8 @@
       "last_seen_at": "2026-07-28T07:58:30Z",
       "battery_percent": 86,
       "rssi_dbm": -54,
-      "firmware_version": "1.8.0"
+      "firmware_version": "1.8.0",
+      "has_pending_render": true
     },
     {
       "id": "e1004-desk",
@@ -30,7 +31,8 @@
       "last_seen_at": null,
       "battery_percent": null,
       "rssi_dbm": null,
-      "firmware_version": null
+      "firmware_version": null,
+      "has_pending_render": false
     }
   ]
 }

--- a/tests/companion/contract/app-v1.openapi.yaml
+++ b/tests/companion/contract/app-v1.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Tesserae Companion API
-  version: 0.4.0
+  version: 0.4.1
   description: >-
     Companion API contract for community-built clients. Previews, History,
     resend, and server-advertised image fit modes are optional additive
@@ -83,14 +83,16 @@ paths:
     get:
       tags: [Displays]
       operationId: getCompanionDevicePreview
-      summary: Read the latest device-specific viewable preview
+      summary: Read the device's last-served viewable preview
       parameters:
         - $ref: "#/components/parameters/IfNoneMatch"
       responses:
         "200":
           description: >-
-            Latest viewable PNG after image fit and device geometry have been
-            applied. Renderer-specific palette and quantisation should be
+            For REST polling devices, the last viewable PNG served through the
+            device frame endpoint after image fit and device geometry have
+            been applied. Other transports fall back to the latest server
+            render. Renderer-specific palette and quantisation should be
             represented when a reusable PNG can be produced from that stage.
           headers:
             ETag:
@@ -639,6 +641,12 @@ components:
         firmware_version:
           type: string
           nullable: true
+        has_pending_render:
+          type: boolean
+          description: >-
+            True when a REST polling device has not yet fetched the server's
+            latest render. False for transports without a reliable served
+            signal.
     Panel:
       type: object
       additionalProperties: false

--- a/tests/companion/test_companion_api.py
+++ b/tests/companion/test_companion_api.py
@@ -211,6 +211,33 @@ def test_devices_listing_is_contract_valid(app: Flask) -> None:
     # Never seen a heartbeat yet.
     assert device["freshness"] == "unknown"
     assert device["last_seen_at"] is None
+    assert device["has_pending_render"] is False
+
+
+def test_devices_listing_reports_a_pending_rest_render_until_frame_is_served(app: Flask) -> None:
+    device_id = _seed_device(app)
+    manager = app.config["PUSH_MANAGER"]
+    latest = {
+        "digest": "latest123456789",
+        "ext": "bin",
+        "filename": "latest123456789.bin",
+        "renderer_id": "pico_bin",
+        "timestamp": 1.0,
+        "composition_digest": "composition12345",
+        "preview_digest": "preview123456789",
+    }
+    manager._latest_renders[device_id] = latest
+    token = _token(app)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    pending = app.test_client().get("/api/app/v1/devices", headers=headers).get_json()
+    device = next(d for d in pending["devices"] if d["id"] == device_id)
+    assert device["has_pending_render"] is True
+
+    manager.record_frame_served(device_id, latest)
+    caught_up = app.test_client().get("/api/app/v1/devices", headers=headers).get_json()
+    device = next(d for d in caught_up["devices"] if d["id"] == device_id)
+    assert device["has_pending_render"] is False
 
 
 def test_dashboards_listing_is_contract_valid(app: Flask) -> None:

--- a/tests/companion/test_companion_previews.py
+++ b/tests/companion/test_companion_previews.py
@@ -74,18 +74,34 @@ def _seed_device(app: Flask, device_id: str = "kitchen") -> str:
 
 
 class _FakePush:
-    """Returns a fixed latest-render pointing at a seeded device preview."""
+    """Returns a fixed served render pointing at a seeded device preview."""
 
-    def __init__(self, preview_digest: object | None) -> None:
-        self._digest = preview_digest
+    def __init__(
+        self,
+        preview_digest: object | None,
+        *,
+        latest_preview_digest: object | None = None,
+    ) -> None:
+        self._served_digest = preview_digest
+        self._latest_digest = (
+            preview_digest if latest_preview_digest is None else latest_preview_digest
+        )
 
     def latest_render_for(self, device_id: str) -> Any:
-        if self._digest is None:
+        if self._latest_digest is None:
             return None
-        return {"preview_digest": self._digest}
+        return {"preview_digest": self._latest_digest}
+
+    def last_served_render_for(self, device_id: str) -> Any:
+        if self._served_digest is None:
+            return None
+        return {"preview_digest": self._served_digest}
 
 
 class _FakeLegacyPush:
+    def last_served_render_for(self, device_id: str) -> Any:
+        return {"composition_digest": "deadbeefcafe0000"}
+
     def latest_render_for(self, device_id: str) -> Any:
         return {"composition_digest": "deadbeefcafe0000"}
 
@@ -110,6 +126,43 @@ def test_device_preview_serves_logical_frame_with_etag(app: Flask) -> None:
     assert resp.get_data() == _PNG
     assert resp.headers["ETag"].strip('"') == "deadbeefcafe0001"
     assert resp.headers["Cache-Control"] == "private, no-cache"
+
+
+def test_device_preview_prefers_last_served_over_newer_server_render(app: Flask) -> None:
+    device = _seed_device(app)
+    _seed_render(app, "deadbeefcafe0010")
+    _seed_render(app, "deadbeefcafe0011")
+    app.config["PUSH_MANAGER"] = _FakePush(
+        "deadbeefcafe0010",
+        latest_preview_digest="deadbeefcafe0011",
+    )
+    token = _token(app)
+
+    resp = app.test_client().get(f"/api/app/v1/devices/{device}/preview", headers=_auth(token))
+
+    assert resp.status_code == 200
+    assert resp.headers["ETag"].strip('"') == "deadbeefcafe0010"
+
+
+def test_device_preview_uses_server_latest_for_non_rest_transport(app: Flask) -> None:
+    device_id = _seed_device(app)
+    device = app.config["DEVICE_REGISTRY"].get(device_id)
+    device.manifest["transport"] = "mqtt"
+    _seed_render(app, "deadbeefcafe0012")
+    _seed_render(app, "deadbeefcafe0013")
+    app.config["PUSH_MANAGER"] = _FakePush(
+        "deadbeefcafe0012",
+        latest_preview_digest="deadbeefcafe0013",
+    )
+    token = _token(app)
+
+    resp = app.test_client().get(
+        f"/api/app/v1/devices/{device_id}/preview",
+        headers=_auth(token),
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers["ETag"].strip('"') == "deadbeefcafe0013"
 
 
 @pytest.mark.parametrize(

--- a/tests/companion/test_contract_fixtures.py
+++ b/tests/companion/test_contract_fixtures.py
@@ -39,7 +39,7 @@ CASES = {
 
 def test_openapi_shape_and_operation_ids_are_stable() -> None:
     assert SPEC["openapi"] == "3.0.3"
-    assert SPEC["info"]["version"] == "0.4.0"
+    assert SPEC["info"]["version"] == "0.4.1"
     assert set(SPEC["paths"]) == {
         "/api/app/v1",
         "/api/app/v1/pair",

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1200,10 +1200,13 @@ def test_prune_keeps_live_frame_artifacts_without_event_rows(
         "filename": "liveart123456.bin",
         "composition_digest": "livecomp12345",
         "preview_digest": "liveprev123456",
+        "last_served_digest": "servedart12345",
+        "last_served_preview_digest": "servedprev12345",
     }
     (renders / "liveart123456.bin").write_bytes(b"x")
     (renders / "livecomp12345.png").write_bytes(b"x")
     (renders / "liveprev123456.png").write_bytes(b"x")
+    (renders / "servedprev12345.png").write_bytes(b"x")
     (renders / "livecomp12345.regions.json").write_text('{"v":1,"regions":[]}')
     (renders / "orphan99999999.png").write_bytes(b"x")
 
@@ -1212,10 +1215,44 @@ def test_prune_keeps_live_frame_artifacts_without_event_rows(
     assert (renders / "liveart123456.bin").exists()
     assert (renders / "livecomp12345.png").exists()
     assert (renders / "liveprev123456.png").exists()
+    assert (renders / "servedprev12345.png").exists()
     assert (renders / "livecomp12345.regions.json").exists(), (
         "the live frame's touch-region sidecar must survive the prune"
     )
     assert not (renders / "orphan99999999.png").exists()
+
+
+def test_latest_render_replacement_preserves_last_served_snapshot(
+    tmp_path: Path, composition_png: bytes
+) -> None:
+    renderers = [_make_renderer(tmp_path, "pi_png", "png", retain=False)]
+    manager, _, _ = _wired(tmp_path, composition_png, renderers)
+    manager._latest_renders["hall_e1003"] = {
+        "digest": "oldart12345678",
+        "filename": "oldart12345678.bin",
+        "preview_digest": "oldprev1234567",
+        "last_served_digest": "servedart12345",
+        "last_served_preview_digest": "servedprev12345",
+    }
+
+    with manager._lock:
+        manager._replace_latest_render_locked(
+            "hall_e1003",
+            {
+                "digest": "newart12345678",
+                "filename": "newart12345678.bin",
+                "preview_digest": "newprev1234567",
+            },
+        )
+
+    latest = manager.latest_render_for("hall_e1003")
+    assert latest["digest"] == "newart12345678"
+    assert latest["last_served_digest"] == "servedart12345"
+    assert latest["last_served_preview_digest"] == "servedprev12345"
+    assert manager.has_pending_render("hall_e1003") is True
+
+    persisted = json.loads(manager._latest_renders_path.read_text(encoding="utf-8"))
+    assert persisted["hall_e1003"]["last_served_preview_digest"] == "servedprev12345"
 
 
 def test_delete_history_keeps_live_frame_artifacts(tmp_path: Path, composition_png: bytes) -> None:

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -729,6 +729,7 @@ def test_frame_returns_url_and_etag_when_rendered(app: Flask) -> None:
         "renderer_id": "pico_bin",
         "timestamp": time.time(),
         "composition_digest": "comp123",
+        "preview_digest": "preview123",
     }
 
     resp = client.get(
@@ -744,6 +745,10 @@ def test_frame_returns_url_and_etag_when_rendered(app: Flask) -> None:
     assert "/renders/abc123.bin" in body["url"]
     assert "sig=" in body["url"]
     assert resp.headers["ETag"] == '"abc123"'
+    assert push_mgr.last_served_render_for("bedroom_pico") == {
+        "digest": "abc123",
+        "preview_digest": "preview123",
+    }
 
 
 def test_frame_carries_button_wake_for_button_kind(app: Flask) -> None:
@@ -1042,6 +1047,7 @@ def test_frame_returns_304_when_if_none_match_matches(app: Flask) -> None:
         "renderer_id": "pico_bin",
         "timestamp": time.time(),
         "composition_digest": "comp123",
+        "preview_digest": "preview123",
     }
 
     resp = client.get(
@@ -1058,11 +1064,14 @@ def test_frame_returns_304_when_if_none_match_matches(app: Flask) -> None:
     # reset, etc.) can still re-fetch the image. RFC 7231 §3.1.4.2
     # explicitly permits Content-Location on 304.
     assert "/renders/abc123.bin" in resp.headers["Content-Location"]
+    assert push_mgr.last_served_render_for("bedroom_pico")["digest"] == "abc123"
+    assert push_mgr.last_served_render_for("bedroom_pico")["preview_digest"] == "preview123"
+    assert push_mgr.has_pending_render("bedroom_pico") is False
 
 
 def test_fetch_latest_action_bypasses_matching_etag_without_rendering(app: Flask) -> None:
     """``fetch_latest`` returns the existing artefact with 200 while
-    leaving the render pipeline and latest-render entry untouched."""
+    leaving the render pipeline and latest-render content untouched."""
     client = app.test_client()
     _sign_in(client)
     code = _issue_pairing(app)
@@ -1098,7 +1107,9 @@ def test_fetch_latest_action_bypasses_matching_etag_without_rendering(app: Flask
 
     assert resp.status_code == 200
     assert resp.get_json()["render_id"] == "abc123"
-    assert push_mgr._latest_renders["bedroom_pico"] == latest
+    stored = push_mgr._latest_renders["bedroom_pico"]
+    assert {key: stored[key] for key in latest} == latest
+    assert stored["last_served_digest"] == "abc123"
 
 
 def test_frame_accepts_legacy_event_alias_and_prefers_canonical_id(app: Flask) -> None:


### PR DESCRIPTION
## Summary

- record the last frame actually served to each REST device on both `200` and matching `304` fetches
- expose that last-served logical preview through the Companion device preview route
- add a backward-compatible `has_pending_render` field so clients can distinguish the on-glass frame from a newer frame waiting for the next wake
- retain last-served preview artifacts through preview garbage collection and carry the state through render replacement
- update the Companion OpenAPI contract and fixtures to 0.4.1

## Why

A sleeping e-ink device may not have fetched the newest render yet. The existing Companion preview therefore represented the latest server-side frame, not necessarily what was physically on the display. This change gives the app an honest current-screen preview while still indicating when a newer frame is pending.

No firmware change is required: the server already knows which digest it returned from the REST frame endpoint. MQTT/push devices retain the existing latest-render preview behavior because delivery is not acknowledged through this polling path.

This follows the current-screen discussion in #147.

## Contract behavior

- `preview_url` for REST devices resolves to the last-served preview when available
- `has_pending_render` is `true` when the latest queued wire digest differs from the last-served digest
- a matching conditional `304` counts as serving the current frame and clears the pending state
- older state files remain valid; the new persisted fields are optional

## Validation

- `166 passed` across the affected push, REST, Companion API, preview, and contract tests
- Ruff passes for all affected Python files
- `git diff --check` passes
