### PR TITLE
Companion API 0.5: image-URL + webpage send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Added
 
+- **Companion API 0.5: send a public image URL or a webpage to your displays.** Community
+  clients can push a public image URL, or a server-rendered screenshot of a public webpage,
+  to explicit displays as asynchronous jobs, with the same History, resend, and photo
+  layout-mode handling as an uploaded image. Both run a strict public-only URL policy with no
+  client override: private, loopback, link-local, reserved, and embedded-credential
+  destinations are refused, including redirect hops (re-validated during the fetch, and by a
+  per-request interceptor during the webpage render). Webpage sends need a browser pool and are
+  advertised only when one is present.
+
 - **Companion display cards distinguish served and pending frames.** REST
   `/frame` polls now retain the last frame handed to each device, including
   matching `304 Not Modified` confirmations. The Companion device preview uses

--- a/app/companion_api.py
+++ b/app/companion_api.py
@@ -17,7 +17,7 @@ job the client polls; quiet-hours suppression surfaces as a *successful*
 app.mdns.
 
 Contract: ``charmmmz/tesserae-companion-ios`` ``Contracts/app-v1.openapi.yaml``
-(OpenAPI 0.4.1). The vendored copy + fixtures under ``tests/companion/``
+(OpenAPI 0.5.0). The vendored copy + fixtures under ``tests/companion/``
 guard these shapes.
 
 mypy --strict applies to this module, see pyproject.toml.
@@ -30,6 +30,7 @@ import logging
 import re
 import secrets
 import time
+import urllib.parse
 from collections.abc import Callable
 from datetime import UTC, datetime
 from functools import wraps
@@ -52,6 +53,7 @@ from app.companion_history import (
 from app.companion_jobs import CompanionJobs, JobOutcome
 from app.device_loader import Device, DeviceRegistry
 from app.device_preview import retained_device_preview
+from app.net_guard import BlockedURLError, assert_public_url
 from app.panel import device_panel, resolve_settings_panel
 from app.quiet_hours import device_is_quiet
 from app.state.companion_token_store import COMPANION_SCOPES, CompanionTokenStore
@@ -93,7 +95,15 @@ IDEMPOTENCY_RETENTION_SECONDS = 86_400
 
 # Features this server serves. The client gates on this list rather than
 # assuming the full set, so unshipped surfaces degrade cleanly.
-FEATURES = ("devices", "dashboards", "dashboard_push", "image_push", "jobs", "history")
+FEATURES = (
+    "devices",
+    "dashboards",
+    "dashboard_push",
+    "image_push",
+    "image_url_push",
+    "jobs",
+    "history",
+)
 
 _PAIRING_CODE_RE = re.compile(r"^[0-9]{6,12}$")
 _IMAGE_CONTENT_TYPES = frozenset(IMAGE_CONTENT_TYPES)
@@ -272,7 +282,10 @@ def _features() -> list[str]:
     the client enables the whole preview surface at once)."""
     feats = list(FEATURES)
     if current_app.config.get("BROWSER_POOL") is not None:
+        # Both need a browser pool: previews to prepare on-demand renders,
+        # webpage_push to screenshot an arbitrary URL server-side.
         feats.append("previews")
+        feats.append("webpage_push")
     return feats
 
 
@@ -779,6 +792,191 @@ def push_image() -> Any:
         payload=payload,
         target_ids=resolved_targets,
         label="Shared photo",
+        work=_work,
+    )
+
+
+# -- link send (image URL + webpage) -------------------------------------
+
+
+def _valid_remote_source_url(raw: Any) -> str | None:
+    """Validate a contract ``RemoteSourceURL``: an absolute http(s) URL, no
+    embedded credentials, 8-4096 chars, no whitespace. Returns the URL or
+    ``None``. Shape only; the public-network policy is enforced separately
+    (synchronously via ``assert_public_url`` and per-hop during fetch/render)."""
+    if not isinstance(raw, str):
+        return None
+    url = raw.strip()
+    if not (8 <= len(url) <= 4096) or any(ch.isspace() for ch in url):
+        return None
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return None
+    if parsed.username or parsed.password:
+        return None
+    return url
+
+
+def _link_send_common(body: Any) -> tuple[str, str, bool, list[str]] | tuple[Response, int]:
+    """Shared validation for the image-URL / webpage routes: url, fit,
+    override_quiet_hours, device_ids, and the synchronous strict URL
+    pre-check. Returns ``(url, fit, override, targets)`` or an error tuple."""
+    if not isinstance(body, dict):
+        return _error("invalid_request", "A JSON body is required.", 400)
+    url = _valid_remote_source_url(body.get("url"))
+    if url is None:
+        return _error("invalid_request", "A valid absolute http(s) url is required.", 400)
+    fit_value = body.get("fit")
+    if (
+        not isinstance(fit_value, str)
+        or fit_value not in _IMAGE_FIT_MODES
+        or not isinstance(body.get("override_quiet_hours"), bool)
+    ):
+        return _error("invalid_request", "fit and override_quiet_hours are required.", 400)
+    targets = _valid_target_ids(body.get("device_ids"))
+    if targets is None:
+        return _error("invalid_target", "One or more target displays are unknown.", 400)
+    # Strict public-only pre-check. Redirect hops are re-validated during the
+    # fetch (fetch_bytes) / render (the Chromium interceptor), so a redirect to
+    # a private host still fails the job even though this check passes.
+    try:
+        assert_public_url(url)
+    except BlockedURLError:
+        return _error("url_blocked", "That URL isn't a public destination.", 400)
+    return url, fit_value, bool(body["override_quiet_hours"]), list(targets)
+
+
+def _fan_out_bytes(
+    manager: Any,
+    image_bytes: bytes,
+    *,
+    source: str,
+    label: str,
+    fit: str,
+    active: list[str],
+) -> tuple[list[str], list[str]]:
+    """Push already-fetched / rendered bytes to each active target, tagging the
+    canonical History ``source`` (``url`` / ``webpage``). Returns
+    ``(published_device_ids, history_event_ids)``."""
+    published: list[str] = []
+    history_event_ids: list[str] = []
+    for did in active:
+        result = manager.push_image(
+            image_bytes,
+            source_label=label,
+            device_id=did,
+            fit=fit,
+            bypass_coalesce=True,
+            force_publish=True,
+            source=source,
+        )
+        if result.status in _PUBLISHED_STATUSES:
+            published.append(did)
+            history_event_ids.extend(_history_event_ids(result) or [])
+    return published, history_event_ids
+
+
+@bp.post("/image-urls")
+@_require_companion("push:write")
+def push_image_url() -> Any:
+    key, err = _require_idempotency_key()
+    if err is not None:
+        return err
+    assert key is not None
+
+    raw = request.get_data(cache=True)
+    common = _link_send_common(request.get_json(silent=True))
+    if isinstance(common, tuple) and len(common) == 2 and isinstance(common[1], int):
+        return common  # error envelope
+    url, fit, override, resolved_targets = common
+
+    def _work() -> JobOutcome:
+        active, _quiet = _partition_quiet(resolved_targets, override=override)
+        if not active:
+            return JobOutcome.quiet(resolved_targets, "all_targets_in_quiet_hours")
+        manager = _push_manager()
+        if manager is None:
+            return JobOutcome.failed("temporarily_unavailable", "The push pipeline is offline.")
+        # Fetch once through the strict policy, then fan the bytes out per
+        # target (no per-display re-fetch). A redirect to a private host is
+        # refused here (fetch_bytes re-validates every hop).
+        try:
+            image_bytes = manager.fetch_remote_image_strict(url)
+        except BlockedURLError:
+            return JobOutcome.failed("url_blocked", "The URL (or a redirect) wasn't public.")
+        except Exception as err:
+            return JobOutcome.failed("fetch_failed", f"The image URL could not be fetched: {err}")
+        published, history_event_ids = _fan_out_bytes(
+            manager, image_bytes, source="url", label=url, fit=fit, active=active
+        )
+        if published:
+            return JobOutcome.published(published, history_event_ids=history_event_ids or None)
+        return JobOutcome.failed("render_failed", "The image could not be published.")
+
+    return _reserve_and_run(
+        kind="image_url_push",
+        key=key,
+        payload=raw,
+        target_ids=resolved_targets,
+        label=url,
+        work=_work,
+    )
+
+
+@bp.post("/webpages")
+@_require_companion("push:write")
+def push_webpage_url() -> Any:
+    key, err = _require_idempotency_key()
+    if err is not None:
+        return err
+    assert key is not None
+
+    if current_app.config.get("BROWSER_POOL") is None:
+        return _error("temporarily_unavailable", "Webpage rendering isn't available.", 503)
+
+    body = request.get_json(silent=True)
+    # viewport_w is optional (server owns the logical height); validate before
+    # the shared checks so a bad value fails fast with invalid_request.
+    viewport_w = 1280
+    if isinstance(body, dict) and "viewport_w" in body:
+        vw = body.get("viewport_w")
+        if not isinstance(vw, int) or isinstance(vw, bool) or not (200 <= vw <= 4096):
+            return _error("invalid_request", "viewport_w must be an integer 200-4096.", 400)
+        viewport_w = vw
+
+    raw = request.get_data(cache=True)
+    common = _link_send_common(body)
+    if isinstance(common, tuple) and len(common) == 2 and isinstance(common[1], int):
+        return common  # error envelope
+    url, fit, override, resolved_targets = common
+
+    def _work() -> JobOutcome:
+        active, _quiet = _partition_quiet(resolved_targets, override=override)
+        if not active:
+            return JobOutcome.quiet(resolved_targets, "all_targets_in_quiet_hours")
+        manager = _push_manager()
+        if manager is None:
+            return JobOutcome.failed("temporarily_unavailable", "The push pipeline is offline.")
+        # Strict pre-check refused the initial URL synchronously; the renderer's
+        # interceptor holds every hop Chromium follows to the same policy. Render
+        # once at the logical viewport, then fan the bytes out per target.
+        try:
+            page_bytes = manager.render_webpage_png(url, viewport_w=viewport_w, allow_local=False)
+        except Exception as err:
+            return JobOutcome.failed("render_failed", f"The webpage could not be rendered: {err}")
+        published, history_event_ids = _fan_out_bytes(
+            manager, page_bytes, source="webpage", label=url, fit=fit, active=active
+        )
+        if published:
+            return JobOutcome.published(published, history_event_ids=history_event_ids or None)
+        return JobOutcome.failed("render_failed", "The webpage could not be published.")
+
+    return _reserve_and_run(
+        kind="webpage_push",
+        key=key,
+        payload=raw,
+        target_ids=resolved_targets,
+        label=url,
         work=_work,
     )
 

--- a/app/net_guard.py
+++ b/app/net_guard.py
@@ -108,6 +108,20 @@ def assert_operator_url(url: str) -> None:
     _validate_url(url, allow_local=True)
 
 
+def assert_public_url(url: str) -> None:
+    """Strict variant of :func:`assert_operator_url` for untrusted callers.
+
+    Refuses loopback, private (RFC1918), link-local, reserved, and cloud
+    metadata destinations with no override. Used by the Companion link-send
+    routes, which must never reach the operator's LAN. This is only the
+    initial-URL check: fetch / render paths that follow redirects must ALSO
+    run in strict mode (``fetch_bytes(allow_local=False)`` re-validates every
+    hop; the webpage renderer's request interceptor guards each Chromium
+    navigation), because this call alone can't see a redirect to a private
+    host."""
+    _validate_url(url, allow_local=False)
+
+
 class _GuardedRedirect(urllib.request.HTTPRedirectHandler):
     """Re-run the URL guard on every redirect target before following it."""
 

--- a/app/push.py
+++ b/app/push.py
@@ -1314,6 +1314,7 @@ class PushManager:
         fit: str | None = None,
         bypass_coalesce: bool = True,
         force_publish: bool = True,
+        source: str = "file",
     ) -> PushResult:
         """Hand arbitrary image bytes to every renderer.
 
@@ -1324,10 +1325,13 @@ class PushManager:
         ``device_id`` (optional): when set, only that device's renderers
         fire and its panel dims are used, same routing as a page bound
         to the device. ``fit`` (optional): the fit mode for non-panel-sized
-        input (``fit``/``fill``/``stretch``/``center``/``blur``)."""
+        input (``fit``/``fill``/``stretch``/``center``/``blur``). ``source``
+        tags the History row: the Companion link-send routes fetch / render
+        once and fan the resulting bytes out through here with ``"url"`` /
+        ``"webpage"`` so History keeps the real origin (default ``"file"``)."""
         supersede = self._acquire_or_supersede(
             device_id=device_id,
-            source="file",
+            source=source,
             target=source_label,
             bypass_coalesce=bypass_coalesce,
         )
@@ -1342,7 +1346,7 @@ class PushManager:
                 result = self._push_bytes_locked(
                     image_bytes,
                     source_label,
-                    source="file",
+                    source=source,
                     device_id=device_id,
                     fit=fit,
                     force_publish=force_publish,
@@ -1473,6 +1477,42 @@ class PushManager:
                 self._lock.release()
         self._notify(result)
         return result
+
+    def fetch_remote_image_strict(self, url: str) -> bytes:
+        """Fetch an image URL under the strict public-only policy, once.
+
+        The Companion ``/image-urls`` route fetches here a single time, then
+        fans the bytes out per target through :meth:`push_image`, so a
+        redirect-to-private is refused (fetch_bytes re-validates each hop) and
+        the source is fetched once rather than per display."""
+        return self._fetch_remote_image(url, allow_local=False)
+
+    def render_webpage_png(
+        self,
+        url: str,
+        *,
+        viewport_w: int,
+        viewport_h: int = 1200,
+        allow_local: bool = True,
+    ) -> bytes:
+        """Render a webpage to a composition PNG once (raises on failure).
+
+        The Companion ``/webpages`` route renders here a single time at the
+        logical viewport, then fans the bytes out per target through
+        :meth:`push_image` (no per-target re-render). ``allow_local=False``
+        installs the renderer's request interceptor so every hop Chromium
+        follows is held to the strict public-only policy."""
+        return render_to_png(
+            RenderRequest(
+                url=url,
+                viewport_w=viewport_w,
+                viewport_h=viewport_h,
+                timezone_id=self._render_timezone_id(),
+                is_composer=False,
+                allow_local=allow_local,
+            ),
+            pool=self._browser_pool_fn(),
+        )
 
     def republish(
         self,

--- a/app/push.py
+++ b/app/push.py
@@ -53,7 +53,12 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from app.device_loader import DeviceRegistry
 from app.device_preview import retained_device_preview, write_device_preview
 from app.dither_regions import has_nearest_region, regions_from_page
-from app.net_guard import BlockedURLError, assert_operator_url, fetch_bytes
+from app.net_guard import (
+    BlockedURLError,
+    assert_operator_url,
+    assert_public_url,
+    fetch_bytes,
+)
 from app.palette_profiles import (
     PaletteProfile,
     PaletteProfileStore,
@@ -1354,9 +1359,15 @@ class PushManager:
         device_id: str | None = None,
         fit: str | None = None,
         bypass_coalesce: bool = True,
+        allow_local: bool = True,
     ) -> PushResult:
         """Download an image URL, then ``push_image``. Networking errors
-        surface as failed events with the URL as the target."""
+        surface as failed events with the URL as the target.
+
+        ``allow_local`` defaults to operator trust (loopback / LAN allowed);
+        the Companion route passes ``False`` for the strict public-only
+        policy, refusing private / loopback / link-local / reserved hosts,
+        including on redirect hops."""
         supersede = self._acquire_or_supersede(
             device_id=device_id,
             source="url",
@@ -1372,7 +1383,7 @@ class PushManager:
         else:
             try:
                 try:
-                    image_bytes = self._fetch_remote_image(url)
+                    image_bytes = self._fetch_remote_image(url, allow_local=allow_local)
                 except Exception as err:
                     result = self._log_failure(source="url", target=url, error=f"fetch: {err}")
                 else:
@@ -1393,13 +1404,20 @@ class PushManager:
         device_id: str | None = None,
         fit: str | None = None,
         bypass_coalesce: bool = True,
+        allow_local: bool = True,
     ) -> PushResult:
-        """Screenshot an arbitrary URL with Playwright, then publish."""
+        """Screenshot an arbitrary URL with Playwright, then publish.
+
+        ``allow_local`` defaults to operator trust (loopback / LAN capture
+        allowed). The Companion route passes ``False``: the pre-flight refuses
+        non-public hosts, and the strict flag rides into the renderer so a
+        request interceptor also blocks every redirect hop / subresource
+        Chromium follows internally (a pre-check alone can't see those)."""
         # SSRF pre-flight. Playwright follows redirects internally, so this is
-        # an initial-URL check only; allow_local keeps same-host / LAN capture
-        # working and just refuses link-local / cloud metadata.
+        # only the initial-URL check; the renderer's interceptor (via
+        # RenderRequest.allow_local) enforces the policy on each hop.
         try:
-            assert_operator_url(url)
+            assert_operator_url(url) if allow_local else assert_public_url(url)
         except BlockedURLError as err:
             return self._log_failure(source="webpage", target=url, error=str(err))
         supersede = self._acquire_or_supersede(
@@ -1429,6 +1447,9 @@ class PushManager:
                             # mount wait and to use networkidle for the
                             # initial goto so SPAs hydrate before screenshot.
                             is_composer=False,
+                            # Strict callers (Companion) refuse non-public hosts
+                            # on every hop the browser follows internally.
+                            allow_local=allow_local,
                         ),
                         pool=self._browser_pool_fn(),
                     )
@@ -2572,22 +2593,25 @@ class PushManager:
             out2["native_h"] = panel.native_h
         return out2
 
-    def _fetch_remote_image(self, url: str) -> bytes:
+    def _fetch_remote_image(self, url: str, *, allow_local: bool = True) -> bytes:
         """Download an image URL through the SSRF guard, bounded size + timeout.
 
         Routes through ``net_guard`` so the scheme allowlist, per-redirect-hop
         host check, and size cap match the widget fetch path. ``allow_local``
         keeps same-host / LAN image sources usable while still refusing
-        link-local / cloud metadata. ``BlockedURLError`` (a ``ValueError``) and
-        the oversize ``ValueError`` propagate to the caller, which logs them as
-        a failed ``url`` push."""
+        link-local / cloud metadata (operator flows); untrusted callers (the
+        Companion route) pass ``allow_local=False`` so loopback / RFC1918 /
+        reserved hosts are refused, including on redirect hops (fetch_bytes
+        re-validates each). ``BlockedURLError`` (a ``ValueError``) and the
+        oversize ``ValueError`` propagate to the caller, which logs them as a
+        failed ``url`` push."""
         try:
             data, _ = fetch_bytes(
                 url,
                 headers={"User-Agent": "tesserae/0.1"},
                 timeout=_HTTP_TIMEOUT_S,
                 max_bytes=_MAX_REMOTE_IMAGE_BYTES,
-                allow_local=True,
+                allow_local=allow_local,
             )
         except urllib.error.URLError as err:
             raise RuntimeError(f"download failed: {err}") from err

--- a/app/renderer.py
+++ b/app/renderer.py
@@ -141,6 +141,13 @@ class RenderRequest:
     #   (defaulting to ``networkidle`` so JS-driven hydration completes
     #   before screenshot), and skip the composer-signal wait.
     is_composer: bool = True
+    # When False, refuse any Chromium request (navigation or subresource) to a
+    # loopback / private / link-local / reserved host, including redirect hops
+    # the browser follows internally. Set by untrusted callers (the Companion
+    # /webpages route) so a paired token can't screenshot the operator's LAN or
+    # cloud metadata. Operator flows (Web-UI Server preview, HA push) leave it
+    # True to keep same-host / LAN capture working.
+    allow_local: bool = True
 
 
 @dataclass(frozen=True)
@@ -298,6 +305,34 @@ def _screenshot_one(browser: Browser, request: RenderRequest) -> bytes:
     raise last_err
 
 
+def _install_ssrf_guard(page: Any, request: RenderRequest) -> None:
+    """Abort Chromium requests to non-public hosts when the request is strict.
+
+    Chromium follows redirects and loads subresources internally, outside
+    net_guard's urllib path, so this per-request interceptor is the only place
+    a webpage render can enforce a public-only policy on every hop. Matches
+    net_guard's guarantee level (host resolved and checked per request; no
+    IP pinning against DNS rebinding, same as the fetch path). A resolution
+    failure or any handler error blocks the request rather than fail-open."""
+    if request.allow_local:
+        return
+    import urllib.parse as _urlparse
+
+    from app.net_guard import host_is_blocked
+
+    def _route(route: Any) -> None:
+        try:
+            host = _urlparse.urlparse(route.request.url).hostname or ""
+            blocked = host_is_blocked(host, allow_local=False)
+        except Exception:
+            blocked = True
+        # Page/context may be torn down mid-flight; nothing to do then.
+        with contextlib.suppress(PlaywrightError):
+            route.abort() if blocked else route.continue_()
+
+    page.route("**/*", _route)
+
+
 def _new_composer_page(browser: Browser, request: RenderRequest) -> tuple[Any, Any]:
     """Open a fresh context + page sized to the request and return
     ``(context, page)``. Caller owns closing the context."""
@@ -310,6 +345,7 @@ def _new_composer_page(browser: Browser, request: RenderRequest) -> tuple[Any, A
         context_kwargs["timezone_id"] = request.timezone_id
     context = browser.new_context(**context_kwargs)
     page = context.new_page()
+    _install_ssrf_guard(page, request)
     page.set_default_timeout(request.timeout_ms)
     page.set_default_navigation_timeout(request.timeout_ms)
     return context, page
@@ -376,6 +412,7 @@ def _screenshot_attempt(browser: Browser, request: RenderRequest, attempt: int) 
     context = browser.new_context(**context_kwargs)
     try:
         page = context.new_page()
+        _install_ssrf_guard(page, request)
         page.set_default_timeout(request.timeout_ms)
         # ``set_default_timeout`` covers actions (evaluate, click, …) but
         # NOT navigation, ``goto`` uses Playwright's 30s default unless

--- a/app/state/job_store.py
+++ b/app/state/job_store.py
@@ -35,7 +35,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
-JobKind = Literal["dashboard_push", "image_push", "history_resend"]
+JobKind = Literal[
+    "dashboard_push", "image_push", "image_url_push", "webpage_push", "history_resend"
+]
 JobStatus = Literal["accepted", "running", "succeeded", "failed"]
 ResultStatus = Literal["published", "quiet"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.213.6"
+version = "0.214.0"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/tests/companion/_schema.py
+++ b/tests/companion/_schema.py
@@ -1,5 +1,5 @@
 """Shared helpers for validating Companion API payloads against the
-vendored OpenAPI 0.4.1 contract.
+vendored OpenAPI 0.5.0 contract.
 
 The spec + fixtures under ``contract/`` are a verbatim copy of
 ``charmmmz/tesserae-companion-ios`` ``Contracts/``. Keeping them in-tree

--- a/tests/companion/contract/app-v1.openapi.yaml
+++ b/tests/companion/contract/app-v1.openapi.yaml
@@ -1,11 +1,12 @@
 openapi: 3.0.3
 info:
   title: Tesserae Companion API
-  version: 0.4.1
+  version: 0.5.0
   description: >-
     Companion API contract for community-built clients. Previews, History,
-    resend, and server-advertised image fit modes are optional additive
-    extensions over the five-feature compatibility floor.
+    resend, remote-image push, webpage push, and server-advertised image fit
+    modes are optional additive extensions over the five-feature compatibility
+    floor.
 servers:
   - url: /
 tags:
@@ -14,6 +15,7 @@ tags:
   - name: Displays
   - name: Dashboards
   - name: Images
+  - name: Webpages
   - name: Jobs
   - name: History
 paths:
@@ -240,6 +242,65 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /api/app/v1/image-urls:
+    post:
+      tags: [Images]
+      operationId: pushCompanionImageURL
+      summary: Fetch one public image URL and send it to explicit display targets
+      description: >-
+        Persist an asynchronous Job that fetches the source once through the
+        strict Companion URL policy, then applies the selected fit per target
+        through the existing push fan-out. The server must refuse private,
+        loopback, link-local, and embedded-credential destinations, including
+        redirect targets. There is no Companion override for this policy.
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImageURLPushRequest"
+      responses:
+        "202":
+          $ref: "#/components/responses/JobAccepted"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
+  /api/app/v1/webpages:
+    post:
+      tags: [Webpages]
+      operationId: pushCompanionWebpage
+      summary: Render one public webpage and send it to explicit display targets
+      description: >-
+        Persist an asynchronous Job that performs one bounded server-side
+        top-level Chromium render at the logical viewport, then applies the
+        selected fit per target through the existing push fan-out. The render
+        must reuse the same queue, timeout, concurrency, cache, and rendering
+        primitive as the Web UI's manual Server preview, without relying on
+        whether the page permits iframe embedding. The Companion call uses the
+        strict URL policy and, unlike a preview-only render, publishes and
+        records canonical History.
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WebpagePushRequest"
+      responses:
+        "202":
+          $ref: "#/components/responses/JobAccepted"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          $ref: "#/components/responses/Conflict"
   /api/app/v1/jobs/{job_id}:
     parameters:
       - $ref: "#/components/parameters/JobID"
@@ -490,7 +551,16 @@ components:
           uniqueItems: true
           items:
             type: string
-            enum: [devices, dashboards, dashboard_push, image_push, jobs, previews, history]
+            enum:
+              - devices
+              - dashboards
+              - dashboard_push
+              - image_push
+              - jobs
+              - previews
+              - history
+              - image_url_push
+              - webpage_push
         limits:
           $ref: "#/components/schemas/Limits"
         web_url:
@@ -646,7 +716,7 @@ components:
           description: >-
             True when a REST polling device has not yet fetched the server's
             latest render. False for transports without a reliable served
-            signal.
+            signal. Absent on older compatible servers.
     Panel:
       type: object
       additionalProperties: false
@@ -724,6 +794,62 @@ components:
             type: string
         fit:
           $ref: "#/components/schemas/ImageFitMode"
+        override_quiet_hours:
+          type: boolean
+          default: false
+    RemoteSourceURL:
+      description: >-
+        Absolute HTTP(S) URL without embedded credentials. Companion-triggered
+        fetches use a strict public-network policy: private, loopback,
+        link-local, reserved, unspecified, and equivalent redirect destinations
+        are refused. The client cannot override that policy.
+      type: string
+      format: uri
+      minLength: 8
+      maxLength: 4096
+      pattern: "^https?://[^\\s]+$"
+    ImageURLPushRequest:
+      type: object
+      additionalProperties: false
+      required: [url, device_ids, fit, override_quiet_hours]
+      properties:
+        url:
+          $ref: "#/components/schemas/RemoteSourceURL"
+        device_ids:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            type: string
+        fit:
+          $ref: "#/components/schemas/ImageFitMode"
+        override_quiet_hours:
+          type: boolean
+          default: false
+    WebpagePushRequest:
+      type: object
+      additionalProperties: false
+      required: [url, device_ids, fit, override_quiet_hours]
+      properties:
+        url:
+          $ref: "#/components/schemas/RemoteSourceURL"
+        device_ids:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            type: string
+        fit:
+          $ref: "#/components/schemas/ImageFitMode"
+        viewport_w:
+          description: >-
+            Optional advanced logical browser width. The server defaults to
+            1280 and owns the logical capture height. It renders once at that
+            logical size and does not re-render for each target display.
+          type: integer
+          minimum: 200
+          maximum: 4096
+          default: 1280
         override_quiet_hours:
           type: boolean
           default: false
@@ -821,7 +947,12 @@ components:
           type: string
         kind:
           type: string
-          enum: [dashboard_push, image_push, history_resend]
+          enum:
+            - dashboard_push
+            - image_push
+            - image_url_push
+            - webpage_push
+            - history_resend
         status:
           description: Execution lifecycle only; quiet is a successful result
           type: string
@@ -873,6 +1004,10 @@ components:
           items:
             type: string
     JobFailure:
+      description: >-
+        Stable failure details. URL-backed Jobs should distinguish policy
+        refusal, fetch failure, render failure, and temporary renderer
+        unavailability with safe machine-readable codes.
       type: object
       additionalProperties: false
       required: [code, message]
@@ -902,6 +1037,7 @@ components:
                 - invalid_target
                 - unsupported_image
                 - image_too_large
+                - url_blocked
                 - idempotency_conflict
                 - not_resendable
                 - temporarily_unavailable

--- a/tests/companion/test_companion_api.py
+++ b/tests/companion/test_companion_api.py
@@ -114,15 +114,19 @@ def test_capabilities_probe_is_unauthenticated_and_valid(app: Flask) -> None:
     # Advertised pairing facts agree with the store the server actually uses.
     assert body["pairing"]["code_length"] == 6
     assert body["pairing"]["ttl_seconds"] == 600
-    # All read/write surfaces are served.
+    # All read/write surfaces served without a browser pool. image_url_push is
+    # always on (plain fetch); webpage_push + previews are gated on the pool and
+    # covered in test_companion_previews.
     assert set(body["features"]) == {
         "devices",
         "dashboards",
         "dashboard_push",
         "image_push",
+        "image_url_push",
         "jobs",
         "history",
     }
+    assert "webpage_push" not in body["features"]
     assert body["limits"]["image_fit_modes"] == list(companion_api.IMAGE_FIT_MODES)
     # No household content leaks from the unauthenticated probe.
     assert "devices" not in body and "dashboards" not in body

--- a/tests/companion/test_companion_jobs.py
+++ b/tests/companion/test_companion_jobs.py
@@ -38,6 +38,8 @@ class _FakePush:
         self.status = status
         self.push_calls: list[dict[str, Any]] = []
         self.image_calls: list[dict[str, Any]] = []
+        self.render_calls: list[dict[str, Any]] = []
+        self.fetch_calls: list[str] = []
         self._next_event_id = 100
 
     def push(self, page_id: str, **kwargs: Any) -> Any:
@@ -46,9 +48,24 @@ class _FakePush:
         return SimpleNamespace(status=self.status, error=None, event_id=self._next_event_id)
 
     def push_image(self, image_bytes: bytes, **kwargs: Any) -> Any:
-        self.image_calls.append({"device_id": kwargs["device_id"], "fit": kwargs["fit"]})
+        self.image_calls.append(
+            {
+                "device_id": kwargs["device_id"],
+                "fit": kwargs["fit"],
+                "source": kwargs.get("source", "file"),
+            }
+        )
         self._next_event_id += 1
         return SimpleNamespace(status=self.status, error=None, event_id=self._next_event_id)
+
+    # Companion link-send: fetch / render once, then fan out via push_image.
+    def fetch_remote_image_strict(self, url: str) -> bytes:
+        self.fetch_calls.append(url)
+        return b"\x89PNG-fake"
+
+    def render_webpage_png(self, url: str, **kwargs: Any) -> bytes:
+        self.render_calls.append({"url": url, **kwargs})
+        return b"\x89PNG-fake"
 
 
 @pytest.fixture
@@ -345,7 +362,7 @@ def test_image_push_accepts_every_advertised_fit_mode(app: Flask, fit: str) -> N
     assert job["result"]["status"] == "published"
     assert job["result"]["device_ids"] == [device]
     assert job["result"]["history_event_ids"] == ["101"]
-    assert fake.image_calls == [{"device_id": device, "fit": fit}]
+    assert fake.image_calls == [{"device_id": device, "fit": fit, "source": "file"}]
 
 
 @pytest.mark.parametrize("invalid_fit", ["tile", ["fit"]], ids=["unknown", "non-string"])
@@ -417,3 +434,212 @@ def test_unknown_job_is_404(app: Flask) -> None:
     resp = app.test_client().get("/api/app/v1/jobs/job_missing", headers=_auth(token))
     assert resp.status_code == 404
     assert resp.get_json()["error"]["code"] == "not_found"
+
+
+# -- link send: image URL + webpage (#163) -------------------------------
+
+# Public IP literals keep the strict-policy checks offline-deterministic:
+# assert_public_url resolves hostnames, but an IP literal is classified
+# directly with no DNS. 93.184.216.34 is a public address.
+_PUBLIC_IMG = "http://93.184.216.34/photo.png"
+_PUBLIC_WEB = "http://93.184.216.34/dashboard"
+
+
+def _image_url_body(**over: Any) -> dict[str, Any]:
+    body = {
+        "url": _PUBLIC_IMG,
+        "device_ids": ["kitchen"],
+        "fit": "fit",
+        "override_quiet_hours": True,
+    }
+    body.update(over)
+    return body
+
+
+def test_image_url_push_fetches_once_and_fans_out_with_url_source(app: Flask) -> None:
+    fake = _install_fake_push(app)
+    d1 = _seed_device(app, "kitchen")
+    d2 = _seed_device(app, "hallway")
+    token = _token(app)
+    resp = app.test_client().post(
+        "/api/app/v1/image-urls",
+        data=json.dumps(_image_url_body(device_ids=[d1, d2])),
+        content_type="application/json",
+        headers=_auth(token, "idem-imageurl-00001"),
+    )
+    assert resp.status_code == 202, resp.get_data(as_text=True)
+    job = _poll(app, token, resp.get_json()["job"]["id"])
+    assert job["status"] == "succeeded"
+    assert job["result"]["status"] == "published"
+    assert set(job["result"]["device_ids"]) == {d1, d2}
+    # Fetched exactly once, then fanned out per target tagged source="url".
+    assert fake.fetch_calls == [_PUBLIC_IMG]
+    assert {c["device_id"] for c in fake.image_calls} == {d1, d2}
+    assert {c["source"] for c in fake.image_calls} == {"url"}
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/x",
+        "http://192.168.1.10/x",
+        "http://10.0.0.5/x",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://[::1]/x",
+    ],
+)
+def test_image_url_push_refuses_non_public_url_synchronously(app: Flask, url: str) -> None:
+    fake = _install_fake_push(app)
+    _seed_device(app, "kitchen")
+    token = _token(app)
+    resp = app.test_client().post(
+        "/api/app/v1/image-urls",
+        data=json.dumps(_image_url_body(url=url)),
+        content_type="application/json",
+        headers=_auth(token, "idem-blocked-000001"),
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"]["code"] == "url_blocked"
+    # Rejected before any fetch or job enqueue.
+    assert fake.fetch_calls == []
+
+
+def test_image_url_push_rejects_embedded_credentials(app: Flask) -> None:
+    _install_fake_push(app)
+    _seed_device(app, "kitchen")
+    token = _token(app)
+    resp = app.test_client().post(
+        "/api/app/v1/image-urls",
+        data=json.dumps(_image_url_body(url="http://user:pw@93.184.216.34/x")),
+        content_type="application/json",
+        headers=_auth(token, "idem-creds-0000001"),
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"]["code"] == "invalid_request"
+
+
+def test_image_url_push_requires_idempotency_key(app: Flask) -> None:
+    _install_fake_push(app)
+    _seed_device(app, "kitchen")
+    token = _token(app)
+    resp = app.test_client().post(
+        "/api/app/v1/image-urls",
+        data=json.dumps(_image_url_body()),
+        content_type="application/json",
+        headers=_auth(token),
+    )
+    assert resp.status_code == 400
+
+
+def test_image_url_push_requires_push_scope(app: Flask) -> None:
+    _install_fake_push(app)
+    _seed_device(app, "kitchen")
+    token = _token(app)
+    app.config["COMPANION_TOKENS"].list_active()[0].scopes = ["devices:read"]
+    resp = app.test_client().post(
+        "/api/app/v1/image-urls",
+        data=json.dumps(_image_url_body()),
+        content_type="application/json",
+        headers=_auth(token, "idem-noscope-00001"),
+    )
+    assert resp.status_code == 401
+
+
+def test_image_url_push_idempotent_replay_returns_same_job(app: Flask) -> None:
+    _install_fake_push(app)
+    _seed_device(app, "kitchen")
+    token = _token(app)
+    client = app.test_client()
+    body = json.dumps(_image_url_body())
+    first = client.post(
+        "/api/app/v1/image-urls",
+        data=body,
+        content_type="application/json",
+        headers=_auth(token, "idem-replay-000001"),
+    )
+    second = client.post(
+        "/api/app/v1/image-urls",
+        data=body,
+        content_type="application/json",
+        headers=_auth(token, "idem-replay-000001"),
+    )
+    assert first.status_code == 202 and second.status_code == 202
+    assert first.get_json()["job"]["id"] == second.get_json()["job"]["id"]
+
+
+def test_webpage_push_requires_browser_pool(app: Flask) -> None:
+    _install_fake_push(app)
+    app.config["BROWSER_POOL"] = None
+    _seed_device(app, "kitchen")
+    token = _token(app)
+    resp = app.test_client().post(
+        "/api/app/v1/webpages",
+        data=json.dumps(_image_url_body(url=_PUBLIC_WEB)),
+        content_type="application/json",
+        headers=_auth(token, "idem-nopool-000001"),
+    )
+    assert resp.status_code == 503
+    assert resp.get_json()["error"]["code"] == "temporarily_unavailable"
+
+
+def test_webpage_push_renders_once_and_fans_out_with_webpage_source(app: Flask) -> None:
+    fake = _install_fake_push(app)
+    app.config["BROWSER_POOL"] = object()  # presence gate only; render is faked
+    d1 = _seed_device(app, "kitchen")
+    d2 = _seed_device(app, "hallway")
+    token = _token(app)
+    resp = app.test_client().post(
+        "/api/app/v1/webpages",
+        data=json.dumps(
+            {
+                "url": _PUBLIC_WEB,
+                "device_ids": [d1, d2],
+                "fit": "fill",
+                "viewport_w": 1024,
+                "override_quiet_hours": True,
+            }
+        ),
+        content_type="application/json",
+        headers=_auth(token, "idem-webpage-00001"),
+    )
+    assert resp.status_code == 202, resp.get_data(as_text=True)
+    job = _poll(app, token, resp.get_json()["job"]["id"])
+    assert job["status"] == "succeeded"
+    assert job["result"]["status"] == "published"
+    # Rendered exactly once at the requested viewport, in strict mode.
+    assert len(fake.render_calls) == 1
+    assert fake.render_calls[0]["url"] == _PUBLIC_WEB
+    assert fake.render_calls[0]["viewport_w"] == 1024
+    assert fake.render_calls[0]["allow_local"] is False
+    assert {c["source"] for c in fake.image_calls} == {"webpage"}
+
+
+def test_webpage_push_refuses_private_url(app: Flask) -> None:
+    fake = _install_fake_push(app)
+    app.config["BROWSER_POOL"] = object()
+    _seed_device(app, "kitchen")
+    token = _token(app)
+    resp = app.test_client().post(
+        "/api/app/v1/webpages",
+        data=json.dumps(_image_url_body(url="http://127.0.0.1/admin")),
+        content_type="application/json",
+        headers=_auth(token, "idem-webblock-0001"),
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"]["code"] == "url_blocked"
+    assert fake.render_calls == []
+
+
+def test_webpage_push_rejects_out_of_range_viewport(app: Flask) -> None:
+    _install_fake_push(app)
+    app.config["BROWSER_POOL"] = object()
+    _seed_device(app, "kitchen")
+    token = _token(app)
+    resp = app.test_client().post(
+        "/api/app/v1/webpages",
+        data=json.dumps(_image_url_body(url=_PUBLIC_WEB, viewport_w=99)),
+        content_type="application/json",
+        headers=_auth(token, "idem-badvp-0000001"),
+    )
+    assert resp.status_code == 400
+    assert resp.get_json()["error"]["code"] == "invalid_request"

--- a/tests/companion/test_contract_fixtures.py
+++ b/tests/companion/test_contract_fixtures.py
@@ -39,7 +39,7 @@ CASES = {
 
 def test_openapi_shape_and_operation_ids_are_stable() -> None:
     assert SPEC["openapi"] == "3.0.3"
-    assert SPEC["info"]["version"] == "0.4.1"
+    assert SPEC["info"]["version"] == "0.5.0"
     assert set(SPEC["paths"]) == {
         "/api/app/v1",
         "/api/app/v1/pair",
@@ -50,6 +50,8 @@ def test_openapi_shape_and_operation_ids_are_stable() -> None:
         "/api/app/v1/dashboards/{dashboard_id}/preview",
         "/api/app/v1/dashboards/{dashboard_id}/push",
         "/api/app/v1/images",
+        "/api/app/v1/image-urls",
+        "/api/app/v1/webpages",
         "/api/app/v1/jobs/{job_id}",
         "/api/app/v1/history",
         "/api/app/v1/history/{history_id}/preview",

--- a/tests/test_schedule_routes.py
+++ b/tests/test_schedule_routes.py
@@ -195,8 +195,10 @@ def test_timeline_now_uses_configured_timezone(app: Flask) -> None:
     """#164 / #170: the Next-24h timeline anchored "now" to the server's
     container TZ (UTC on Docker) instead of the configured app timezone, so
     the now-marker and hour ticks read an offset off the user's wall clock.
-    A daily schedule also exercises the tz-aware fire-time comparison that
-    would otherwise raise once "now" became tz-aware."""
+    An interval schedule guarantees fires in any 24h window regardless of the
+    wall-clock hour the test runs at; a daily schedule additionally exercises
+    the tz-aware fire-time comparison that would otherwise raise once "now"
+    became tz-aware."""
     from datetime import datetime, timedelta
 
     from app.schedule_routes import _build_timeline
@@ -204,21 +206,32 @@ def test_timeline_now_uses_configured_timezone(app: Flask) -> None:
 
     with app.app_context():
         app.config["SETTINGS_STORE"].update_section("app", {"timezone": "Asia/Hong_Kong"})
+        interval = Schedule(
+            id="every30",
+            name="Every 30",
+            page_id="p1",
+            type="interval",
+            interval_minutes=30,
+        )
         daily = Schedule(
             id="morning",
             name="Morning",
-            page_id="p1",
+            page_id="p2",
             type="daily",
             fires_at=datetime(2020, 1, 1, 7, 0),
         )
-        tl = _build_timeline([daily])
+        tl = _build_timeline([interval, daily])
 
     now = tl["now"]
     assert now.tzinfo is not None
     assert now.utcoffset() == timedelta(hours=8)  # Hong Kong, no DST
+    # The interval schedule always projects fires; all must carry the zone.
     fires = tl["rows"][0]["fires"]
-    assert fires, "a daily every-day schedule should project a fire within 24h"
+    assert fires, "an interval schedule should project fires within 24h"
     assert all(f["at"].utcoffset() == timedelta(hours=8) for f in fires)
+    # The daily projection must not raise on the tz-aware comparison, and any
+    # fires it does yield carry the same zone.
+    assert all(f["at"].utcoffset() == timedelta(hours=8) for f in tl["rows"][1]["fires"])
 
 
 def test_last_fired_abs_uses_configured_timezone(app: Flask) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1934,7 +1934,7 @@ wheels = [
 
 [[package]]
 name = "tesserae"
-version = "0.213.6"
+version = "0.214.0"
 source = { editable = "." }
 dependencies = [
     { name = "amqtt" },


### PR DESCRIPTION
## Summary
Server side of Companion 0.5 (contract merged in charmmmz/tesserae-companion-ios#2). Adds two async routes to send a **public image URL** or a **server-rendered webpage screenshot** to explicit displays.

## What's included
- `POST /api/app/v1/image-urls` and `/webpages` — async Jobs (`push:write`, required `Idempotency-Key`, `202` + Job). Fetch/render **once**, fan out per target (no per-display re-fetch/re-render).
- **Strict public-only URL policy, no client override:** private / loopback / link-local / reserved / embedded-credential destinations refused, *including redirect hops* (net_guard re-validates each fetch hop; a new Chromium request interceptor guards every navigation and subresource during the webpage render).
- Canonical History `source=url|webpage` (preview, resend, `history_event_ids`) via a source tag threaded through `push_image`.
- Capabilities: `image_url_push` always; `webpage_push` when a browser pool is present. New `url_blocked` error code.
- Vendored OpenAPI 0.5.0 + strict-policy / integration tests.

## Security note
The load-bearing part: `push_url_image` / `push_webpage` default to operator trust (`allow_local=True`, LAN capture). The Companion routes pass `allow_local=False`. Because Chromium follows redirects internally (outside net_guard), the webpage render enforces the policy with a per-request interceptor, not just a pre-check.

Closes #163
