### PR TITLE
Implement generic Reminders server adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Fixed
 
+- **Expired personal-data snapshots no longer retain raw values.** The store
+  removes list names and Reminder contents at `expires_at` while preserving a
+  metadata-only tombstone for the `expired` status. Reminder due dates are now
+  also validated as real `YYYY-MM-DD` calendar dates for both the generic and
+  deprecated source schemas.
+
 - **Revoking a remote panel now actually cuts it off.** The relay Worker's
   revoke deleted the panel's mailbox but left its token record, so a revoked
   panel kept authenticating and saw an empty-mailbox `204` it couldn't tell

--- a/app/companion_api.py
+++ b/app/companion_api.py
@@ -32,7 +32,7 @@ import secrets
 import time
 import urllib.parse
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from functools import wraps
 from pathlib import Path
 from typing import Any
@@ -101,13 +101,15 @@ JOB_RETENTION_SECONDS = 86_400
 IDEMPOTENCY_RETENTION_SECONDS = 86_400
 
 # Personal-data bridge (#176, contract 0.7): a snapshot is fresh until it is
-# this old, then stale, then expired (deleted). ``max_ttl`` bounds how far a
-# client may set expires_at past generated_at. Server-advertised so the app
-# doesn't hard-code them.
+# this old, then stale, then expired (raw values redacted). ``max_ttl`` bounds
+# how far a client may set expires_at past generated_at. Server-advertised so
+# the app does not hard-code them.
 PERSONAL_DATA_STALE_SECONDS = 86_400  # 24 h
 PERSONAL_DATA_MAX_TTL_SECONDS = 172_800  # 48 h
-PERSONAL_DATA_SOURCES = ("reminders.fridge",)
+PERSONAL_DATA_SOURCES = ("reminders", "reminders.fridge")
 PERSONAL_DATA_SNAPSHOT_VERSION = "personal_data_bridge_v1"
+PERSONAL_DATA_REMINDERS_MAX_LISTS = 20
+PERSONAL_DATA_REMINDERS_MAX_ITEMS = 200
 _REMINDER_PRIORITIES = frozenset(("none", "low", "medium", "high"))
 
 # Features this server serves. The client gates on this list rather than
@@ -323,6 +325,11 @@ def _capabilities() -> dict[str, Any]:
             "ttl_seconds": 600,
         },
         "features": _features(),
+        # Source ids are advertised directly so clients can prefer the most
+        # capable strict schema without growing one feature flag per source.
+        # ``personal_data_reminders`` remains in ``features`` for compatibility
+        # with clients that predate this source list.
+        "personal_data": {"sources": list(PERSONAL_DATA_SOURCES)},
         "limits": {
             "image_upload_bytes": IMAGE_UPLOAD_BYTES,
             "image_max_edge": IMAGE_MAX_EDGE,
@@ -441,6 +448,15 @@ def _iso(epoch: float) -> str:
     return datetime.fromtimestamp(epoch, UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+def _is_iso_date(value: Any) -> bool:
+    if not isinstance(value, str) or len(value) != 10:
+        return False
+    try:
+        return date.fromisoformat(value).isoformat() == value
+    except ValueError:
+        return False
+
+
 def _personal_data_state(generated_epoch: float, expires_epoch: float, now: float) -> str:
     if now >= expires_epoch:
         return "expired"
@@ -500,18 +516,102 @@ def _validate_reminders_fridge(
             return bad("each item must be an object")
         if set(item) - {"id", "title", "due_date", "priority", "completed"}:
             return bad("an item has unexpected fields")
+        if "due_date" not in item:
+            return bad("item due_date is required")
         iid, title = item.get("id"), item.get("title")
         if not isinstance(iid, str) or not (1 <= len(iid) <= 256):
             return bad("item id must be a 1-256 char string")
         if not isinstance(title, str) or not (1 <= len(title) <= 512):
             return bad("item title must be a 1-512 char string")
         due = item.get("due_date")
-        if due is not None and not isinstance(due, str):
-            return bad("item due_date must be a date string or null")
+        if due is not None and not _is_iso_date(due):
+            return bad("item due_date must be an ISO date or null")
         if item.get("priority") not in _REMINDER_PRIORITIES:
             return bad("item priority must be none/low/medium/high")
         if item.get("completed") is not False:
             return bad("item completed must be false")
+    return (body, gen, exp), None
+
+
+def _validate_reminders(
+    source_id: str, body: Any
+) -> tuple[tuple[dict[str, Any], float, float] | None, tuple[Response, int] | None]:
+    """Validate the generic, grouped Apple Reminders snapshot.
+
+    The schema stays deliberately bounded and source-specific: list ids are
+    opaque publication identifiers from Companion, not EventKit identifiers,
+    and all items still use the minimal v1 reminder shape.
+    """
+
+    def bad(msg: str) -> tuple[None, tuple[Response, int]]:
+        return None, _error("invalid_snapshot", msg, 400)
+
+    if not isinstance(body, dict):
+        return bad("body must be a JSON object")
+    if set(body) - {"version", "source_id", "generated_at", "expires_at", "data"}:
+        return bad("snapshot has unexpected fields")
+    if body.get("version") != PERSONAL_DATA_SNAPSHOT_VERSION:
+        return bad("unsupported snapshot version")
+    if body.get("source_id") != source_id:
+        return bad("source_id does not match the path")
+    gen = _parse_iso(body.get("generated_at"))
+    exp = _parse_iso(body.get("expires_at"))
+    if gen is None or exp is None:
+        return bad("generated_at and expires_at must be ISO 8601")
+    if exp <= gen:
+        return bad("expires_at must be after generated_at")
+    if exp - gen > PERSONAL_DATA_MAX_TTL_SECONDS:
+        return bad("expires_at exceeds the maximum retention window")
+
+    data = body.get("data")
+    if not isinstance(data, dict) or set(data) - {"lists"}:
+        return bad("data must be an object with only lists")
+    lists = data.get("lists")
+    if not isinstance(lists, list):
+        return bad("data.lists must be an array")
+    if len(lists) > PERSONAL_DATA_REMINDERS_MAX_LISTS:
+        return bad(f"too many lists (max {PERSONAL_DATA_REMINDERS_MAX_LISTS})")
+
+    seen_list_ids: set[str] = set()
+    total_items = 0
+    for reminder_list in lists:
+        if not isinstance(reminder_list, dict):
+            return bad("each list must be an object")
+        if set(reminder_list) - {"id", "title", "items"}:
+            return bad("a list has unexpected fields")
+        list_id, list_title = reminder_list.get("id"), reminder_list.get("title")
+        if not isinstance(list_id, str) or not (1 <= len(list_id) <= 256):
+            return bad("list id must be a 1-256 char string")
+        if list_id in seen_list_ids:
+            return bad("list ids must be unique")
+        seen_list_ids.add(list_id)
+        if not isinstance(list_title, str) or not (1 <= len(list_title) <= 256):
+            return bad("list title must be a 1-256 char string")
+        items = reminder_list.get("items")
+        if not isinstance(items, list):
+            return bad("list items must be an array")
+        total_items += len(items)
+        if total_items > PERSONAL_DATA_REMINDERS_MAX_ITEMS:
+            return bad(f"too many items across all lists (max {PERSONAL_DATA_REMINDERS_MAX_ITEMS})")
+        for item in items:
+            if not isinstance(item, dict):
+                return bad("each item must be an object")
+            if set(item) - {"id", "title", "due_date", "priority", "completed"}:
+                return bad("an item has unexpected fields")
+            if "due_date" not in item:
+                return bad("item due_date is required")
+            item_id, item_title = item.get("id"), item.get("title")
+            if not isinstance(item_id, str) or not (1 <= len(item_id) <= 256):
+                return bad("item id must be a 1-256 char string")
+            if not isinstance(item_title, str) or not (1 <= len(item_title) <= 512):
+                return bad("item title must be a 1-512 char string")
+            due = item.get("due_date")
+            if due is not None and not _is_iso_date(due):
+                return bad("item due_date must be an ISO date or null")
+            if item.get("priority") not in _REMINDER_PRIORITIES:
+                return bad("item priority must be none/low/medium/high")
+            if item.get("completed") is not False:
+                return bad("item completed must be false")
     return (body, gen, exp), None
 
 
@@ -524,7 +624,11 @@ def put_personal_data(source_id: str) -> Any:
     timestamp is refused so delayed background work can't overwrite newer data."""
     if source_id not in PERSONAL_DATA_SOURCES:
         return _error("unsupported_personal_data_source", f"unknown source {source_id!r}", 400)
-    result, err = _validate_reminders_fridge(source_id, request.get_json(silent=True))
+    body = request.get_json(silent=True)
+    if source_id == "reminders":
+        result, err = _validate_reminders(source_id, body)
+    else:
+        result, err = _validate_reminders_fridge(source_id, body)
     if err is not None:
         return err
     assert result is not None  # narrow for mypy; err is None here

--- a/app/state/personal_data_store.py
+++ b/app/state/personal_data_store.py
@@ -1,18 +1,24 @@
 """Latest-only personal-data snapshots for the Companion bridge (#176).
 
-The iOS Companion publishes a minimal, expiring snapshot of one Apple-Reminders
-list; the server keeps only the *latest* snapshot per source and renders it in a
-widget. No history: exactly one snapshot per ``source_id``, replaced on each
-accepted PUT and deleted on disable or expiry. The server never connects to
-iCloud, it only stores what the phone explicitly publishes, and drops it once
-expired. Contract: ``tests/companion/contract/app-v1.openapi.yaml`` (Companion
-0.7.0).
+The iOS Companion publishes minimal, expiring Apple Reminders snapshots; the
+server keeps only the *latest* snapshot per source and renders it in a widget.
+The generic source may group several explicitly selected lists, while the
+legacy fridge source keeps its original one-list shape. No history: exactly one
+snapshot per ``source_id``, replaced on each accepted PUT and deleted on disable
+or expiry. The server never connects to iCloud, it only stores what the phone
+explicitly publishes, and drops it once expired. Contract:
+``tests/companion/contract/app-v1.openapi.yaml`` (Companion 0.7.0).
 
 Each stored record wraps the raw snapshot with the two epochs the API needs for
 ordering and freshness, so this store never parses ISO timestamps itself::
 
     { "snapshot": {...}, "generated_epoch": float, "expires_epoch": float,
       "stored_at": float }
+
+After expiry the raw ``snapshot`` key is removed while the non-sensitive
+timestamps remain as an ``expired`` tombstone. That lets status surfaces and
+widgets distinguish "expired" from "never synced" without retaining personal
+values past their deadline.
 
 mypy --strict applies to this module.
 """
@@ -49,10 +55,12 @@ class PersonalDataSnapshotStore:
         tmp.replace(self._path)
 
     def get(self, source_id: str) -> dict[str, Any] | None:
+        self.redact_expired(time.time())
         entry = self._load().get(source_id)
         return entry if isinstance(entry, dict) else None
 
     def all(self) -> dict[str, dict[str, Any]]:
+        self.redact_expired(time.time())
         return {k: v for k, v in self._load().items() if isinstance(v, dict)}
 
     def put(
@@ -84,19 +92,32 @@ class PersonalDataSnapshotStore:
             self._save(data)
             return True
 
-    def purge_expired(self, now: float) -> list[str]:
-        """Delete snapshots whose ``expires_epoch`` has passed. Returns the
-        removed source ids. Called opportunistically so expired personal data
-        does not linger on disk past its deadline."""
+    def redact_expired(self, now: float) -> list[str]:
+        """Remove raw values from snapshots past ``expires_epoch``.
+
+        Non-sensitive timing metadata remains as a tombstone so callers can
+        report ``expired`` without retaining Reminder titles or list contents.
+        Returns the source ids redacted during this call.
+        """
         with self._lock:
             data = self._load()
-            removed: list[str] = []
+            redacted: list[str] = []
             for source_id in list(data):
                 entry = data.get(source_id)
                 exp = entry.get("expires_epoch") if isinstance(entry, dict) else None
-                if isinstance(exp, (int, float)) and now >= exp:
-                    del data[source_id]
-                    removed.append(source_id)
-            if removed:
+                if (
+                    isinstance(entry, dict)
+                    and isinstance(exp, (int, float))
+                    and now >= exp
+                    and "snapshot" in entry
+                ):
+                    del entry["snapshot"]
+                    entry["expired"] = True
+                    redacted.append(source_id)
+            if redacted:
                 self._save(data)
-            return removed
+            return redacted
+
+    def purge_expired(self, now: float) -> list[str]:
+        """Compatibility alias for the original opportunistic cleanup API."""
+        return self.redact_expired(now)

--- a/tests/companion/test_companion_api.py
+++ b/tests/companion/test_companion_api.py
@@ -129,6 +129,7 @@ def test_capabilities_probe_is_unauthenticated_and_valid(app: Flask) -> None:
         "image_framing",
         "personal_data_reminders",
     }
+    assert body["personal_data"]["sources"] == ["reminders", "reminders.fridge"]
     assert "webpage_push" not in body["features"]
     assert body["limits"]["image_fit_modes"] == list(companion_api.IMAGE_FIT_MODES)
     # Contract 0.6: the zoom bound is mandatory alongside image_framing.

--- a/tests/companion/test_companion_personal_data.py
+++ b/tests/companion/test_companion_personal_data.py
@@ -78,9 +78,61 @@ def _snapshot(generated: datetime, *, ttl_hours: int = 47, title: str = "Yogurt"
     }
 
 
+def _multi_list_snapshot(
+    generated: datetime,
+    *,
+    ttl_hours: int = 47,
+    lists: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    if lists is None:
+        lists = [
+            {
+                "id": "2b684174-fc12-4a28-9e6b-1ef61984e57e",
+                "title": "Grocery List",
+                "items": [
+                    {
+                        "id": "reminder-yogurt",
+                        "title": "Yogurt",
+                        "due_date": "2026-08-03",
+                        "priority": "high",
+                        "completed": False,
+                    }
+                ],
+            },
+            {
+                "id": "b7b355f7-ce24-431b-b307-998f948613a5",
+                "title": "Weekend",
+                "items": [
+                    {
+                        "id": "reminder-clean-grill",
+                        "title": "Clean grill",
+                        "due_date": None,
+                        "priority": "none",
+                        "completed": False,
+                    }
+                ],
+            },
+        ]
+    return {
+        "version": "personal_data_bridge_v1",
+        "source_id": "reminders",
+        "generated_at": _iso(generated),
+        "expires_at": _iso(generated + timedelta(hours=ttl_hours)),
+        "data": {"lists": lists},
+    }
+
+
 def _put(app: Flask, token: str, snap: dict[str, Any]) -> Any:
     return app.test_client().put(
         "/api/app/v1/personal-data/reminders.fridge",
+        headers=_auth(token),
+        data=json.dumps(snap),
+    )
+
+
+def _put_multi(app: Flask, token: str, snap: dict[str, Any]) -> Any:
+    return app.test_client().put(
+        "/api/app/v1/personal-data/reminders",
         headers=_auth(token),
         data=json.dumps(snap),
     )
@@ -90,6 +142,7 @@ def test_capabilities_advertise_personal_data(app: Flask) -> None:
     body = app.test_client().get("/api/app/v1").get_json()
     jsonschema.validate(body, schema_for("Capabilities"), format_checker=_FMT)
     assert "personal_data_reminders" in body["features"]
+    assert body["personal_data"]["sources"] == ["reminders", "reminders.fridge"]
     assert body["limits"]["personal_data_stale_after_seconds"] == 86400
     assert body["limits"]["personal_data_max_ttl_seconds"] == 172800
 
@@ -110,6 +163,42 @@ def test_put_then_status_round_trip(app: Flask) -> None:
     jsonschema.validate(body, schema_for("PersonalDataStatusResponse"), format_checker=_FMT)
     assert [s["source_id"] for s in body["sources"]] == ["reminders.fridge"]
     assert body["sources"][0]["state"] == "fresh"
+
+
+def test_multi_list_put_then_status_round_trip(app: Flask) -> None:
+    token = _token(app)
+    now = datetime.now(UTC).replace(microsecond=0)
+    resp = _put_multi(app, token, _multi_list_snapshot(now))
+    assert resp.status_code == 200, resp.get_data(as_text=True)
+    status = resp.get_json()
+    jsonschema.validate(status, schema_for("PersonalDataSourceStatus"), format_checker=_FMT)
+    assert status["source_id"] == "reminders"
+    assert status["state"] == "fresh"
+
+    listing = app.test_client().get("/api/app/v1/personal-data/status", headers=_auth(token))
+    assert listing.status_code == 200
+    body = listing.get_json()
+    jsonschema.validate(body, schema_for("PersonalDataStatusResponse"), format_checker=_FMT)
+    assert [source["source_id"] for source in body["sources"]] == ["reminders"]
+
+
+def test_empty_list_set_is_a_fresh_enabled_snapshot(app: Flask) -> None:
+    token = _token(app)
+    now = datetime.now(UTC).replace(microsecond=0)
+    response = _put_multi(app, token, _multi_list_snapshot(now, lists=[]))
+
+    assert response.status_code == 200, response.get_data(as_text=True)
+    assert response.get_json()["state"] == "fresh"
+    record = app.config["PERSONAL_DATA_STORE"].get("reminders")
+    assert record is not None
+    assert record["snapshot"]["data"]["lists"] == []
+
+    status = app.test_client().get(
+        "/api/app/v1/personal-data/status",
+        headers=_auth(token),
+    )
+    assert status.status_code == 200
+    assert status.get_json()["sources"][0]["state"] == "fresh"
 
 
 def test_put_ordering(app: Flask) -> None:
@@ -147,6 +236,18 @@ def test_validation_and_unknown_source(app: Flask) -> None:
     r = _put(app, token, completed_item)
     assert r.status_code == 400 and r.get_json()["error"]["code"] == "invalid_snapshot"
 
+    invalid_due_date = _snapshot(now)
+    invalid_due_date["data"]["items"][0]["due_date"] = "2026-02-30"
+    r = _put(app, token, invalid_due_date)
+    assert r.status_code == 400
+    assert r.get_json()["error"]["message"] == "item due_date must be an ISO date or null"
+
+    missing_due_date = _snapshot(now)
+    del missing_due_date["data"]["items"][0]["due_date"]
+    r = _put(app, token, missing_due_date)
+    assert r.status_code == 400
+    assert r.get_json()["error"]["message"] == "item due_date is required"
+
     # ttl beyond the 48h max.
     r = _put(app, token, _snapshot(now, ttl_hours=72))
     assert r.status_code == 400 and r.get_json()["error"]["code"] == "invalid_snapshot"
@@ -159,6 +260,108 @@ def test_validation_and_unknown_source(app: Flask) -> None:
     )
     assert r.status_code == 400
     assert r.get_json()["error"]["code"] == "unsupported_personal_data_source"
+
+
+def test_multi_list_validation_is_strict_and_bounded(app: Flask) -> None:
+    token = _token(app)
+    now = datetime.now(UTC).replace(microsecond=0)
+
+    duplicate_lists = _multi_list_snapshot(now)
+    duplicate_lists["data"]["lists"][1]["id"] = duplicate_lists["data"]["lists"][0]["id"]
+    response = _put_multi(app, token, duplicate_lists)
+    assert response.status_code == 400
+    assert response.get_json()["error"]["message"] == "list ids must be unique"
+
+    too_many_lists = _multi_list_snapshot(
+        now,
+        lists=[
+            {"id": f"list-{index}", "title": f"List {index}", "items": []} for index in range(21)
+        ],
+    )
+    response = _put_multi(app, token, too_many_lists)
+    assert response.status_code == 400
+    assert response.get_json()["error"]["message"] == "too many lists (max 20)"
+
+    item = {
+        "id": "reminder-id",
+        "title": "Reminder",
+        "due_date": None,
+        "priority": "none",
+        "completed": False,
+    }
+    too_many_items = _multi_list_snapshot(
+        now,
+        lists=[
+            {"id": "list-a", "title": "A", "items": [item | {"id": f"a-{i}"} for i in range(101)]},
+            {"id": "list-b", "title": "B", "items": [item | {"id": f"b-{i}"} for i in range(100)]},
+        ],
+    )
+    response = _put_multi(app, token, too_many_items)
+    assert response.status_code == 400
+    assert response.get_json()["error"]["message"] == "too many items across all lists (max 200)"
+
+    unexpected = _multi_list_snapshot(now)
+    unexpected["data"]["lists"][0]["eventkit_id"] = "must-not-be-uploaded"
+    response = _put_multi(app, token, unexpected)
+    assert response.status_code == 400
+    assert response.get_json()["error"]["message"] == "a list has unexpected fields"
+
+    invalid_due_date = _multi_list_snapshot(now)
+    invalid_due_date["data"]["lists"][0]["items"][0]["due_date"] = "tomorrow"
+    response = _put_multi(app, token, invalid_due_date)
+    assert response.status_code == 400
+    assert response.get_json()["error"]["message"] == "item due_date must be an ISO date or null"
+
+    missing_due_date = _multi_list_snapshot(now)
+    del missing_due_date["data"]["lists"][0]["items"][0]["due_date"]
+    response = _put_multi(app, token, missing_due_date)
+    assert response.status_code == 400
+    assert response.get_json()["error"]["message"] == "item due_date is required"
+
+
+def test_expiry_redacts_values_but_preserves_metadata_state(app: Flask) -> None:
+    token = _token(app)
+    now = datetime.now(UTC).replace(microsecond=0)
+    store = app.config["PERSONAL_DATA_STORE"]
+    store.put(
+        "reminders",
+        snapshot=_multi_list_snapshot(now - timedelta(hours=49)),
+        generated_epoch=(now - timedelta(hours=49)).timestamp(),
+        expires_epoch=(now - timedelta(hours=1)).timestamp(),
+    )
+
+    response = app.test_client().get(
+        "/api/app/v1/personal-data/status",
+        headers=_auth(token),
+    )
+    assert response.status_code == 200
+    assert response.get_json()["sources"][0]["state"] == "expired"
+    record = store.get("reminders")
+    assert record is not None
+    assert record["expired"] is True
+    assert "snapshot" not in record
+
+
+def test_legacy_and_multi_list_sources_coexist_and_delete_independently(app: Flask) -> None:
+    token = _token(app)
+    now = datetime.now(UTC).replace(microsecond=0)
+    assert _put(app, token, _snapshot(now)).status_code == 200
+    assert _put_multi(app, token, _multi_list_snapshot(now)).status_code == 200
+
+    status = (
+        app.test_client().get("/api/app/v1/personal-data/status", headers=_auth(token)).get_json()
+    )
+    assert [source["source_id"] for source in status["sources"]] == [
+        "reminders",
+        "reminders.fridge",
+    ]
+
+    response = app.test_client().delete("/api/app/v1/personal-data/reminders", headers=_auth(token))
+    assert response.status_code == 204
+    status = (
+        app.test_client().get("/api/app/v1/personal-data/status", headers=_auth(token)).get_json()
+    )
+    assert [source["source_id"] for source in status["sources"]] == ["reminders.fridge"]
 
 
 def test_delete_is_idempotent(app: Flask) -> None:


### PR DESCRIPTION
## Summary

- advertise the generic `reminders` source alongside the deprecated `reminders.fridge` source
- accept and strictly validate grouped multi-list Reminder snapshots defined by #182
- reject duplicate list publication IDs, more than 20 lists, and more than 200 aggregate items with `invalid_snapshot`
- keep `lists: []` as a fresh enabled snapshot and reserve DELETE for disabling a source
- redact expired raw personal-data values while retaining a metadata-only tombstone for `expired` status
- validate required nullable Reminder due dates as real `YYYY-MM-DD` dates

## Why

PR #182 pinned the generic Apple Reminders contract so Companion can publish several explicitly selected lists using opaque publication IDs. This PR implements the server adapter offered in the review while preserving the published legacy fridge source for existing clients and widgets. New clients discover support only through `personal_data.sources` and do not fall back to the legacy source.

## Validation

- `python -m pytest -q tests/companion` — 174 passed
- targeted contract and personal-data tests — 67 passed
- `ruff check` on the changed Python modules and tests
- `mypy --python-version 3.12 --strict app/companion_api.py app/state/personal_data_store.py`

## Privacy

The server still retains only the latest snapshot per source. Once `expires_at` is reached, Reminder titles, list names, and the raw snapshot are removed; only non-sensitive timestamps remain so status can report `expired` rather than `never synced`.
