### PR TITLE
Picture: source crop primitive + Panel-view dithered preview (#45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Added
 
+- **Panel view: preview a dashboard as the e-ink panel will actually paint it.** The
+  dashboard editor's live preview gains a Fit view / Panel view toggle. Panel view
+  quantises and dithers the render to the target panel's colour palette, so you see the
+  exact per-pixel output (dithering, palette reduction) before pushing, per preview group's
+  gamut. Also adds a shared source-crop primitive (a normalized crop + rotate applied before
+  the panel fit) that the Send and Companion image paths will build framing on.
+
 - **Companion dashboard listings now include their Phosphor icon name.** The
   optional `icon` field uses the same bare identifier as the web dashboard
   list, so companion clients can render a consistent icon and safely fall back

--- a/app/composer.py
+++ b/app/composer.py
@@ -1405,6 +1405,84 @@ def compose_preview(page_id: str) -> Response:
     return resp
 
 
+@bp.get("/compose/<page_id>/panel.png")
+def compose_panel_preview(page_id: str) -> Response:
+    """Panel view (#45): the dashboard preview quantised and dithered to a target
+    device's palette, so the editor can show the exact per-pixel output the e-ink
+    panel paints rather than the full-colour composition.
+
+    Reuses the same rendered composition as ``preview.png`` (returning ``202``
+    while that render is in flight), then runs it through the quantiser.
+    ``?device=<id>`` selects the panel's gamut (falls back to the page's first
+    bound device, then 6-colour Spectra); ``?dither=<mode>`` overrides the dither
+    (default floyd-steinberg). The quantised result is cached per
+    (token, gamut, dither)."""
+    from typing import cast, get_args
+
+    from app.panel import device_panel
+    from app.quantizer import DitherMode, canonicalise_gamut, palette_for_gamut, quantize_to_png
+
+    preview_pages: dict[str, Page] = current_app.config.get("PREVIEW_CACHE", {}) or {}
+    page = preview_pages.get(page_id) or current_app.config["PAGE_STORE"].get(page_id)
+    if page is None:
+        abort(404)
+    devices = current_app.config.get("DEVICE_REGISTRY")
+    settings_store = current_app.config["SETTINGS_STORE"]
+    width, height = preview_dims(page, devices, settings_store)
+    token = page_preview_token(page, (width, height))
+
+    gamut = "waveshare_e6"
+    device_id = (request.args.get("device") or "").strip()
+    if not device_id and page.device_ids:
+        device_id = page.device_ids[0]
+    if device_id and devices is not None:
+        dev = devices.get(device_id)
+        panel = device_panel(dev) if dev is not None else None
+        if panel is not None and getattr(panel, "gamut", None):
+            gamut = str(panel.gamut)
+    gamut = canonicalise_gamut(gamut)
+
+    dither = (request.args.get("dither") or "floyd-steinberg").strip()
+    if dither not in get_args(DitherMode):
+        dither = "floyd-steinberg"
+
+    cache_dir = Path(current_app.config["DATA_ROOT"]) / "core" / "previews"
+    comp_path = cache_dir / f"{page_id}__{token}.png"
+    if not comp_path.exists():
+        from app import preview_cache
+
+        preview_cache.submit(
+            key=f"{page_id}__{token}",
+            base_url=request.host_url.rstrip("/"),
+            page_id=page_id,
+            width=width,
+            height=height,
+            cache_path=comp_path,
+            pool=current_app.config.get("BROWSER_POOL"),
+        )
+        resp = current_app.response_class(status=202)
+        resp.headers["Cache-Control"] = "no-store"
+        return resp
+
+    panel_path = cache_dir / f"{page_id}__{token}__{gamut}__{dither}.png"
+    if not panel_path.exists():
+        quantised = quantize_to_png(
+            comp_path.read_bytes(),
+            dither=cast(DitherMode, dither),
+            palette=palette_for_gamut(gamut),
+        )
+        panel_path.write_bytes(quantised)
+
+    etag = f"{token}-{gamut}-{dither}"
+    if request.if_none_match and etag in request.if_none_match:
+        resp = current_app.response_class(status=304)
+    else:
+        resp = current_app.response_class(panel_path.read_bytes(), mimetype="image/png")
+    resp.set_etag(etag)
+    resp.headers["Cache-Control"] = "private, max-age=86400"
+    return resp
+
+
 @bp.get("/compose/canvas/<canvas_id>")
 def compose_canvas(canvas_id: str) -> str:
     """Render target for a Panels canvas document (issue #60).

--- a/app/composer.py
+++ b/app/composer.py
@@ -1431,16 +1431,19 @@ def compose_panel_preview(page_id: str) -> Response:
     width, height = preview_dims(page, devices, settings_store)
     token = page_preview_token(page, (width, height))
 
-    gamut = "waveshare_e6"
-    device_id = (request.args.get("device") or "").strip()
-    if not device_id and page.device_ids:
-        device_id = page.device_ids[0]
-    if device_id and devices is not None:
-        dev = devices.get(device_id)
-        panel = device_panel(dev) if dev is not None else None
-        if panel is not None and getattr(panel, "gamut", None):
-            gamut = str(panel.gamut)
-    gamut = canonicalise_gamut(gamut)
+    # An explicit ?gamut wins (the editor passes the preview group's gamut);
+    # else resolve it from ?device or the page's first bound device.
+    gamut = (request.args.get("gamut") or "").strip()
+    if not gamut:
+        device_id = (request.args.get("device") or "").strip()
+        if not device_id and page.device_ids:
+            device_id = page.device_ids[0]
+        if device_id and devices is not None:
+            dev = devices.get(device_id)
+            panel = device_panel(dev) if dev is not None else None
+            if panel is not None and getattr(panel, "gamut", None):
+                gamut = str(panel.gamut)
+    gamut = canonicalise_gamut(gamut or "waveshare_e6")
 
     dither = (request.args.get("dither") or "floyd-steinberg").strip()
     if dither not in get_args(DitherMode):

--- a/app/panel.py
+++ b/app/panel.py
@@ -324,12 +324,24 @@ def preview_groups_for_page(
     panels = _selected_device_panels(page, devices)
     if not panels:
         p = resolve_page_panel(page.panel, settings)
-        return [{"w": p.w, "h": p.h, "label": "Virtual panel", "devices": []}]
+        return [
+            {"w": p.w, "h": p.h, "label": "Virtual panel", "devices": [], "gamut": "waveshare_e6"}
+        ]
     groups: dict[tuple[int, int], dict[str, Any]] = {}
     for device, panel in panels:
         g = gcd(panel.w, panel.h) or 1
         key = (panel.w // g, panel.h // g)
-        grp = groups.setdefault(key, {"w": panel.w, "h": panel.h, "devices": []})
+        # First device in an aspect group also sets the group's gamut, so the
+        # editor's Panel view can quantise to that panel's palette (#45).
+        grp = groups.setdefault(
+            key,
+            {
+                "w": panel.w,
+                "h": panel.h,
+                "devices": [],
+                "gamut": str(getattr(panel, "gamut", None) or "waveshare_e6"),
+            },
+        )
         grp["devices"].append(device.display_name)
     out: list[dict[str, Any]] = []
     for (aw, ah), grp in groups.items():

--- a/app/quantizer.py
+++ b/app/quantizer.py
@@ -22,7 +22,7 @@ palette to firmware-nibble LUT) is byte-compatible with the existing
 from __future__ import annotations
 
 import io
-from typing import Literal
+from typing import Any, Literal, TypedDict
 
 import numpy as np
 from PIL import Image, ImageEnhance, ImageFilter
@@ -574,6 +574,67 @@ def apply_underscan(png_bytes: bytes, *, underscan: int, fill: str = "#ffffff") 
     return out.getvalue()
 
 
+class SourceCrop(TypedDict, total=False):
+    """A source-image crop, in the image's own normalized coordinate space.
+
+    ``x``/``y``/``w``/``h`` are fractions in [0, 1] of the source dimensions, so
+    the rect stays valid if the image is later re-uploaded at a different
+    resolution. ``rotate`` is a clockwise quarter-turn (0/90/180/270). This is
+    the shared crop shape: the Send / gallery path resolves an editor rectangle
+    into it, and the Companion image push resolves focus + zoom into it per
+    target panel, then both feed it through :func:`apply_source_crop`.
+    """
+
+    x: float
+    y: float
+    w: float
+    h: float
+    rotate: int
+
+
+def _clamp01(value: Any) -> float:
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(1.0, v))
+
+
+# PIL's ``Transpose.ROTATE_*`` turns counter-clockwise; ``rotate`` is clockwise.
+_CW_ROTATE: dict[int, Image.Transpose] = {
+    90: Image.Transpose.ROTATE_270,
+    180: Image.Transpose.ROTATE_180,
+    270: Image.Transpose.ROTATE_90,
+}
+
+
+def apply_source_crop(img: Image.Image, crop: SourceCrop | None) -> Image.Image:
+    """Crop and rotate a source image by a normalized rect before it's fit.
+
+    Clamps the rect into the image and enforces a minimum 1px extent, so a
+    zero/negative/out-of-range box can never resolve to an empty crop (the
+    server owns this clamp; a caller's rect is advisory). An absent crop, or one
+    that resolves to the whole image with no rotation, returns ``img`` unchanged.
+    """
+    if not crop:
+        return img
+    w0, h0 = img.width, img.height
+    x = _clamp01(crop.get("x", 0.0))
+    y = _clamp01(crop.get("y", 0.0))
+    cw = min(_clamp01(crop.get("w", 1.0)), 1.0 - x)
+    ch = min(_clamp01(crop.get("h", 1.0)), 1.0 - y)
+    left = round(x * w0)
+    top = round(y * h0)
+    right = min(w0, max(left + 1, round((x + cw) * w0)))
+    bottom = min(h0, max(top + 1, round((y + ch) * h0)))
+    if (left, top, right, bottom) != (0, 0, w0, h0):
+        img = img.crop((left, top, right, bottom))
+    transpose = _CW_ROTATE.get(int(crop.get("rotate", 0) or 0) % 360)
+    if transpose is not None:
+        img = img.transpose(transpose)
+    return img
+
+
 def fit_to_panel(
     img: Image.Image,
     *,
@@ -581,6 +642,7 @@ def fit_to_panel(
     target_h: int,
     scale: str = "fit",
     bg: str = "white",
+    crop: SourceCrop | None = None,
 ) -> Image.Image:
     """Resize ``img`` to (target_w, target_h) using the requested scale mode.
 
@@ -593,8 +655,12 @@ def fit_to_panel(
                     copy of the image so the letterbox area is filled.
 
     Used by the Send page when the uploaded image isn't already panel
-    sized. Dashboard renders skip this, the composer emits panel-exact PNGs."""
-    src = img.convert("RGB")
+    sized. Dashboard renders skip this, the composer emits panel-exact PNGs.
+
+    ``crop`` (optional) is a normalized source crop applied *before* the fit, so
+    a chosen subject survives the panel fit rather than being centre-cropped by
+    ``fill``. See :func:`apply_source_crop`."""
+    src = apply_source_crop(img.convert("RGB"), crop)
     if src.size == (target_w, target_h) and scale != "blur":
         return src
     if scale == "stretch":

--- a/app/quantizer.py
+++ b/app/quantizer.py
@@ -349,6 +349,26 @@ _GAMUT_TABLE: dict[str, tuple[tuple[tuple[int, int, int], ...], tuple[int, ...]]
 # panels and the XIAO 7.5" BWR class.
 _NATIVE_2BPP_GAMUTS: frozenset[str] = frozenset({"bwry_4", "bwr_3"})
 
+_MONO_PALETTE: tuple[tuple[int, int, int], ...] = ((0, 0, 0), (255, 255, 255))
+
+
+def palette_for_gamut(gamut: str) -> tuple[tuple[int, int, int], ...]:
+    """The viewable RGB palette a panel of ``gamut`` reproduces, for quantise
+    previews (Panel view). Colour gamuts use the .bin packer's palette; the
+    grayscale ramps and mono map to their grey levels; anything unrecognised
+    canonicalises to the 6-colour Spectra palette so a preview never fails."""
+    g = canonicalise_gamut(gamut)
+    table_entry = _GAMUT_TABLE.get(g)
+    if table_entry is not None:
+        return table_entry[0]
+    if g == "gray_16":
+        return GRAY_16_PALETTE
+    if g == "gray_4":
+        return GRAY_4_PALETTE
+    if g == "mono":
+        return _MONO_PALETTE
+    return WAVESHARE_E6_PALETTE
+
 
 def _apply_exposure(img: Image.Image, exposure: int) -> Image.Image:
     """Linear brightness shift. ``exposure`` in -100..+100 maps to a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.217.0"
+version = "0.218.0"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/static/pages/editor.js
+++ b/static/pages/editor.js
@@ -55,15 +55,21 @@
     if (!status) return;
     status.dataset.state = state;
     const label =
-      state === "saving" ? "Saving…" :
-      state === "error" ? "Save failed" :
-      state === "dirty" ? "Unsaved changes" :
-      "Saved";
+      state === "saving"
+        ? "Saving…"
+        : state === "error"
+          ? "Save failed"
+          : state === "dirty"
+            ? "Unsaved changes"
+            : "Saved";
     const iconClass =
-      state === "saving" ? "ph ph-arrows-clockwise" :
-      state === "error" ? "ph-fill ph-warning-circle" :
-      state === "dirty" ? "ph ph-circle-dashed" :
-      "ph-fill ph-check-circle";
+      state === "saving"
+        ? "ph ph-arrows-clockwise"
+        : state === "error"
+          ? "ph-fill ph-warning-circle"
+          : state === "dirty"
+            ? "ph ph-circle-dashed"
+            : "ph-fill ph-check-circle";
     status.innerHTML =
       '<i class="' + iconClass + '" aria-hidden="true"></i><span>' + label + "</span>";
   }
@@ -89,7 +95,13 @@
   // step-wise widget options where each keystroke isn't a meaningful
   // value; the 'change' (blur) commit is the natural preview point.
   const _DEFER_INPUT_TYPES = new Set([
-    "text", "search", "email", "url", "password", "tel", "number",
+    "text",
+    "search",
+    "email",
+    "url",
+    "password",
+    "tel",
+    "number",
   ]);
   function _deferToBlur(el) {
     if (!el) return false;
@@ -144,11 +156,100 @@
           // the next preview cycle diffs against what's actually painted.
           lastStateByFrame.delete(iframe);
         },
-        { once: true },
+        { once: true }
       );
       iframe.src = url.pathname + url.search;
     });
+    // In Panel view an edit means a fresh composition, so re-poll the
+    // quantised preview (the hidden iframes still reload above, harmless).
+    if (_previewMode === "panel") refreshPanelPreviews();
   }
+
+  // --- Panel view: quantised + dithered preview (#45) ------------------
+  // "Fit view" shows the live HTML iframe; "Panel view" swaps in a PNG the
+  // server quantises + dithers to the panel's palette, so the editor shows the
+  // exact per-pixel e-ink output. That PNG needs a headless render, so it can
+  // 202 briefly while the render lands; poll until it's ready.
+  let _previewMode = "fit";
+  const _panelPollTimers = new Map();
+
+  function _panelImg(frame) {
+    return frame.querySelector("[data-panel-preview]");
+  }
+  function _clearPanelPoll(frame) {
+    const t = _panelPollTimers.get(frame);
+    if (t) {
+      clearTimeout(t);
+      _panelPollTimers.delete(frame);
+    }
+  }
+
+  function loadPanelPreview(frame) {
+    const img = _panelImg(frame);
+    if (!img || !img.dataset.panelSrc) return;
+    _clearPanelPoll(frame);
+    const base = img.dataset.panelSrc;
+    const url = base + (base.includes("?") ? "&" : "?") + "_t=" + Date.now();
+    const iframe = frame.querySelector("[data-preview-iframe]");
+    if (iframe) showPreviewThrobber(iframe);
+    let tries = 0;
+    const attempt = () => {
+      if (_previewMode !== "panel") return;
+      fetch(url, { cache: "no-store" })
+        .then((r) => {
+          if (r.status === 200) {
+            img.onload = () => {
+              if (iframe) hidePreviewThrobber(iframe);
+            };
+            img.src = url;
+          } else if (r.status === 202 && tries++ < 40) {
+            _panelPollTimers.set(frame, setTimeout(attempt, 500));
+          } else if (iframe) {
+            hidePreviewThrobber(iframe);
+          }
+        })
+        .catch(() => {
+          if (iframe) hidePreviewThrobber(iframe);
+        });
+    };
+    attempt();
+  }
+
+  function refreshPanelPreviews() {
+    document.querySelectorAll(".preview-frame").forEach(loadPanelPreview);
+  }
+
+  function setPreviewMode(mode) {
+    _previewMode = mode === "panel" ? "panel" : "fit";
+    document.querySelectorAll("[data-preview-mode]").forEach((b) => {
+      const on = b.dataset.previewMode === _previewMode;
+      b.classList.toggle("is-active", on);
+      b.setAttribute("aria-pressed", on ? "true" : "false");
+    });
+    document.querySelectorAll(".preview-frame").forEach((frame) => {
+      _clearPanelPoll(frame);
+      const iframe = frame.querySelector("[data-preview-iframe]");
+      const img = _panelImg(frame);
+      if (_previewMode === "panel") {
+        if (iframe) iframe.hidden = true;
+        if (img) img.hidden = false;
+      } else {
+        if (img) {
+          img.hidden = true;
+          img.removeAttribute("src");
+        }
+        if (iframe) {
+          iframe.hidden = false;
+          hidePreviewThrobber(iframe);
+        }
+      }
+    });
+    if (_previewMode === "panel") refreshPanelPreviews();
+  }
+
+  document.querySelectorAll("[data-preview-mode]").forEach((btn) => {
+    btn.addEventListener("click", () => setPreviewMode(btn.dataset.previewMode));
+  });
 
   // Bounded-lifetime preview iframes.
   //
@@ -190,11 +291,11 @@
               hidePreviewThrobber(iframe);
               lastStateByFrame.delete(iframe);
             },
-            { once: true },
+            { once: true }
           );
           iframe.src = finalUrl;
         },
-        { once: true },
+        { once: true }
       );
       iframe.src = "about:blank";
     });
@@ -214,9 +315,7 @@
     const u = new URL(iframe.src, location.origin);
     const w = Number(u.searchParams.get("w"));
     const h = Number(u.searchParams.get("h"));
-    return Number.isFinite(w) && Number.isFinite(h) && w > 0 && h > 0
-      ? { w, h }
-      : null;
+    return Number.isFinite(w) && Number.isFinite(h) && w > 0 && h > 0 ? { w, h } : null;
   }
 
   // Decide whether two hydrated states can be reconciled in-place via a
@@ -263,7 +362,10 @@
       cells: next.cells.map((c) => ({
         id: c.id,
         plugin: c.plugin || "",
-        x: c.x, y: c.y, w: c.w, h: c.h,
+        x: c.x,
+        y: c.y,
+        w: c.w,
+        h: c.h,
         zoom: typeof c.zoom === "number" ? c.zoom : 1,
         options: c.options,
         data: c.data,
@@ -295,10 +397,7 @@
       const prev = lastStateByFrame.get(iframe);
       if (canPatch(prev, match.state)) {
         try {
-          iframe.contentWindow.postMessage(
-            buildPatch(match.state),
-            location.origin,
-          );
+          iframe.contentWindow.postMessage(buildPatch(match.state), location.origin);
           lastStateByFrame.set(iframe, match.state);
           appliedAny = true;
         } catch (err) {
@@ -331,7 +430,7 @@
             iframe.style.opacity = "1";
             lastStateByFrame.set(iframe, match.state);
           },
-          { once: true },
+          { once: true }
         );
         iframe.src = u.pathname + u.search;
       }
@@ -438,7 +537,11 @@
       mount.dataset.touchBound = "1";
       const input = mount.parentElement.querySelector("[data-touch-input]");
       let value = {};
-      try { value = JSON.parse(mount.dataset.touchValue || "{}") || {}; } catch (e) { value = {}; }
+      try {
+        value = JSON.parse(mount.dataset.touchValue || "{}") || {};
+      } catch (e) {
+        value = {};
+      }
       const node = TouchInteraction.render({
         value: value,
         pagesUrl: mount.dataset.pagesUrl,
@@ -670,15 +773,18 @@
     target.scrollIntoView({ behavior: "smooth", block: "nearest" });
     const field = target.querySelector("select, input, textarea, button");
     if (field) {
-      try { field.focus({ preventScroll: true }); } catch (e) { field.focus(); }
+      try {
+        field.focus({ preventScroll: true });
+      } catch (e) {
+        field.focus();
+      }
     }
     previewFrames().forEach((iframe) => {
       try {
-        iframe.contentWindow.postMessage(
-          { type: "tesserae-focus-cell", cellId },
-          location.origin,
-        );
-      } catch (e) { /* iframe not ready / cross-origin */ }
+        iframe.contentWindow.postMessage({ type: "tesserae-focus-cell", cellId }, location.origin);
+      } catch (e) {
+        /* iframe not ready / cross-origin */
+      }
     });
   }
 

--- a/static/style/editor.css
+++ b/static/style/editor.css
@@ -54,7 +54,9 @@
   position: absolute;
   inset: 0;
 }
-.preview-placeholder[hidden] { display: none !important; }
+.preview-placeholder[hidden] {
+  display: none !important;
+}
 
 /* Live-preview throbber (v0.69.8). Sits on top of the faded iframe
    while the composer server-renders the page (waiting on each
@@ -70,7 +72,9 @@
   z-index: 2;
   animation: preview-throbber-fade-in 180ms ease 100ms both;
 }
-.preview-throbber[hidden] { display: none; }
+.preview-throbber[hidden] {
+  display: none;
+}
 .preview-throbber > i {
   font-size: 40px;
   color: var(--t-accent);
@@ -78,15 +82,23 @@
   animation: preview-throbber-spin 0.9s linear infinite;
 }
 @keyframes preview-throbber-spin {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 @keyframes preview-throbber-fade-in {
   /* Small delay + fade so a fast render (cached widget data, no
      network hit) doesn't flash the throbber. Anything under ~280 ms
      stays invisible; longer waits get the spinner. */
-  from { opacity: 0; }
-  to   { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 /* ----- Dashboards index (mirrors inky-dash) ----------------------- */
@@ -121,7 +133,9 @@
   border-color: var(--t-accent);
   box-shadow: 0 0 0 3px color-mix(in oklab, var(--t-accent) 20%, transparent);
 }
-.dashboard-create-btn { flex: 0 0 auto; }
+.dashboard-create-btn {
+  flex: 0 0 auto;
+}
 
 .dashboard-count {
   font-size: var(--t-size-xs);
@@ -161,7 +175,9 @@
   box-shadow: var(--t-shadow-sm);
   transform: translateY(-1px);
 }
-.page-row:hover .page-name { color: var(--t-accent); }
+.page-row:hover .page-name {
+  color: var(--t-accent);
+}
 
 .page-icon-tile {
   flex: 0 0 auto;
@@ -202,7 +218,11 @@
   opacity: 0.75;
 }
 
-.page-actions { display: flex; gap: var(--t-space-2); align-items: center; }
+.page-actions {
+  display: flex;
+  gap: var(--t-space-2);
+  align-items: center;
+}
 
 /* Outlined pill actions (Edit / Push / Delete). */
 .page-action {
@@ -219,15 +239,21 @@
   font-weight: 500;
   text-decoration: none;
   cursor: pointer;
-  transition: border-color var(--t-trans-fast), color var(--t-trans-fast),
-              background var(--t-trans-fast);
+  transition:
+    border-color var(--t-trans-fast),
+    color var(--t-trans-fast),
+    background var(--t-trans-fast);
 }
-.page-action .ph { font-size: 15px; }
+.page-action .ph {
+  font-size: 15px;
+}
 .page-action:hover {
   border-color: var(--t-accent);
   color: var(--t-accent);
 }
-.page-action-danger { color: var(--t-danger); }
+.page-action-danger {
+  color: var(--t-danger);
+}
 .page-action-danger:hover {
   border-color: var(--t-danger);
   color: var(--t-danger);
@@ -236,8 +262,12 @@
 
 @media (max-width: 640px) {
   /* Collapse action labels to icons on narrow screens. */
-  .page-action span { display: none; }
-  .page-action { padding: var(--t-space-2) var(--t-space-3); }
+  .page-action span {
+    display: none;
+  }
+  .page-action {
+    padding: var(--t-space-2) var(--t-space-3);
+  }
 }
 
 .cell-list {
@@ -257,7 +287,9 @@
   background: var(--t-surface-soft);
   border: 1px solid transparent;
   border-radius: var(--t-radius-sm);
-  transition: background var(--t-trans-fast), border-color var(--t-trans-fast);
+  transition:
+    background var(--t-trans-fast),
+    border-color var(--t-trans-fast);
 }
 .cell-row:hover {
   background: var(--t-surface);
@@ -270,10 +302,19 @@
   min-width: 0;
 }
 
-.cell-row-name { font-weight: 600; font-size: 14px; }
-.cell-row-meta { font-size: 12px; }
+.cell-row-name {
+  font-weight: 600;
+  font-size: 14px;
+}
+.cell-row-meta {
+  font-size: 12px;
+}
 
-.add-cell { padding-top: var(--t-space-1); border-top: 1px dashed var(--t-border); margin-top: var(--t-space-1); }
+.add-cell {
+  padding-top: var(--t-space-1);
+  border-top: 1px dashed var(--t-border);
+  margin-top: var(--t-space-1);
+}
 
 .form-group {
   border: 1px solid var(--t-border);
@@ -298,7 +339,9 @@
   color: var(--t-fg-soft);
   padding: var(--t-space-1) 0;
 }
-.form-group[open] summary { margin-bottom: var(--t-space-3); }
+.form-group[open] summary {
+  margin-bottom: var(--t-space-3);
+}
 
 .header-action {
   display: inline-flex;
@@ -340,7 +383,9 @@
     0 0 0 4px color-mix(in oklab, var(--t-accent) 18%, transparent);
   transform: translateY(-1px);
 }
-.header-action:active { transform: translateY(0); }
+.header-action:active {
+  transform: translateY(0);
+}
 .header-action:focus-visible {
   outline: none;
   box-shadow:
@@ -352,7 +397,9 @@
   color: var(--t-fg-soft);
   text-decoration: none;
 }
-.header-back:hover { color: var(--t-accent); }
+.header-back:hover {
+  color: var(--t-accent);
+}
 
 .page-id-tag {
   font-size: 13px;
@@ -383,7 +430,9 @@
   margin-right: calc(-1 * var(--t-space-1));
 }
 @supports not (backdrop-filter: blur(1px)) {
-  .editor-header { background: var(--t-bg); }
+  .editor-header {
+    background: var(--t-bg);
+  }
 }
 
 .editor-header .header-back {
@@ -393,7 +442,10 @@
   border-radius: var(--t-radius-sm);
   color: var(--t-fg-soft);
 }
-.editor-header .header-back:hover { background: var(--t-surface-soft); color: var(--t-accent); }
+.editor-header .header-back:hover {
+  background: var(--t-surface-soft);
+  color: var(--t-accent);
+}
 
 .editor-name-icon {
   display: inline-grid;
@@ -406,11 +458,18 @@
   font-size: 18px;
   flex-shrink: 0;
 }
-.editor-name-icon:empty { display: none; }
+.editor-name-icon:empty {
+  display: none;
+}
 
-.inline-name-form { flex: 1; max-width: 480px; }
+.inline-name-form {
+  flex: 1;
+  max-width: 480px;
+}
 .inline-name-input {
-  font: 700 18px/1.2 system-ui, sans-serif;
+  font:
+    700 18px/1.2 system-ui,
+    sans-serif;
   padding: var(--t-space-2) var(--t-space-3);
   border: 1px solid transparent;
   border-radius: var(--t-radius-sm);
@@ -418,8 +477,14 @@
   width: 100%;
   color: var(--t-fg);
 }
-.inline-name-input:hover { background: var(--t-surface-soft); }
-.inline-name-input:focus { background: var(--t-surface); border-color: var(--t-border-strong); outline: none; }
+.inline-name-input:hover {
+  background: var(--t-surface-soft);
+}
+.inline-name-input:focus {
+  background: var(--t-surface);
+  border-color: var(--t-border-strong);
+  outline: none;
+}
 
 .save-status {
   display: inline-flex;
@@ -434,16 +499,23 @@
   border: 1px solid color-mix(in oklab, var(--t-ok) 25%, transparent);
   font-variant-numeric: tabular-nums;
   letter-spacing: -0.005em;
-  transition: background var(--t-trans), color var(--t-trans),
-              border-color var(--t-trans);
+  transition:
+    background var(--t-trans),
+    color var(--t-trans),
+    border-color var(--t-trans);
 }
-.save-status .ph, .save-status [class^="ph-"] { font-size: 13px; }
+.save-status .ph,
+.save-status [class^="ph-"] {
+  font-size: 13px;
+}
 .save-status[data-state="saving"] {
   background: var(--t-surface-sunk);
   color: var(--t-fg-soft);
   border-color: var(--t-border);
 }
-.save-status[data-state="saving"] .ph { animation: ts-spin 0.9s linear infinite; }
+.save-status[data-state="saving"] .ph {
+  animation: ts-spin 0.9s linear infinite;
+}
 .save-status[data-state="dirty"] {
   background: color-mix(in oklab, var(--t-warn) 14%, transparent);
   color: var(--t-warn);
@@ -456,25 +528,37 @@
 }
 
 @keyframes ts-spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
-.editor-spacer { flex: 1; }
+.editor-spacer {
+  flex: 1;
+}
 
 .editor-actions {
   display: inline-flex;
   align-items: center;
   gap: var(--t-space-2);
 }
-.editor-actions button { padding: var(--t-space-2) var(--t-space-3); font-size: var(--t-size-md); }
-.editor-actions button[disabled] { opacity: 0.5; cursor: not-allowed; }
+.editor-actions button {
+  padding: var(--t-space-2) var(--t-space-3);
+  font-size: var(--t-size-md);
+}
+.editor-actions button[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 
 /* ----- Editor grid: options on the left, preview pinned on the right - */
 
 @media (min-width: 1100px) {
   /* Bumps the shared page-column variable so .page and the topbar's
      padding-inline both pick up the wider column. */
-  :root { --t-page-max: 1440px; }
+  :root {
+    --t-page-max: 1440px;
+  }
   .editor-grid {
     grid-template-columns: minmax(0, 1fr) minmax(360px, 620px);
     grid-template-areas: "column preview";
@@ -514,7 +598,9 @@
 }
 
 @media (max-width: 1099px) {
-  .editor-grid { gap: var(--t-space-4); }
+  .editor-grid {
+    gap: var(--t-space-4);
+  }
   /* Mobile: editor header is NOT sticky, scrolls away naturally so
      the save/send/delete row only exists at the top of the page.
      Preview card scrolls with the rest of the content; the
@@ -554,9 +640,17 @@
   /* Shorter cap on phone-portrait so the cell editors get most of the
      viewport. The sticky preview at the top is meant for live-eyeing
      edits, not dominating the screen. */
-  :root { --mobile-preview-h: 30vh; }
-  .editor-grid { gap: var(--t-space-3); }
-  .preview-dims { font-size: var(--t-size-xs); margin-top: var(--t-space-2); text-align: center; }
+  :root {
+    --mobile-preview-h: 30vh;
+  }
+  .editor-grid {
+    gap: var(--t-space-3);
+  }
+  .preview-dims {
+    font-size: var(--t-size-xs);
+    margin-top: var(--t-space-2);
+    text-align: center;
+  }
 
   /* Two-row header. Row 1: back · icon · name input (takes the rest).
      Row 2: save-status (left) · actions (right). page-id-tag and the
@@ -568,12 +662,30 @@
     gap: var(--t-space-2);
     padding: var(--t-space-2) var(--t-space-1);
   }
-  .editor-header .header-back { grid-row: 1; grid-column: 1; }
-  .editor-name-icon            { grid-row: 1; grid-column: 2; }
-  .inline-name-form            { grid-row: 1; grid-column: 3 / span 2; max-width: none; }
-  .save-status                 { grid-row: 2; grid-column: 1 / span 2; justify-self: start; }
-  .editor-spacer               { display: none; }
-  .page-id-tag                 { display: none; }
+  .editor-header .header-back {
+    grid-row: 1;
+    grid-column: 1;
+  }
+  .editor-name-icon {
+    grid-row: 1;
+    grid-column: 2;
+  }
+  .inline-name-form {
+    grid-row: 1;
+    grid-column: 3 / span 2;
+    max-width: none;
+  }
+  .save-status {
+    grid-row: 2;
+    grid-column: 1 / span 2;
+    justify-self: start;
+  }
+  .editor-spacer {
+    display: none;
+  }
+  .page-id-tag {
+    display: none;
+  }
   .editor-actions {
     grid-row: 2;
     grid-column: 3 / span 2;
@@ -581,7 +693,9 @@
     flex-wrap: nowrap;
   }
   /* Action button labels collapse, icons only at this width. */
-  .editor-actions button > span:not(.icon) { display: none; }
+  .editor-actions button > span:not(.icon) {
+    display: none;
+  }
   .editor-actions button {
     padding: var(--t-space-2) var(--t-space-3);
     min-width: 40px;
@@ -589,7 +703,9 @@
   }
 }
 
-.preview-card .preview-frame { margin: 0 auto; }
+.preview-card .preview-frame {
+  margin: 0 auto;
+}
 .preview-dims {
   text-align: right;
   font-size: var(--t-size-sm);
@@ -660,9 +776,7 @@
   outline: none;
 }
 .scroll-to-preview:focus-visible {
-  box-shadow:
-    var(--t-shadow-xl),
-    var(--t-ring);
+  box-shadow: var(--t-shadow-xl), var(--t-ring);
 }
 /* Hover lift on desktop pointers, the icon nudges up to telegraph the
    "back to top" action. Skipped on touch (`hover: none`) so a finger
@@ -753,7 +867,10 @@
 /* Cell cards inherit .card-head + .card-head h2 verbatim from
    shell.css, no overrides needed. The plugin tag inside the title
    reads as secondary. */
-.cell-card-plugin { font-weight: 500; color: var(--t-fg-soft); }
+.cell-card-plugin {
+  font-weight: 500;
+  color: var(--t-fg-soft);
+}
 
 /* ----- Layout editor (interactive grid) --------------------------- */
 
@@ -788,7 +905,10 @@
   align-items: center;
   gap: var(--t-space-2);
 }
-.layout-editor-hint .ph { font-size: 14px; color: var(--t-accent); }
+.layout-editor-hint .ph {
+  font-size: 14px;
+  color: var(--t-accent);
+}
 
 /* Snap-to-grid controls live below the board + hint. The dashed
    gridline overlay is painted by the JS directly on
@@ -801,7 +921,9 @@
   flex-direction: column;
   gap: var(--t-space-2);
 }
-.layout-snap-dims[hidden] { display: none; }
+.layout-snap-dims[hidden] {
+  display: none;
+}
 
 .le-cell {
   position: absolute;
@@ -826,7 +948,10 @@
   background: var(--t-danger);
   border-color: var(--t-danger);
   color: var(--t-bg, #fff);
-  transition: background 600ms linear, border-color 600ms linear, color 200ms ease;
+  transition:
+    background 600ms linear,
+    border-color 600ms linear,
+    color 200ms ease;
 }
 .le-cell.is-pressing .le-cell-label,
 .le-cell.is-pressing .le-cell-delete {
@@ -861,14 +986,21 @@
   color: var(--t-fg-soft);
   cursor: pointer;
   opacity: 0;
-  transition: opacity 120ms ease, color 120ms ease, border-color 120ms ease;
+  transition:
+    opacity 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease;
 }
-.le-cell:hover .le-cell-delete { opacity: 1; }
+.le-cell:hover .le-cell-delete {
+  opacity: 1;
+}
 .le-cell-delete:hover {
   color: var(--t-danger);
   border-color: var(--t-danger);
 }
-.le-cell-delete .ph { font-size: 13px; }
+.le-cell-delete .ph {
+  font-size: 13px;
+}
 
 /* Insert affordances, thin invisible strips on each side that show a
    "+ insert here" hint on hover. Click splits the cell along the
@@ -894,7 +1026,9 @@
   display: grid;
   place-items: center;
   opacity: 0;
-  transition: opacity 120ms ease, transform 120ms ease;
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
 }
 .le-insert:hover {
   background: color-mix(in oklab, var(--t-accent) 18%, transparent);
@@ -903,10 +1037,30 @@
   opacity: 1;
   transform: scale(1.05);
 }
-.le-insert--top    { top: 0;    left: 0; right: 0; height: 14px; }
-.le-insert--bottom { bottom: 0; left: 0; right: 0; height: 14px; }
-.le-insert--left   { left: 0;   top: 0; bottom: 0; width: 14px; }
-.le-insert--right  { right: 0;  top: 0; bottom: 0; width: 14px; }
+.le-insert--top {
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 14px;
+}
+.le-insert--bottom {
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 14px;
+}
+.le-insert--left {
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 14px;
+}
+.le-insert--right {
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 14px;
+}
 
 /* Resize handles for shared edges. Sit ON TOP of the cells with a
    generous hit-target (24px) for touch; the visible bar inside is
@@ -927,7 +1081,9 @@
   transition: opacity 120ms ease;
 }
 .le-edge:hover::after,
-.layout-editor-board.is-dragging .le-edge::after { opacity: 0.7; }
+.layout-editor-board.is-dragging .le-edge::after {
+  opacity: 0.7;
+}
 
 .le-edge--h {
   height: 24px;
@@ -935,7 +1091,8 @@
   cursor: ns-resize;
 }
 .le-edge--h::after {
-  left: 0; right: 0;
+  left: 0;
+  right: 0;
   top: 11px;
   height: 2px;
 }
@@ -945,7 +1102,8 @@
   cursor: ew-resize;
 }
 .le-edge--v::after {
-  top: 0; bottom: 0;
+  top: 0;
+  bottom: 0;
   left: 11px;
   width: 2px;
 }
@@ -962,7 +1120,10 @@
   color: var(--t-fg-soft);
   padding: var(--t-space-2) 0;
 }
-.custom-layout[open] summary { color: var(--t-fg); margin-bottom: var(--t-space-2); }
+.custom-layout[open] summary {
+  color: var(--t-fg);
+  margin-bottom: var(--t-space-2);
+}
 
 /* ----- Layout picker (thumbnails) --------------------------------- */
 
@@ -977,7 +1138,9 @@
   --thumb-h: 96px;
 }
 
-.layout-form { margin: 0; }
+.layout-form {
+  margin: 0;
+}
 
 .layout-card {
   display: grid;
@@ -991,9 +1154,13 @@
   cursor: pointer;
   width: 100%;
   text-align: center;
-  font: var(--t-size-sm)/1.2 system-ui, sans-serif;
+  font:
+    var(--t-size-sm)/1.2 system-ui,
+    sans-serif;
   color: var(--t-fg);
-  transition: border-color 80ms ease, transform 80ms ease;
+  transition:
+    border-color 80ms ease,
+    transform 80ms ease;
   /* Reset the global button inline-flex so the grid-rows take effect. */
   white-space: normal;
 }
@@ -1051,7 +1218,6 @@
   border-style: dashed;
 }
 
-
 /* ----- Schedules card on the page editor --------------------------- */
 /* Compact list of schedules pinned to this dashboard, surfaced under
    the live preview so the composer can see "what fires this" at a
@@ -1073,7 +1239,9 @@
   border-radius: 8px;
   background: color-mix(in srgb, var(--t-fg-soft, #9aa0aa) 6%, transparent);
 }
-.schedules-card-row.is-disabled .schedules-card-row-name { color: var(--t-fg-soft); }
+.schedules-card-row.is-disabled .schedules-card-row-name {
+  color: var(--t-fg-soft);
+}
 .schedules-card-row-main {
   display: flex;
   flex-direction: column;
@@ -1104,4 +1272,35 @@
   align-items: center;
   gap: var(--t-space-3);
   margin-top: var(--t-space-3);
+}
+
+/* Panel-view toggle (#45): Fit view / Panel view segmented control over the
+   live preview. Panel view shows the composition quantised + dithered to the
+   panel's palette (crisp 1:1, so image-rendering is pixelated). */
+.preview-modes {
+  display: inline-flex;
+  gap: 2px;
+  margin: 0 0 var(--t-space-3);
+  padding: 2px;
+  background: var(--t-surface-sunk);
+  border-radius: var(--t-radius-pill);
+}
+.preview-mode {
+  border: 0;
+  background: transparent;
+  color: var(--t-fg-soft);
+  font: inherit;
+  font-size: var(--t-size-sm);
+  padding: 4px 12px;
+  border-radius: var(--t-radius-pill);
+  cursor: pointer;
+}
+.preview-mode.is-active {
+  background: var(--t-surface);
+  color: var(--t-fg);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+.preview-panel-img {
+  display: block;
+  image-rendering: pixelated;
 }

--- a/templates/page_editor.html
+++ b/templates/page_editor.html
@@ -247,6 +247,16 @@
 
   <section class="dx-section-card preview-card">
     {{ card_head('Live preview', icon_name='monitor-play', blurb='Click a cell to edit it. Updates after every change.') }}
+    {# Fit view = the live full-colour HTML render; Panel view = that render
+       quantised + dithered to the panel's palette, the exact per-pixel e-ink
+       output (#45). Editor JS swaps the iframe for the panel <img> per group. #}
+    <div class="preview-modes" data-preview-modes role="group" aria-label="Preview mode">
+      <button type="button" class="preview-mode is-active" data-preview-mode="fit">Fit view</button>
+      <button type="button" class="preview-mode" data-preview-mode="panel"
+              title="Quantised and dithered to the panel's palette, the exact per-pixel e-ink output">
+        Panel view
+      </button>
+    </div>
     {# One preview per distinct aspect ratio among the selected devices.
        preview_groups is a single virtual-panel group when nothing is
        picked, or one group per shape when devices of differing aspect
@@ -272,6 +282,13 @@
                 style="width: {{ g.w }}px; height: {{ g.h }}px;"
                 loading="lazy" sandbox="allow-scripts allow-same-origin"
                 data-preview-iframe></iframe>
+        {# Panel view target: quantised PNG for this group's gamut. Its src is
+           set lazily by editor.js when Panel view is active (kept out of the
+           DOM src so it doesn't render until asked). #}
+        <img class="preview-panel-img" data-panel-preview
+             data-panel-src="{{ url_for('composer.compose_panel_preview', page_id=page.id) }}?gamut={{ g.gamut }}&amp;dither=floyd-steinberg"
+             alt="Panel view (quantised)" hidden
+             style="width: {{ g.w }}px; height: {{ g.h }}px;">
       </div>
       <p class="muted preview-dims">
         {{ g.w }} × {{ g.h }}

--- a/tests/test_composer.py
+++ b/tests/test_composer.py
@@ -651,3 +651,56 @@ def test_resolved_options_migrates_legacy_flat_lat_lon(app: Flask) -> None:
         # Legacy fields have no ``name`` so no auto-label; ``label`` stays
         # unset and the cell can render "no label" cleanly.
         assert not out.get("label")
+
+
+def test_compose_panel_preview_quantises_existing_composition(
+    app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Panel view (#45) serves a quantised+dithered PNG built from the cached
+    composition, without a re-render, and caches the quantised result keyed by
+    gamut + dither."""
+    import io
+
+    from PIL import Image
+
+    from app.state.page_store import Page
+
+    page = Page(id="pg", name="Grid", layout_kind="grid")
+    app.config["PAGE_STORE"].save(page)
+    width, height = composer.preview_dims(
+        page, app.config.get("DEVICE_REGISTRY"), app.config["SETTINGS_STORE"]
+    )
+    token = composer.page_preview_token(page, (width, height))
+    cache_dir = app.config["DATA_ROOT"] / "core" / "previews"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    buf = io.BytesIO()
+    Image.new("RGB", (24, 18), (123, 200, 60)).save(buf, "PNG")
+    (cache_dir / f"pg__{token}.png").write_bytes(buf.getvalue())
+
+    def _boom(req: object, pool: object = None) -> bytes:
+        raise AssertionError("should not render when the composition is cached")
+
+    monkeypatch.setattr("app.renderer.render_to_png", _boom)
+    resp = app.test_client().get("/compose/pg/panel.png?dither=none")
+    assert resp.status_code == 200 and resp.mimetype == "image/png"
+    # A quantised cache file was written (keyed by gamut + dither).
+    assert list(cache_dir.glob("pg__*__none.png"))
+    out = Image.open(io.BytesIO(resp.data))
+    assert out.size == (24, 18)
+
+
+def test_compose_panel_preview_202_when_composition_missing(
+    app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no cached composition yet, Panel view enqueues the render and 202s,
+    same fallback as preview.png."""
+    from app.state.page_store import Page
+
+    monkeypatch.setattr("app.preview_cache.submit", lambda **kw: None)
+    app.config["PAGE_STORE"].save(Page(id="pg2", name="Grid", layout_kind="grid"))
+    resp = app.test_client().get("/compose/pg2/panel.png")
+    assert resp.status_code == 202
+
+
+def test_compose_panel_preview_unknown_page_404(client: FlaskClient) -> None:
+    assert client.get("/compose/nope/panel.png").status_code == 404

--- a/tests/test_quantizer.py
+++ b/tests/test_quantizer.py
@@ -466,3 +466,79 @@ def test_fit_to_panel_fill_crops() -> None:
     img = Image.new("RGB", (200, 100), (0, 0, 0))
     out = fit_to_panel(img, target_w=100, target_h=80, scale="fill")
     assert out.size == (100, 80)
+
+
+# -- source crop primitive (#45) ----------------------------------------
+
+
+def _swatch(w: int, h: int, left_rgb: tuple, right_rgb: tuple) -> Image.Image:
+    """An image whose left and right halves are distinct solid colours."""
+    img = Image.new("RGB", (w, h), left_rgb)
+    img.paste(Image.new("RGB", (w - w // 2, h), right_rgb), (w // 2, 0))
+    return img
+
+
+def test_apply_source_crop_none_and_full_are_identity() -> None:
+    from PIL import Image
+
+    from app.quantizer import apply_source_crop
+
+    img = Image.new("RGB", (40, 30), (10, 20, 30))
+    assert apply_source_crop(img, None) is img
+    same = apply_source_crop(img, {"x": 0.0, "y": 0.0, "w": 1.0, "h": 1.0})
+    assert same.size == (40, 30)
+
+
+def test_apply_source_crop_selects_the_rect() -> None:
+    from app.quantizer import apply_source_crop
+
+    img = _swatch(100, 100, (255, 0, 0), (0, 0, 255))  # left red, right blue
+    # Right half only -> all blue, half width.
+    right = apply_source_crop(img, {"x": 0.5, "y": 0.0, "w": 0.5, "h": 1.0})
+    assert right.size == (50, 100)
+    assert right.getpixel((0, 0)) == (0, 0, 255)
+    assert right.getpixel((49, 99)) == (0, 0, 255)
+
+
+def test_apply_source_crop_clamps_out_of_range_to_non_empty() -> None:
+    from app.quantizer import apply_source_crop
+
+    img = _swatch(80, 60, (0, 0, 0), (255, 255, 255))
+    # Garbage / out-of-range rect must clamp, never produce an empty crop.
+    for crop in (
+        {"x": -1.0, "y": -1.0, "w": 5.0, "h": 5.0},
+        {"x": 0.9, "y": 0.9, "w": 0.0, "h": 0.0},
+        {"x": "nonsense", "y": None, "w": 2.0, "h": 2.0},
+    ):
+        out = apply_source_crop(img, crop)  # type: ignore[arg-type]
+        assert out.width >= 1 and out.height >= 1
+
+
+def test_apply_source_crop_rotate_transposes_dims() -> None:
+    from app.quantizer import apply_source_crop
+
+    img = _swatch(100, 40, (255, 0, 0), (0, 0, 255))
+    r90 = apply_source_crop(img, {"x": 0.0, "y": 0.0, "w": 1.0, "h": 1.0, "rotate": 90})
+    assert r90.size == (40, 100)  # quarter turn swaps w/h
+    r180 = apply_source_crop(img, {"rotate": 180})
+    assert r180.size == (100, 40)
+    # 180 flips left/right: the top-left pixel was red, now reads blue.
+    assert r180.getpixel((0, 0)) == (0, 0, 255)
+
+
+def test_fit_to_panel_applies_crop_before_fill() -> None:
+    from app.quantizer import fit_to_panel
+
+    # Left red, right blue. Crop to the right half, then fill a square panel:
+    # the panel should be entirely blue (the chosen subject survives the fit),
+    # whereas an uncropped fill would centre-crop and keep red.
+    img = _swatch(200, 100, (255, 0, 0), (0, 0, 255))
+    out = fit_to_panel(
+        img,
+        target_w=60,
+        target_h=60,
+        scale="fill",
+        crop={"x": 0.5, "y": 0.0, "w": 0.5, "h": 1.0},
+    )
+    assert out.size == (60, 60)
+    assert out.getpixel((30, 30)) == (0, 0, 255)

--- a/tests/test_quantizer.py
+++ b/tests/test_quantizer.py
@@ -542,3 +542,20 @@ def test_fit_to_panel_applies_crop_before_fill() -> None:
     )
     assert out.size == (60, 60)
     assert out.getpixel((30, 30)) == (0, 0, 255)
+
+
+def test_palette_for_gamut_maps_colour_and_grayscale() -> None:
+    from app.quantizer import (
+        GRAY_4_PALETTE,
+        GRAY_16_PALETTE,
+        INKY_7COLOUR_PALETTE,
+        palette_for_gamut,
+    )
+
+    assert palette_for_gamut("waveshare_e6") == WAVESHARE_E6_PALETTE
+    assert palette_for_gamut("spectra_6") == WAVESHARE_E6_PALETTE  # chemistry alias
+    assert palette_for_gamut("acep_7colour") == INKY_7COLOUR_PALETTE  # alias
+    assert palette_for_gamut("gray_4") == GRAY_4_PALETTE
+    assert palette_for_gamut("gray_16") == GRAY_16_PALETTE
+    assert palette_for_gamut("mono") == ((0, 0, 0), (255, 255, 255))
+    assert palette_for_gamut("nonsense") == WAVESHARE_E6_PALETTE  # safe fallback

--- a/uv.lock
+++ b/uv.lock
@@ -1934,7 +1934,7 @@ wheels = [
 
 [[package]]
 name = "tesserae"
-version = "0.217.0"
+version = "0.218.0"
 source = { editable = "." }
 dependencies = [
     { name = "amqtt" },


### PR DESCRIPTION
Partial #45: the two clean, high-value pieces surfaced by the design exploration. The picture-gallery on-web crop editor + per-image dither are deliberately **not** here (see "Deferred" below).

## What's included

**1. Source crop primitive** (`app/quantizer.py`)
- `SourceCrop` (normalized `{x,y,w,h}` in [0,1] + clockwise `rotate`) and `apply_source_crop`, threaded into `fit_to_panel` and applied **before** the fit, so a chosen subject survives `fill` rather than being centre-cropped.
- The rect is clamped to the image and a 1px minimum, so a zero/negative/out-of-range box can never resolve empty (the server owns the clamp).
- This is the shared crop foundation the Send/gallery path and the Companion image push both build framing on (the Companion resolves focus+zoom into a `SourceCrop` per target panel).

**2. Panel view: quantised + dithered preview**
- `GET /compose/<page>/panel.png` reuses the cached dashboard composition, quantises + dithers it to a target device's palette via `quantize_to_png`, and serves the result (cached per token/gamut/dither). `?gamut` / `?device` select the palette; `?dither` overrides the mode.
- `palette_for_gamut` maps any gamut (incl. grayscale/mono) to its viewable palette.
- Editor **Fit view / Panel view toggle**: Panel view swaps the live HTML iframe for the quantised `panel.png` per preview group (each group renders to its own panel's palette), polling while the headless render lands. So the editor shows the exact per-pixel e-ink output before pushing.

## Deferred (design friction, not scope-cut)
The exploration found the picture gallery is **folder-rotation** based (no per-image identity) with **two render paths**, so #45's "per-image crop editor + per-image dither" doesn't map cleanly onto it. Those need a design decision (per-(folder,file) store vs single-image selection) and are tracked separately rather than forced onto a mismatched model.

Full local suite green (2632), mypy + ruff clean, prettier/eslint clean on the touched frontend.

Refs #45
