### PR TITLE
feat(companion): expose pending render previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,13 @@ All notable changes to Tesserae are recorded here. Format loosely follows
   per-request interceptor during the webpage render). Webpage sends need a browser pool and are
   advertised only when one is present.
 
+- **Companion clients can inspect the exact frame waiting for a sleeping
+  display.** A REST device with `has_pending_render` now includes an optional
+  `pending_render` revision and authenticated preview URL. The existing device
+  preview endpoint accepts that revision while preserving its default
+  last-served meaning, so clients can present Current and Next without guessing
+  from global History or racing a newer render.
+
 - **Companion display cards distinguish served and pending frames.** REST
   `/frame` polls now retain the last frame handed to each device, including
   matching `304 Not Modified` confirmations. The Companion device preview uses

--- a/app/companion_api.py
+++ b/app/companion_api.py
@@ -17,7 +17,7 @@ job the client polls; quiet-hours suppression surfaces as a *successful*
 app.mdns.
 
 Contract: ``charmmmz/tesserae-companion-ios`` ``Contracts/app-v1.openapi.yaml``
-(OpenAPI 0.5.1). The vendored copy + fixtures under ``tests/companion/``
+(OpenAPI 0.5.2). The vendored copy + fixtures under ``tests/companion/``
 guard these shapes.
 
 mypy --strict applies to this module, see pyproject.toml.
@@ -38,7 +38,7 @@ from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from flask import Blueprint, Flask, current_app, g, jsonify, request
+from flask import Blueprint, Flask, current_app, g, jsonify, request, url_for
 from werkzeug.wrappers import Response
 
 from app.companion_history import (
@@ -448,12 +448,38 @@ def _device_view(
 
     fw = parsed.get("fw_version") if isinstance(parsed, dict) else None
     has_pending_render = False
+    pending_render: dict[str, Any] | None = None
     if device.transport == "rest" and push_manager is not None:
         pending_lookup = getattr(push_manager, "has_pending_render", None)
         if callable(pending_lookup):
             has_pending_render = bool(pending_lookup(device.id))
+        if has_pending_render:
+            latest_lookup = getattr(push_manager, "latest_render_for", None)
+            latest = latest_lookup(device.id) if callable(latest_lookup) else None
+            if isinstance(latest, dict):
+                revision = latest.get("digest")
+                preview_digest = latest.get("preview_digest")
+                if (
+                    isinstance(revision, str)
+                    and revision
+                    and isinstance(preview_digest, str)
+                    and preview_digest
+                ):
+                    pending_render = {
+                        "revision": revision,
+                        "preview_url": url_for(
+                            ".device_preview",
+                            device_id=device.id,
+                            revision=revision,
+                        ),
+                    }
+                    rendered_at = latest.get("timestamp")
+                    if isinstance(rendered_at, (int, float)):
+                        pending_render["rendered_at"] = datetime.fromtimestamp(
+                            float(rendered_at), UTC
+                        ).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    return {
+    view = {
         "id": device.id,
         "name": device.display_name,
         "kind": str(device.kind_of or ""),
@@ -472,6 +498,9 @@ def _device_view(
         "firmware_version": (str(fw) if isinstance(fw, (str, int, float)) else None),
         "has_pending_render": has_pending_render,
     }
+    if pending_render is not None:
+        view["pending_render"] = pending_render
+    return view
 
 
 @bp.get("/devices")
@@ -1154,10 +1183,14 @@ def get_job(job_id: str) -> Any:
 @bp.get("/devices/<device_id>/preview")
 @_require_companion("devices:read")
 def device_preview(device_id: str) -> Any:
-    """Last-served logical full-frame PNG for a display.
+    """Logical full-frame PNG for a display.
 
-    REST polling devices use the frame most recently returned by ``/frame``;
-    transports without a reliable served signal fall back to server-latest.
+    Without ``revision``, REST polling devices use the frame most recently
+    returned by ``/frame``; transports without a reliable served signal fall
+    back to server-latest. A ``revision`` advertised by ``pending_render``
+    selects that exact server-latest render, including during the normal
+    superseded-render grace window.
+
     The preview includes the selected image-fit mode and logical panel geometry,
     but excludes hardware-only row-stride and mount compensation. A live
     partial-refresh patch may be newer than this last full frame.
@@ -1168,18 +1201,32 @@ def device_preview(device_id: str) -> Any:
     manager = _push_manager()
     render: dict[str, Any] | None = None
     if manager is not None:
-        if device.transport == "rest":
+        revision = request.args.get("revision", "").strip()
+        if revision:
+            latest_lookup = getattr(manager, "latest_render_for", None)
+            latest = latest_lookup(device_id) if callable(latest_lookup) else None
+            if isinstance(latest, dict) and latest.get("digest") == revision:
+                render = latest
+            else:
+                previous_lookup = getattr(manager, "previous_render_for", None)
+                previous = previous_lookup(device_id) if callable(previous_lookup) else None
+                if isinstance(previous, dict) and previous.get("digest") == revision:
+                    render = previous
+        elif device.transport == "rest":
             served_lookup = getattr(manager, "last_served_render_for", None)
             if callable(served_lookup):
                 render = served_lookup(device_id)
         else:
             render = manager.latest_render_for(device_id)
     if not isinstance(render, dict):
-        message = (
-            "No frame has been served to this display yet."
-            if device.transport == "rest"
-            else "No frame has been rendered for this display yet."
-        )
+        if request.args.get("revision", "").strip():
+            message = "No retained preview exists for that display revision."
+        else:
+            message = (
+                "No frame has been served to this display yet."
+                if device.transport == "rest"
+                else "No frame has been rendered for this display yet."
+            )
         return _error("not_found", message, 404)
     digest = render.get("preview_digest")
     if digest is None:

--- a/tests/companion/_schema.py
+++ b/tests/companion/_schema.py
@@ -1,5 +1,5 @@
 """Shared helpers for validating Companion API payloads against the
-vendored OpenAPI 0.5.0 contract.
+vendored OpenAPI 0.5.2 contract.
 
 The spec + fixtures under ``contract/`` are a verbatim copy of
 ``charmmmz/tesserae-companion-ios`` ``Contracts/``. Keeping them in-tree

--- a/tests/companion/contract/Fixtures/devices-response.json
+++ b/tests/companion/contract/Fixtures/devices-response.json
@@ -15,7 +15,12 @@
       "battery_percent": 86,
       "rssi_dbm": -54,
       "firmware_version": "1.8.0",
-      "has_pending_render": true
+      "has_pending_render": true,
+      "pending_render": {
+        "revision": "a1b2c3d4e5f67890",
+        "rendered_at": "2026-07-28T08:00:00Z",
+        "preview_url": "/api/app/v1/devices/picpak-kitchen/preview?revision=a1b2c3d4e5f67890"
+      }
     },
     {
       "id": "e1004-desk",

--- a/tests/companion/contract/app-v1.openapi.yaml
+++ b/tests/companion/contract/app-v1.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Tesserae Companion API
-  version: 0.5.1
+  version: 0.5.2
   description: >-
     Companion API contract for community-built clients. Previews, History,
     resend, remote-image push, webpage push, and server-advertised image fit
@@ -88,6 +88,14 @@ paths:
       summary: Read the device's last-served viewable preview
       parameters:
         - $ref: "#/components/parameters/IfNoneMatch"
+        - in: query
+          name: revision
+          required: false
+          description: >-
+            Exact pending-render revision advertised by the devices list.
+            When omitted, REST devices return their last-served frame.
+          schema:
+            type: string
       responses:
         "200":
           description: >-
@@ -717,6 +725,27 @@ components:
             True when a REST polling device has not yet fetched the server's
             latest render. False for transports without a reliable served
             signal. Absent on older compatible servers.
+        pending_render:
+          allOf:
+            - $ref: "#/components/schemas/PendingRender"
+          description: >-
+            The exact newer render waiting for a REST device's next fetch.
+            Omitted when no render is pending or its viewable preview is
+            unavailable.
+    PendingRender:
+      type: object
+      additionalProperties: false
+      required: [revision, preview_url]
+      properties:
+        revision:
+          type: string
+          description: Opaque revision accepted by the device preview endpoint
+        rendered_at:
+          type: string
+          format: date-time
+        preview_url:
+          type: string
+          description: Authenticated relative URL for this exact pending preview
     Panel:
       type: object
       additionalProperties: false

--- a/tests/companion/test_companion_api.py
+++ b/tests/companion/test_companion_api.py
@@ -238,11 +238,45 @@ def test_devices_listing_reports_a_pending_rest_render_until_frame_is_served(app
     pending = app.test_client().get("/api/app/v1/devices", headers=headers).get_json()
     device = next(d for d in pending["devices"] if d["id"] == device_id)
     assert device["has_pending_render"] is True
+    assert device["pending_render"] == {
+        "revision": "latest123456789",
+        "rendered_at": "1970-01-01T00:00:01Z",
+        "preview_url": (f"/api/app/v1/devices/{device_id}/preview?revision=latest123456789"),
+    }
 
     manager.record_frame_served(device_id, latest)
     caught_up = app.test_client().get("/api/app/v1/devices", headers=headers).get_json()
     device = next(d for d in caught_up["devices"] if d["id"] == device_id)
     assert device["has_pending_render"] is False
+    assert "pending_render" not in device
+
+
+def test_devices_listing_omits_pending_render_when_no_preview_exists(app: Flask) -> None:
+    device_id = _seed_device(app)
+    manager = app.config["PUSH_MANAGER"]
+    manager._latest_renders[device_id] = {
+        "digest": "latest123456789",
+        "ext": "bin",
+        "filename": "latest123456789.bin",
+        "renderer_id": "pico_bin",
+        "timestamp": 1.0,
+        "composition_digest": "composition12345",
+        "preview_digest": None,
+    }
+    token = _token(app)
+
+    body = (
+        app.test_client()
+        .get(
+            "/api/app/v1/devices",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        .get_json()
+    )
+
+    device = next(d for d in body["devices"] if d["id"] == device_id)
+    assert device["has_pending_render"] is True
+    assert "pending_render" not in device
 
 
 def test_dashboards_listing_is_contract_valid(app: Flask) -> None:

--- a/tests/companion/test_companion_previews.py
+++ b/tests/companion/test_companion_previews.py
@@ -81,21 +81,38 @@ class _FakePush:
         preview_digest: object | None,
         *,
         latest_preview_digest: object | None = None,
+        latest_revision: str = "latest000000001",
+        previous_preview_digest: object | None = None,
+        previous_revision: str = "previous0000001",
     ) -> None:
         self._served_digest = preview_digest
         self._latest_digest = (
             preview_digest if latest_preview_digest is None else latest_preview_digest
         )
+        self._latest_revision = latest_revision
+        self._previous_digest = previous_preview_digest
+        self._previous_revision = previous_revision
 
     def latest_render_for(self, device_id: str) -> Any:
         if self._latest_digest is None:
             return None
-        return {"preview_digest": self._latest_digest}
+        return {
+            "digest": self._latest_revision,
+            "preview_digest": self._latest_digest,
+        }
 
     def last_served_render_for(self, device_id: str) -> Any:
         if self._served_digest is None:
             return None
         return {"preview_digest": self._served_digest}
+
+    def previous_render_for(self, device_id: str) -> Any:
+        if self._previous_digest is None:
+            return None
+        return {
+            "digest": self._previous_revision,
+            "preview_digest": self._previous_digest,
+        }
 
 
 class _FakeLegacyPush:
@@ -142,6 +159,68 @@ def test_device_preview_prefers_last_served_over_newer_server_render(app: Flask)
 
     assert resp.status_code == 200
     assert resp.headers["ETag"].strip('"') == "deadbeefcafe0010"
+
+
+def test_device_preview_serves_exact_pending_revision(app: Flask) -> None:
+    device = _seed_device(app)
+    _seed_render(app, "deadbeefcafe0010")
+    _seed_render(app, "deadbeefcafe0011")
+    app.config["PUSH_MANAGER"] = _FakePush(
+        "deadbeefcafe0010",
+        latest_preview_digest="deadbeefcafe0011",
+        latest_revision="latest000000011",
+    )
+    token = _token(app)
+
+    resp = app.test_client().get(
+        f"/api/app/v1/devices/{device}/preview?revision=latest000000011",
+        headers=_auth(token),
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers["ETag"].strip('"') == "deadbeefcafe0011"
+
+
+def test_device_preview_serves_superseded_advertised_revision_during_grace_window(
+    app: Flask,
+) -> None:
+    device = _seed_device(app)
+    _seed_render(app, "deadbeefcafe0014")
+    app.config["PUSH_MANAGER"] = _FakePush(
+        "deadbeefcafe0010",
+        latest_preview_digest="deadbeefcafe0011",
+        latest_revision="latest000000011",
+        previous_preview_digest="deadbeefcafe0014",
+        previous_revision="previous0000014",
+    )
+    token = _token(app)
+
+    resp = app.test_client().get(
+        f"/api/app/v1/devices/{device}/preview?revision=previous0000014",
+        headers=_auth(token),
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers["ETag"].strip('"') == "deadbeefcafe0014"
+
+
+def test_device_preview_rejects_unknown_revision(app: Flask) -> None:
+    device = _seed_device(app)
+    _seed_render(app, "deadbeefcafe0011")
+    app.config["PUSH_MANAGER"] = _FakePush(
+        "deadbeefcafe0010",
+        latest_preview_digest="deadbeefcafe0011",
+        latest_revision="latest000000011",
+    )
+    token = _token(app)
+
+    resp = app.test_client().get(
+        f"/api/app/v1/devices/{device}/preview?revision=unknown",
+        headers=_auth(token),
+    )
+
+    assert resp.status_code == 404
+    assert resp.get_json()["error"]["code"] == "not_found"
 
 
 def test_device_preview_uses_server_latest_for_non_rest_transport(app: Flask) -> None:

--- a/tests/companion/test_contract_fixtures.py
+++ b/tests/companion/test_contract_fixtures.py
@@ -39,7 +39,7 @@ CASES = {
 
 def test_openapi_shape_and_operation_ids_are_stable() -> None:
     assert SPEC["openapi"] == "3.0.3"
-    assert SPEC["info"]["version"] == "0.5.1"
+    assert SPEC["info"]["version"] == "0.5.2"
     assert set(SPEC["paths"]) == {
         "/api/app/v1",
         "/api/app/v1/pair",
@@ -132,6 +132,23 @@ def test_preview_endpoints_are_read_only_and_conditional() -> None:
     extension = json.loads((FIXTURES_DIR / "capabilities-previews.json").read_text())
     assert "previews" not in base["features"]
     assert "previews" in extension["features"]
+
+
+def test_pending_render_identifies_an_exact_retrievable_preview() -> None:
+    devices = json.loads((FIXTURES_DIR / "devices-response.json").read_text())["devices"]
+    pending = next(device for device in devices if device["has_pending_render"])
+
+    assert pending["pending_render"] == {
+        "revision": "a1b2c3d4e5f67890",
+        "rendered_at": "2026-07-28T08:00:00Z",
+        "preview_url": ("/api/app/v1/devices/picpak-kitchen/preview?revision=a1b2c3d4e5f67890"),
+    }
+
+    revision_parameter = SPEC["paths"]["/api/app/v1/devices/{device_id}/preview"]["get"][
+        "parameters"
+    ][1]
+    assert revision_parameter["name"] == "revision"
+    assert revision_parameter["required"] is False
 
 
 def test_extended_capabilities_advertise_history_and_all_image_fit_modes() -> None:


### PR DESCRIPTION
## Summary

- add an optional `pending_render` object to REST device summaries when `has_pending_render` is true and a retained logical preview exists
- identify that queued frame with an opaque revision, render timestamp, and authenticated preview URL
- extend the existing `GET /api/app/v1/devices/{device_id}/preview` route with an optional `revision` query instead of adding a second preview endpoint
- keep the default preview semantic unchanged: REST devices still return their last-served frame when no revision is supplied
- update the vendored Companion contract to 0.5.2, preserving the 0.5 Link/Webpage routes and the 0.5.1 Dashboard icon field

## Why

#162 made the Displays preview truthful by showing the last frame handed to a sleeping REST panel and exposing only a boolean when a newer render is waiting. On-device use showed a useful next step: the Companion can say that an update is pending, but cannot show what that pending frame actually is.

Tesserae already retains both the server-latest render and its logical `preview_digest`. Exposing that existing information lets the app present an explicit **Current / Next** comparison without guessing from global History, duplicating render logic, or changing firmware.

This stays within the endpoint boundary discussed in #147: there is no second pending-preview route. The list response advertises the exact revision and a URL back to the existing preview route. Revision lookup also accepts the normal superseded-render grace slot, avoiding a race when a newer render lands between the list and preview requests.

## Contract behavior

A pending REST device may now include:

```json
{
  "has_pending_render": true,
  "pending_render": {
    "revision": "a1b2c3d4e5f67890",
    "rendered_at": "2026-07-28T08:00:00Z",
    "preview_url": "/api/app/v1/devices/picpak-kitchen/preview?revision=a1b2c3d4e5f67890"
  }
}
```

- `pending_render` is optional and omitted when the device is caught up or no viewable pending preview exists
- the preview URL requires the existing Companion bearer token and `devices:read` scope
- an unknown or expired revision returns the existing `404 not_found` shape
- existing clients remain compatible because the new field and query parameter are additive
- MQTT/push transports retain their existing server-latest fallback and do not advertise pending state

## Rebase note

This branch is rebased onto current `main` after the Companion 0.5 Link/Webpage routes and Dashboard icon support landed. The conflict resolution keeps both features and layers the pending-render contract as 0.5.2.

## Validation

- 127 tests passed across the complete `tests/companion` suite
- 65 focused Companion API, preview, and contract tests passed
- Ruff passed for all affected Python files
- `mypy --python-version 3.12 --strict app/companion_api.py` passed
- `git diff --check` passed
