### PR TITLE
Generalize Apple Reminders personal-data contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to Tesserae are recorded here. Format loosely follows
   EventKit calendar identifiers. The deprecated `reminders.fridge` source and
   its legacy feature flag remain available only for the already published
   fridge widget; new Companion and widget integrations use `reminders` only.
+  The server rejects duplicate list IDs and aggregate item overflow instead of
+  truncating them, while an empty list set remains a fresh enabled snapshot;
+  deleting the source is reserved for disabling the integration.
 
 - **Physical buttons now work on relay-paired panels** (#180). A button press
   rides the status JSON the panel already posts to its relay mailbox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Added
 
+- **The Companion API contract now supports selected Apple Reminders lists as
+  one domain source.** Servers advertise accepted schemas through
+  `personal_data.sources`; the new strict `reminders` snapshot carries up to
+  20 named list groups and 200 incomplete items in aggregate without exposing
+  EventKit calendar identifiers. The deprecated `reminders.fridge` source and
+  its legacy feature flag remain available during the compatibility period.
+
 - **Physical buttons now work on relay-paired panels** (#180). A button press
   rides the status JSON the panel already posts to its relay mailbox
   (`button` + `button_event_id`, the same fields as the REST status body); the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ All notable changes to Tesserae are recorded here. Format loosely follows
   `personal_data.sources`; the new strict `reminders` snapshot carries up to
   20 named list groups and 200 incomplete items in aggregate without exposing
   EventKit calendar identifiers. The deprecated `reminders.fridge` source and
-  its legacy feature flag remain available during the compatibility period.
+  its legacy feature flag remain available only for the already published
+  fridge widget; new Companion and widget integrations use `reminders` only.
 
 - **Physical buttons now work on relay-paired panels** (#180). A button press
   rides the status JSON the panel already posts to its relay mailbox

--- a/tests/companion/contract/Fixtures/capabilities-personal-data.json
+++ b/tests/companion/contract/Fixtures/capabilities-personal-data.json
@@ -4,6 +4,9 @@
   "api": { "name": "companion", "version": 1 },
   "pairing": { "supported": true, "code_length": 6, "ttl_seconds": 600 },
   "features": ["devices","dashboards","dashboard_push","image_push","jobs","previews","history","image_url_push","webpage_push","image_framing","personal_data_reminders"],
+  "personal_data": {
+    "sources": ["reminders", "reminders.fridge"]
+  },
   "limits": {
     "image_upload_bytes": 26214400, "image_max_edge": 8192,
     "image_content_types": ["image/jpeg","image/png","image/heic","image/heif","image/webp"],

--- a/tests/companion/contract/Fixtures/personal-data-reminders-empty.json
+++ b/tests/companion/contract/Fixtures/personal-data-reminders-empty.json
@@ -1,0 +1,9 @@
+{
+  "version": "personal_data_bridge_v1",
+  "source_id": "reminders",
+  "generated_at": "2026-08-03T09:00:00Z",
+  "expires_at": "2026-08-05T09:00:00Z",
+  "data": {
+    "lists": []
+  }
+}

--- a/tests/companion/contract/Fixtures/personal-data-reminders-put-response.json
+++ b/tests/companion/contract/Fixtures/personal-data-reminders-put-response.json
@@ -1,0 +1,7 @@
+{
+  "source_id": "reminders",
+  "state": "fresh",
+  "generated_at": "2026-08-03T08:00:00Z",
+  "stale_at": "2026-08-04T08:00:00Z",
+  "expires_at": "2026-08-05T08:00:00Z"
+}

--- a/tests/companion/contract/Fixtures/personal-data-reminders.json
+++ b/tests/companion/contract/Fixtures/personal-data-reminders.json
@@ -1,0 +1,36 @@
+{
+  "version": "personal_data_bridge_v1",
+  "source_id": "reminders",
+  "generated_at": "2026-08-03T08:00:00Z",
+  "expires_at": "2026-08-05T08:00:00Z",
+  "data": {
+    "lists": [
+      {
+        "id": "2b684174-fc12-4a28-9e6b-1ef61984e57e",
+        "title": "Grocery List",
+        "items": [
+          {
+            "id": "reminder-yogurt",
+            "title": "Yogurt",
+            "due_date": "2026-08-03",
+            "priority": "high",
+            "completed": false
+          }
+        ]
+      },
+      {
+        "id": "b7b355f7-ce24-431b-b307-998f948613a5",
+        "title": "Weekend",
+        "items": [
+          {
+            "id": "reminder-clean-grill",
+            "title": "Clean grill",
+            "due_date": null,
+            "priority": "none",
+            "completed": false
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/companion/contract/app-v1.openapi.yaml
+++ b/tests/companion/contract/app-v1.openapi.yaml
@@ -1264,8 +1264,9 @@ components:
             $ref: "#/components/schemas/ReminderSnapshotItem"
     RemindersFridgeSnapshot:
       description: >-
-        Deprecated one-list compatibility source. New clients should prefer
-        the grouped reminders source when it is advertised.
+        Deprecated one-list compatibility source retained for the already
+        published reminders_fridge widget. New clients and widgets should use
+        the grouped reminders source rather than implement this fallback.
       deprecated: true
       type: object
       additionalProperties: false

--- a/tests/companion/contract/app-v1.openapi.yaml
+++ b/tests/companion/contract/app-v1.openapi.yaml
@@ -7,7 +7,10 @@ info:
     resend, remote-image push, webpage push, and server-advertised image fit
     modes are optional additive extensions over the five-feature compatibility
     floor. Image framing is an accepted additive extension for server-resolved
-    drag and pinch composition across mixed target geometries.
+    drag and pinch composition across mixed target geometries. New Reminders
+    clients require `reminders` in `personal_data.sources`; they do not infer
+    generic support from the legacy feature flag or fall back to
+    `reminders.fridge`.
 servers:
   - url: /
 tags:
@@ -693,8 +696,9 @@ components:
           minimum: 60
     PersonalDataCapabilities:
       description: >-
-        Strict personal-data source schemas accepted by this server. When
-        absent, legacy clients may use legacy feature flags for compatibility.
+        Strict personal-data source schemas accepted by this server. Absent on
+        servers that predate source advertisement; those servers signal
+        personal-data support through feature flags only.
       type: object
       additionalProperties: false
       required: [sources]
@@ -1233,13 +1237,21 @@ components:
       description: >-
         Incomplete items grouped by user-approved Apple Reminders lists. List
         identifiers are opaque Companion publication identifiers rather than
-        EventKit calendar identifiers. At most 200 items may appear across all
-        lists in one snapshot.
+        EventKit calendar identifiers and must be unique within one snapshot;
+        duplicate ids are rejected as invalid_snapshot (400). At most 200 items
+        may appear across all lists in one snapshot. Exceeding that aggregate
+        cap is rejected as invalid_snapshot (400), never truncated by the
+        server. An empty lists array means no lists are currently published;
+        the source remains fresh and widgets show their selected-list-
+        unavailable state. DELETE is reserved for disabling the source.
       type: object
       additionalProperties: false
       required: [lists]
       properties:
         lists:
+          description: >-
+            Complete atomic set of currently published lists. An empty array is
+            a valid enabled snapshot, not a request to delete the source.
           type: array
           maxItems: 20
           items:

--- a/tests/companion/contract/app-v1.openapi.yaml
+++ b/tests/companion/contract/app-v1.openapi.yaml
@@ -629,6 +629,8 @@ components:
               - webpage_push
               - image_framing
               - personal_data_reminders
+        personal_data:
+          $ref: "#/components/schemas/PersonalDataCapabilities"
         limits:
           $ref: "#/components/schemas/Limits"
         web_url:
@@ -689,6 +691,20 @@ components:
         personal_data_max_ttl_seconds:
           type: integer
           minimum: 60
+    PersonalDataCapabilities:
+      description: >-
+        Strict personal-data source schemas accepted by this server. When
+        absent, clients may use legacy feature flags for compatibility.
+      type: object
+      additionalProperties: false
+      required: [sources]
+      properties:
+        sources:
+          type: array
+          minItems: 1
+          uniqueItems: true
+          items:
+            $ref: "#/components/schemas/PersonalDataSourceID"
     PairingRequest:
       type: object
       additionalProperties: false
@@ -1183,15 +1199,74 @@ components:
     PersonalDataSourceID:
       type: string
       enum:
+        - reminders
         - reminders.fridge
     PersonalDataSnapshot:
       oneOf:
+        - $ref: "#/components/schemas/RemindersSnapshot"
         - $ref: "#/components/schemas/RemindersFridgeSnapshot"
       discriminator:
         propertyName: source_id
         mapping:
+          reminders: "#/components/schemas/RemindersSnapshot"
           reminders.fridge: "#/components/schemas/RemindersFridgeSnapshot"
+    RemindersSnapshot:
+      type: object
+      additionalProperties: false
+      required: [version, source_id, generated_at, expires_at, data]
+      properties:
+        version:
+          type: string
+          enum: [personal_data_bridge_v1]
+        source_id:
+          type: string
+          enum: [reminders]
+        generated_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+        data:
+          $ref: "#/components/schemas/RemindersData"
+    RemindersData:
+      description: >-
+        Incomplete items grouped by user-approved Apple Reminders lists. List
+        identifiers are opaque Companion publication identifiers rather than
+        EventKit calendar identifiers. At most 200 items may appear across all
+        lists in one snapshot.
+      type: object
+      additionalProperties: false
+      required: [lists]
+      properties:
+        lists:
+          type: array
+          maxItems: 20
+          items:
+            $ref: "#/components/schemas/ReminderListSnapshot"
+    ReminderListSnapshot:
+      type: object
+      additionalProperties: false
+      required: [id, title, items]
+      properties:
+        id:
+          type: string
+          minLength: 1
+          maxLength: 256
+        title:
+          type: string
+          minLength: 1
+          maxLength: 256
+        items:
+          type: array
+          maxItems: 200
+          items:
+            $ref: "#/components/schemas/ReminderSnapshotItem"
     RemindersFridgeSnapshot:
+      description: >-
+        Deprecated one-list compatibility source. New clients should prefer
+        the grouped reminders source when it is advertised.
+      deprecated: true
       type: object
       additionalProperties: false
       required: [version, source_id, generated_at, expires_at, data]

--- a/tests/companion/contract/app-v1.openapi.yaml
+++ b/tests/companion/contract/app-v1.openapi.yaml
@@ -694,7 +694,7 @@ components:
     PersonalDataCapabilities:
       description: >-
         Strict personal-data source schemas accepted by this server. When
-        absent, clients may use legacy feature flags for compatibility.
+        absent, legacy clients may use legacy feature flags for compatibility.
       type: object
       additionalProperties: false
       required: [sources]

--- a/tests/companion/test_contract_fixtures.py
+++ b/tests/companion/test_contract_fixtures.py
@@ -25,6 +25,7 @@ CASES = {
     "capabilities-personal-data.json": "Capabilities",
     "personal-data-reminders-fridge.json": "PersonalDataSnapshot",
     "personal-data-reminders.json": "PersonalDataSnapshot",
+    "personal-data-reminders-empty.json": "PersonalDataSnapshot",
     "personal-data-put-response.json": "PersonalDataSourceStatus",
     "personal-data-reminders-put-response.json": "PersonalDataSourceStatus",
     "personal-data-status.json": "PersonalDataStatusResponse",

--- a/tests/companion/test_contract_fixtures.py
+++ b/tests/companion/test_contract_fixtures.py
@@ -24,7 +24,9 @@ CASES = {
     "capabilities-framing.json": "Capabilities",
     "capabilities-personal-data.json": "Capabilities",
     "personal-data-reminders-fridge.json": "PersonalDataSnapshot",
+    "personal-data-reminders.json": "PersonalDataSnapshot",
     "personal-data-put-response.json": "PersonalDataSourceStatus",
+    "personal-data-reminders-put-response.json": "PersonalDataSourceStatus",
     "personal-data-status.json": "PersonalDataStatusResponse",
     "pair-request.json": "PairingRequest",
     "pair-response.json": "PairingResponse",
@@ -188,6 +190,17 @@ def test_extended_capabilities_advertise_history_and_all_image_fit_modes() -> No
         "stretch",
         "center",
     ]
+
+
+def test_personal_data_capabilities_advertise_source_ids_directly() -> None:
+    capabilities = json.loads((FIXTURES_DIR / "capabilities-personal-data.json").read_text())
+
+    assert capabilities["personal_data"]["sources"] == [
+        "reminders",
+        "reminders.fridge",
+    ]
+    assert "personal_data_reminders" in capabilities["features"]
+    assert "personal_data_reminders_multi_list" not in capabilities["features"]
 
 
 def test_image_framing_is_independently_gated_and_fill_only() -> None:


### PR DESCRIPTION
## Summary

- add the strict grouped `reminders` personal-data source for up to 20 selected lists and 200 incomplete items in aggregate
- advertise accepted personal-data source IDs through optional `personal_data.sources` instead of adding a feature flag per schema
- keep the `personal_data_bridge_v1` envelope and the existing latest-only, required-expiry semantics
- retain `reminders.fridge` and `personal_data_reminders` only for the already published Reminders, Fridge widget
- add synthetic request/response fixtures and contract guards

## Why

This follows the accepted direction in [Discussion #176](https://github.com/dmellok/tesserae/discussions/176#discussioncomment-17874174): Apple Reminders is the source domain, while fridge, tasks, and shopping are widget presentation choices. Advertising source IDs directly also gives future personal-data schemas one capability mechanism.

## Compatibility

`personal_data` remains optional in the capability response. The new Companion integration requires `reminders` in `personal_data.sources` and writes only the grouped `reminders` source. The new Apple Reminders widget also reads only that source. Neither implements a `reminders.fridge` fallback or automatic migration.

The server retains `personal_data_reminders` and `reminders.fridge` solely so the already published Reminders, Fridge widget can continue to work. The envelope remains `personal_data_bridge_v1`.

## Scope

This is contract-only. It does not include the server adapter, Companion EventKit/UI changes, or the new community widget. Those remain separate dependent changes after contract review.

## Validation

- `pytest -q tests/companion/test_contract_fixtures.py` — 41 passed
- `ruff check tests/companion/test_contract_fixtures.py` — passed
- `git diff --check` — passed