### PR TITLE
Avoid repeated DNS checks in Companion webpage renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Fixed
 
+- **Companion webpage sends no longer time out on asset-heavy sites because
+  of repeated DNS safety checks.** The strict public-only Chromium guard now
+  classifies each hostname once per page attempt while continuing to validate
+  every distinct redirect and subresource host and to fail closed on lookup
+  errors.
+
 - **Relay deliveries now show up in the events log.** Each sealed frame or
   config upload to a relay mailbox records a device event row
   (`relay://<id>/frame`, `relay://<id>/config`), and upload failures record

--- a/app/renderer.py
+++ b/app/renderer.py
@@ -335,21 +335,31 @@ def _install_ssrf_guard(page: Any, request: RenderRequest) -> None:
     Chromium follows redirects and loads subresources internally, outside
     net_guard's urllib path, so this per-request interceptor is the only place
     a webpage render can enforce a public-only policy on every hop. Matches
-    net_guard's guarantee level (host resolved and checked per request; no
-    IP pinning against DNS rebinding, same as the fetch path). A resolution
-    failure or any handler error blocks the request rather than fail-open."""
+    net_guard's guarantee level (each distinct host is resolved and checked;
+    no IP pinning against DNS rebinding, same as the fetch path). The result is
+    cached for this page attempt so a site with many same-host assets does not
+    spend its navigation deadline repeating the same DNS lookup. A retry gets
+    a fresh page and cache. Resolution failures and handler errors are cached
+    as blocked rather than failing open."""
     if request.allow_local:
         return
     import urllib.parse as _urlparse
 
     from app.net_guard import host_is_blocked
 
+    host_blocked: dict[str, bool] = {}
+
     def _route(route: Any) -> None:
+        host: str | None = None
         try:
             host = _urlparse.urlparse(route.request.url).hostname or ""
-            blocked = host_is_blocked(host, allow_local=False)
+            if host not in host_blocked:
+                host_blocked[host] = host_is_blocked(host, allow_local=False)
+            blocked = host_blocked[host]
         except Exception:
             blocked = True
+            if host is not None:
+                host_blocked[host] = True
         # Page/context may be torn down mid-flight; nothing to do then.
         with contextlib.suppress(PlaywrightError):
             route.abort() if blocked else route.continue_()

--- a/tests/test_renderer_ssrf_guard.py
+++ b/tests/test_renderer_ssrf_guard.py
@@ -1,0 +1,92 @@
+"""Per-page hostname caching for strict external webpage renders.
+
+Companion webpage sends install this route interceptor for every Chromium
+request. Pages with many same-host assets must not repeat a synchronous DNS
+classification until the navigation deadline expires, while distinct hosts
+and failures must still be blocked independently and fail closed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+from app.renderer import RenderRequest, _install_ssrf_guard
+
+
+def _route(url: str) -> MagicMock:
+    route = MagicMock()
+    route.request.url = url
+    return route
+
+
+def test_strict_guard_classifies_each_hostname_once_per_page() -> None:
+    page = MagicMock()
+    request = RenderRequest(url="https://www.example/", allow_local=False)
+    routes = [
+        _route("https://www.example/"),
+        _route("https://www.example/assets/site.css"),
+        _route("https://private.example/metrics.gif"),
+        _route("https://private.example/another.gif"),
+    ]
+
+    with patch(
+        "app.net_guard.host_is_blocked",
+        side_effect=lambda host, *, allow_local: host == "private.example",
+    ) as classify:
+        _install_ssrf_guard(page, request)
+        handler = page.route.call_args.args[1]
+        for route in routes:
+            handler(route)
+
+    assert classify.call_args_list == [
+        call("www.example", allow_local=False),
+        call("private.example", allow_local=False),
+    ]
+    routes[0].continue_.assert_called_once_with()
+    routes[1].continue_.assert_called_once_with()
+    routes[2].abort.assert_called_once_with()
+    routes[3].abort.assert_called_once_with()
+
+
+def test_strict_guard_caches_resolution_failures_as_blocked() -> None:
+    page = MagicMock()
+    request = RenderRequest(url="https://unresolved.example/", allow_local=False)
+    routes = [
+        _route("https://unresolved.example/"),
+        _route("https://unresolved.example/site.js"),
+    ]
+
+    with patch("app.net_guard.host_is_blocked", side_effect=OSError("DNS failed")) as classify:
+        _install_ssrf_guard(page, request)
+        handler = page.route.call_args.args[1]
+        for route in routes:
+            handler(route)
+
+    classify.assert_called_once_with("unresolved.example", allow_local=False)
+    routes[0].abort.assert_called_once_with()
+    routes[1].abort.assert_called_once_with()
+
+
+def test_new_page_attempt_gets_a_fresh_hostname_classification() -> None:
+    request = RenderRequest(url="https://www.example/", allow_local=False)
+    pages = [MagicMock(), MagicMock()]
+
+    with patch("app.net_guard.host_is_blocked", return_value=False) as classify:
+        for page in pages:
+            _install_ssrf_guard(page, request)
+            handler = page.route.call_args.args[1]
+            handler(_route("https://www.example/asset.js"))
+
+    assert classify.call_args_list == [
+        call("www.example", allow_local=False),
+        call("www.example", allow_local=False),
+    ]
+
+
+def test_operator_render_does_not_install_the_strict_guard() -> None:
+    page = MagicMock()
+    request = RenderRequest(url="http://display.lan/", allow_local=True)
+
+    _install_ssrf_guard(page, request)
+
+    page.route.assert_not_called()


### PR DESCRIPTION
## Summary

- cache the strict Chromium SSRF classification once per hostname for each page attempt
- keep distinct redirect and subresource hosts independently validated and preserve fail-closed lookup handling
- add regression coverage for cache scope, fresh retry-page checks, blocked hosts, lookup failures, and operator renders
- document the user-visible fix in the Unreleased changelog

## Root cause

Companion `POST /api/app/v1/webpages` renders use the strict public-only Chromium request interceptor. That interceptor synchronously resolved and classified the hostname for every request, even when a page loaded many assets from the same host.

On `https://www.apple.com/`, 38 requests to `www.apple.com` spent about 15.1 seconds repeating the same DNS safety check, exhausting the 15-second navigation deadline. The operator Web Send path succeeded because it does not enable the Companion-only strict interceptor.

The cache is scoped to one Chromium page attempt. A retry creates a new page and performs fresh classifications, while every distinct hostname encountered during redirects or subresource loading is still checked separately. Classification errors remain blocked and cached as blocked.

## Impact

Companion webpage sends can render asset-heavy public sites without timing out on repeated same-host safety checks. The public-only policy remains enforced for every distinct destination hostname.

## Validation

- `pytest` renderer, Companion job, and Web Send coverage: 95 passed
- `ruff check app/renderer.py tests/test_renderer_ssrf_guard.py`
- `ruff format --check app/renderer.py tests/test_renderer_ssrf_guard.py`
- `mypy app/renderer.py`
- `git diff --check`
- real strict-mode Chromium render of Apple.com: succeeded on the first attempt in 3.93 seconds locally and 2.62 seconds in the running container
- Companion end-to-end webpage job: rendered, published, recorded in History, and fetched by the target REST display
