### PR TITLE
Fix REST device config saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,11 @@ All notable changes to Tesserae are recorded here. Format loosely follows
   letterboxed `object-fit: contain` box). The HTML-view button is also renamed from
   "Fit view", which read as a sizing control.
 
+- **Saving a REST device no longer emits a misleading MQTT publish failure.**
+  REST instances can retain dormant MQTT topics for a later transport switch;
+  device settings now follow the active transport, save to disk, and return on
+  the next status poll without attempting a broker publish.
+
 - **CalDAV discovery handles compressed responses.** A Nextcloud behind a proxy or CDN
   can return a gzip- or deflate-compressed body; Python's HTTP client doesn't request or
   decompress that, so the parser saw a binary blob and discovery failed with "wasn't valid

--- a/app/settings/devices_routes.py
+++ b/app/settings/devices_routes.py
@@ -1026,16 +1026,18 @@ def devices_update_combined(instance_id: str) -> Response:
                 any_change = True
 
     # 1. Renderer-defined config fields. Mirror settings_update("device-<id>").
-    # Two paths: MQTT publish (when ``config_topic`` is set) and
-    # save-only (when it isn't, HTTP-polled TRMNL clients pick up
-    # config from the next /api/display response).
+    # Two paths: MQTT devices publish when ``config_topic`` is set;
+    # REST devices save only and pick up config on their next status
+    # poll. REST instances may retain dormant MQTT topics so they can
+    # be switched back later, so topic presence alone is not enough to
+    # decide whether to publish.
     schema_fields = config_fields_from_schema(device.config_schema)
     if schema_fields:
         values = values_from_form(schema_fields)
         ok, err = device.validate_config(values)
         if not ok:
             flash(f"Invalid {device.name} config: {err}", "error")
-        elif device.config_topic is None:
+        elif device.transport == "rest" or device.config_topic is None:
             store.update_for_namespace("devices", instance_id, values, schema_fields)
             ok_messages.append("config saved")
             any_change = True

--- a/app/settings/update_routes.py
+++ b/app/settings/update_routes.py
@@ -112,10 +112,10 @@ def settings_update(section_kind: str) -> Response:
             flash(f"Invalid {device.name} config: {err}", "error")
             return redirect_to_section(section_kind)
         store.update_for_namespace("devices", did, values, fields)
-        if device.config_topic is None:
-            # Non-MQTT device (e.g. HTTP-polled TRMNL). Config flows
-            # back to the device via the next /api/display response,
-            # not a transport publish, the save itself is the action.
+        if device.transport == "rest" or device.config_topic is None:
+            # REST instances may retain dormant MQTT topics for a later
+            # transport switch. They still receive saved config through
+            # the next status poll, never through a broker publish.
             flash(f"{device.name} config saved.", "ok")
             return redirect_to_section(section_kind)
         tr = transport()

--- a/tests/test_settings_routes.py
+++ b/tests/test_settings_routes.py
@@ -577,6 +577,80 @@ def test_combined_save_persists_panel_and_quiet_hours_in_one_post(
     assert qh == {"enabled": True, "start": "22:30", "end": "07:00"}
 
 
+def test_combined_save_rest_device_with_dormant_topic_does_not_publish(
+    app_with_gate: Flask,
+) -> None:
+    """REST devices retain MQTT topics for a future transport switch.
+    Saving their config must still be a disk-only operation; otherwise a
+    healthy REST save also emits a misleading broker failure toast."""
+    client = app_with_gate.test_client()
+    client.post("/setup", data={"password": "abcdefgh", "password_confirm": "abcdefgh"})
+    client.post(
+        "/settings/devices/add",
+        data={"id": "rest_lab", "kind": "esp32_client", "panel_preset": "inky_7_3"},
+    )
+    client.post("/settings/devices/rest_lab/set-transport", data={"transport": "rest"})
+    device = app_with_gate.config["DEVICE_REGISTRY"].get("rest_lab")
+    assert device is not None
+    assert device.transport == "rest"
+    assert device.config_topic is not None
+
+    transport = MagicMock()
+    app_with_gate.config["MQTT_TRANSPORT"] = transport
+    app_with_gate.config["REBUILD_TRANSPORT"] = MagicMock()
+    with client.session_transaction() as sess:
+        sess.pop("_flashes", None)
+
+    resp = client.post(
+        "/settings/devices/rest_lab/save",
+        data={"sleep_interval_s": "300", "button_wake_s": "0"},
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 302
+    transport.publish.assert_not_called()
+    with client.session_transaction() as sess:
+        flashes = sess.get("_flashes", [])
+    assert any(category == "ok" and "config saved" in msg for category, msg in flashes)
+    assert not any(category == "error" for category, _msg in flashes)
+
+
+def test_legacy_save_rest_device_with_dormant_topic_does_not_publish(
+    app_with_gate: Flask,
+) -> None:
+    """The legacy per-section save route follows the same REST rule as
+    the combined device-card form."""
+    client = app_with_gate.test_client()
+    client.post("/setup", data={"password": "abcdefgh", "password_confirm": "abcdefgh"})
+    client.post(
+        "/settings/devices/add",
+        data={"id": "rest_lab", "kind": "esp32_client", "panel_preset": "inky_7_3"},
+    )
+    client.post("/settings/devices/rest_lab/set-transport", data={"transport": "rest"})
+    device = app_with_gate.config["DEVICE_REGISTRY"].get("rest_lab")
+    assert device is not None
+    assert device.transport == "rest"
+    assert device.config_topic is not None
+
+    transport = MagicMock()
+    app_with_gate.config["MQTT_TRANSPORT"] = transport
+    with client.session_transaction() as sess:
+        sess.pop("_flashes", None)
+
+    resp = client.post(
+        "/settings/device-rest_lab",
+        data={"sleep_interval_s": "300", "button_wake_s": "0"},
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 302
+    transport.publish.assert_not_called()
+    with client.session_transaction() as sess:
+        flashes = sess.get("_flashes", [])
+    assert any(category == "ok" and "config saved" in msg for category, msg in flashes)
+    assert not any(category == "error" for category, _msg in flashes)
+
+
 def test_renderer_card_hides_device_settings(app_with_gate: Flask) -> None:
     """Fields flagged ``device_setting: true`` belong on the device
     card. The renderer card must drop them, and surface a hint in the


### PR DESCRIPTION
## What changed

- save renderer-defined settings for REST devices without publishing to MQTT
- apply the same active-transport rule to both the combined device card and legacy settings route
- add regression coverage for REST instances that retain a dormant MQTT config topic
- document the behavior change in the changelog

## Root cause

REST instances can retain MQTT topics so they can switch transports later. The settings routes used the presence of `config_topic` as the publish decision, even when the active transport was REST. A successful save therefore also attempted an MQTT publish and showed a misleading `transport not connected` error on broker-less installations.

## User impact

REST device settings continue to persist immediately and return through the next status poll, but the UI now shows one successful save instead of simultaneous success and failure notifications. MQTT devices retain their existing publish behavior.

## Validation

- `pytest tests/test_settings_routes.py -k rest_device_with_dormant_topic -q` — 2 passed
- `pytest tests/test_settings_routes.py -q` — 61 passed
- `ruff check app/settings/devices_routes.py app/settings/update_routes.py tests/test_settings_routes.py`
- `git diff --check`