### PR TITLE
Add per-placement widget update-on-change policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- **Widgets can declare opt-in data-change updates.** A widget manifest may
+  expose strict `updates.on_change` source declarations, optionally narrowed
+  by a declared `selector_option`. Grid cells and Canvas widget elements now
+  persist an independent `update_on_change` policy (off by default), and their
+  editors surface the switch only for capable widgets. This stage defines the
+  placement contract only; data-change delivery remains separate.
+
 ### Changed
 
 - **The Decks page got its designed look.** Implemented from a design

--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -1129,6 +1129,7 @@ def _drift_conflict(page: Any) -> Response | None:
 
 def _save_mcp(page: Any) -> None:
     """Stamp the page as MCP-written and persist it."""
+    _pr._coerce_canvas_update_policy(page)
     _pr._stamp(page, "mcp")
     _pr._pages().save(page)
 

--- a/app/page_routes.py
+++ b/app/page_routes.py
@@ -1184,6 +1184,16 @@ def _apply_cell_form(cell: Cell, form: Any, panel: Any) -> Cell:
         options = _cell_options_from_form(plugin, form)
     else:
         options = {}
+    if plugin_changed:
+        # The opt-in belongs to the old widget dependency, not merely the box.
+        # A newly selected widget always starts at the contract default (off).
+        update_on_change = False
+    else:
+        update_on_change = _update_on_change_from_form(
+            form,
+            cell.update_on_change,
+            supported=bool(plugin and plugin.on_change_updates),
+        )
     return cell.model_copy(
         update={
             "plugin": new_plugin_id,
@@ -1195,12 +1205,28 @@ def _apply_cell_form(cell: Cell, form: Any, panel: Any) -> Cell:
             "style": (form.get("style") or None),
             "font": (form.get("font") or None),
             "options": options,
+            "update_on_change": update_on_change,
             "zoom": _coerce_float(form.get("zoom"), cell.zoom, lo=0.5, hi=3.0),
             "padding_override": _padding_override_from_form(form, cell.padding_override),
             "dither": _dither_override_from_form(form, cell.dither),
             **_touch_from_form(form, cell),
         }
     )
+
+
+def _update_on_change_from_form(form: Any, current: bool, *, supported: bool) -> bool:
+    """Parse the host-owned per-placement update policy.
+
+    The hidden ``update_on_change_present`` marker distinguishes a complete
+    widget form with an unchecked checkbox from partial autosave payloads that
+    do not carry this control. Widgets without a manifest declaration can never
+    retain or enable the policy.
+    """
+    if not supported:
+        return False
+    if "update_on_change_present" not in form:
+        return current
+    return form.get("update_on_change") in ("1", "true", "on")
 
 
 def _touch_from_form(form: Any, cell: Cell) -> dict[str, Any]:

--- a/app/panels_routes.py
+++ b/app/panels_routes.py
@@ -108,18 +108,46 @@ def _as_doc(page: Page) -> CanvasPage:
     )
 
 
+def _coerce_canvas_update_policy(page: Page) -> Page:
+    """Drop update opt-ins that the current canvas placement cannot support.
+
+    The editor UI hides the toggle for non-capable widgets, but UI and MCP
+    payloads are both untrusted persistence inputs. Keep the stored policy
+    symmetric with Grid cells: only widget elements whose current manifest
+    declares ``updates.on_change`` may retain a true value.
+    """
+    if page.canvas is None:
+        return page
+    registry = _registry()
+    coerced: list[Element] = []
+    for element in page.canvas.els:
+        plugin = (
+            registry.get(element.widget) if element.kind == "widget" and element.widget else None
+        )
+        supported = bool(plugin and plugin.on_change_updates)
+        coerced.append(
+            element
+            if supported or not element.update_on_change
+            else element.model_copy(update={"update_on_change": False})
+        )
+    page.canvas.els = coerced
+    return page
+
+
 def _doc_to_page(doc: CanvasPage) -> Page:
     """Build a canvas Page from an editor document. Page-level theme/style/font
     mirror the canvas so the dashboards list reflects it."""
-    return Page(
-        id=doc.id,
-        name=doc.name or "Untitled Panel",
-        layout_kind="canvas",
-        device_ids=list(doc.device_ids),
-        theme=doc.theme,
-        style=doc.style,
-        font=doc.font or None,
-        canvas=doc.to_layout(),
+    return _coerce_canvas_update_policy(
+        Page(
+            id=doc.id,
+            name=doc.name or "Untitled Panel",
+            layout_kind="canvas",
+            device_ids=list(doc.device_ids),
+            theme=doc.theme,
+            style=doc.style,
+            font=doc.font or None,
+            canvas=doc.to_layout(),
+        )
     )
 
 

--- a/app/panels_schema.py
+++ b/app/panels_schema.py
@@ -7,7 +7,7 @@ plus an implicit ``full`` fragment for whole-widget placement, so the editor
 palette can list a widget and expand it to its parts.
 
 The catalog entry the editor consumes is
-``{key, name, icon, desc, fragments:[{id,label,icon?,w,h}]}``.
+``{key, name, icon, desc, fragments:[{id,label,icon?,w,h}], updates_on_change}``.
 
 mypy --strict does not apply here; see pyproject.toml.
 """
@@ -74,6 +74,10 @@ def catalog_entry(plugin: Plugin) -> dict[str, Any]:
         "desc": str(plugin.manifest.get("description") or ""),
         "fragments": fragments_of(plugin),
         "sample": _preview_sample(plugin),
+        "updates_on_change": bool(
+            isinstance(plugin.manifest.get("updates"), dict)
+            and plugin.manifest["updates"].get("on_change")
+        ),
     }
 
 

--- a/app/panels_schema.py
+++ b/app/panels_schema.py
@@ -74,6 +74,8 @@ def catalog_entry(plugin: Plugin) -> dict[str, Any]:
         "desc": str(plugin.manifest.get("description") or ""),
         "fragments": fragments_of(plugin),
         "sample": _preview_sample(plugin),
+        # Deliberately read the manifest instead of Plugin.on_change_updates:
+        # catalog builders accept duck-typed plugin objects in tests and tools.
         "updates_on_change": bool(
             isinstance(plugin.manifest.get("updates"), dict)
             and plugin.manifest["updates"].get("on_change")

--- a/app/plugin_loader.py
+++ b/app/plugin_loader.py
@@ -112,6 +112,29 @@ class Plugin:
                 return str(value)
         return "strict"
 
+    @property
+    def on_change_updates(self) -> list[dict[str, str]]:
+        """Validated ``updates.on_change`` declarations for this widget.
+
+        The manifest schema owns the public shape.  Keep this accessor
+        defensive because tests and internal callers can construct ``Plugin``
+        instances without going through discovery.
+        """
+        updates = self.manifest.get("updates")
+        raw = updates.get("on_change") if isinstance(updates, dict) else None
+        if not isinstance(raw, list):
+            return []
+        out: list[dict[str, str]] = []
+        for item in raw:
+            if not isinstance(item, dict) or not isinstance(item.get("source"), str):
+                continue
+            spec = {"source": str(item["source"])}
+            selector = item.get("selector_option")
+            if isinstance(selector, str) and selector:
+                spec["selector_option"] = selector
+            out.append(spec)
+        return out
+
     def cell_option_defaults(self) -> dict[str, Any]:
         defaults: dict[str, Any] = {}
         for opt in self.manifest.get("cell_options", []):
@@ -266,6 +289,35 @@ def _scan_plugin_dir(
             field_path = ".".join(str(p) for p in err.absolute_path) or "<root>"
             registry.errors.append(
                 LoaderError(plugin_id, child, f"manifest schema [{field_path}]: {err.message}")
+            )
+            continue
+
+        updates = manifest.get("updates")
+        raw_on_change = updates.get("on_change") if isinstance(updates, dict) else None
+        on_change = raw_on_change if isinstance(raw_on_change, list) else []
+        option_names = {
+            str(option.get("name"))
+            for option in manifest.get("cell_options", [])
+            if isinstance(option, dict) and option.get("name")
+        }
+        unknown_selector = next(
+            (
+                str(spec["selector_option"])
+                for spec in on_change
+                if isinstance(spec, dict)
+                and spec.get("selector_option")
+                and str(spec["selector_option"]) not in option_names
+            ),
+            None,
+        )
+        if unknown_selector is not None:
+            registry.errors.append(
+                LoaderError(
+                    plugin_id,
+                    child,
+                    "manifest updates.on_change selector_option "
+                    f"{unknown_selector!r} is not declared in cell_options",
+                )
             )
             continue
 

--- a/app/state/page_store.py
+++ b/app/state/page_store.py
@@ -98,6 +98,11 @@ class Cell(BaseModel):
     style: str | None = None
     font: str | None = None
     options: dict[str, Any] = Field(default_factory=dict)
+    # Per-placement opt-in for manifest-declared ``updates.on_change`` events.
+    # False preserves every existing dashboard's pull/schedule-only behaviour;
+    # the event coordinator (a later stage) will also require the current
+    # plugin manifest to declare a matching source before acting on this bit.
+    update_on_change: bool = False
     # Per-cell content zoom. Inverse-sized at render time: the widget
     # paints into a 1/zoom virtual container that's transform-scaled back
     # up to the cell box, so text/icons grow without breaking layout. The

--- a/app/state/panel_store.py
+++ b/app/state/panel_store.py
@@ -126,6 +126,10 @@ class Element(BaseModel):
     # Per-instance widget config, matching the widget's ``cell_options`` shape;
     # resolved via ``_resolved_options`` and handed to ``fetch()``.
     options: dict[str, Any] = Field(default_factory=dict)
+    # Per-placement opt-in for manifest-declared ``updates.on_change`` events.
+    # Kept on the element (not plugin settings) so two dashboards using the
+    # same widget can choose independently. False is the compatibility default.
+    update_on_change: bool = False
     # Decoration props (kind != "widget"; ignored for widgets). ``color`` is a
     # CSS colour or a Spectra token (e.g. "var(--accent-1)") so decorations can
     # follow the theme. ``fill`` false = outlined, ``stroke`` = outline/line

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -120,6 +120,27 @@ lowercase `[a-z0-9_]` is convention, not enforced. Name it `<family>_<role>`
   for `secret` reveals every sensitive value.
 * **`icon`**, Phosphor name used in the editor's widget picker.
 * **`render.needs_network`**, hint for the renderer (not enforced).
+* **`updates.on_change`**, optional data-change sources this widget knows how
+  to consume. Declaring one only exposes a host-owned, per-placement **Refresh
+  when this widget's data changes** switch; it does not enable refreshes by
+  default. `selector_option` may name one of the widget's `cell_options` to
+  narrow the dependency to that placement's selected value (for example one
+  published Reminders `list_id`). The selector must reference a declared
+  option. Grid cells and Canvas widget elements store their opt-ins
+  independently, so using the same widget on another dashboard is unaffected.
+
+  ```json
+  {
+    "cell_options": [
+      { "name": "list_id", "type": "select", "label": "Reminders list" }
+    ],
+    "updates": {
+      "on_change": [
+        { "source": "personal_data.reminders", "selector_option": "list_id" }
+      ]
+    }
+  }
+  ```
 
 Full schema: [`schema/plugin.schema.json`](https://github.com/dmellok/tesserae/blob/main/schema/plugin.schema.json).
 

--- a/schema/plugin.schema.json
+++ b/schema/plugin.schema.json
@@ -147,6 +147,38 @@
         "needs_network": { "type": "boolean" }
       }
     },
+    "updates": {
+      "type": "object",
+      "description": "Declares data-change events this widget can subscribe to. The declaration only makes the per-placement opt-in available; it never refreshes a dashboard by itself.",
+      "required": ["on_change"],
+      "additionalProperties": false,
+      "properties": {
+        "on_change": {
+          "type": "array",
+          "description": "Data sources that may refresh an opted-in placement. selector_option optionally narrows an event to the placement's selected cell option value.",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "required": ["source"],
+            "additionalProperties": false,
+            "properties": {
+              "source": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9_.-]*$",
+                "description": "Stable server data-change source id, for example personal_data.reminders."
+              },
+              "selector_option": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "description": "Optional cell_options name whose saved value narrows the dependency, for example list_id."
+              }
+            }
+          }
+        }
+      }
+    },
     "design": {
       "type": "object",
       "description": "Design-system intent. Default for every field is the strict, palette-safe behaviour; opt-in values signal a widget is using a richer surface and accepts the downstream trade-offs.",
@@ -194,6 +226,11 @@
       "description": "Placeable widgets must declare at least one size; non-placeable kinds (service, data, font, admin) may leave supports.sizes empty.",
       "if": { "properties": { "kind": { "const": "widget" } } },
       "then": { "properties": { "supports": { "properties": { "sizes": { "minItems": 1 } } } } }
+    },
+    {
+      "description": "Only placeable widgets may declare data-change update capabilities.",
+      "if": { "required": ["updates"] },
+      "then": { "properties": { "kind": { "const": "widget" } } }
     }
   ]
 }

--- a/static/panels/editor.js
+++ b/static/panels/editor.js
@@ -202,7 +202,7 @@
   function makeElement(widget, fragment, x, y, w, h) {
     return {
       id: uid(), kind: "widget", widget: widget || "", fragment: fragment || "full",
-      options: {}, x: x, y: y, w: w, h: h, opacity: 100,
+      options: {}, update_on_change: false, x: x, y: y, w: w, h: h, opacity: 100,
       dither: true, visible: true, locked: false, group: null,
     };
   }
@@ -2522,6 +2522,7 @@
       var frs = fragmentsOf(e.widget);
       e.fragment = frs.length ? frs[0].id : "full";
       e.options = {};
+      e.update_on_change = false;
       scheduleSave(); paint();
     });
     wrow.appendChild(wsel); mount.appendChild(wrow);
@@ -2544,6 +2545,28 @@
       cfg.style.width = "100%"; cfg.style.justifyContent = "center";
       cfg.addEventListener("click", function () { openConfig(e.id); });
       cfgrow.appendChild(cfg); mount.appendChild(cfgrow);
+    }
+
+    // Host-owned placement policy. The widget only declares that it can
+    // consume change events; each element opts in independently and defaults
+    // off. Actual event delivery lands in a later server stage.
+    var selectedWidget = widgetFor(e.widget);
+    if (selectedWidget && selectedWidget.updates_on_change) {
+      mount.appendChild(el("div", "psec", '<i class="ph-bold ph-arrows-clockwise"></i>Updates'));
+      var urow = el("div", "prow");
+      urow.innerHTML = '<span class="plab">Data changes</span>';
+      var ubtn = el("button", "minibtn",
+        e.update_on_change
+          ? '<i class="ph-bold ph-check-square"></i> Refresh'
+          : '<i class="ph-bold ph-square"></i> Off');
+      ubtn.addEventListener("click", function () {
+        pushHistory();
+        e.update_on_change = !e.update_on_change;
+        scheduleSave(); paint();
+      });
+      urow.appendChild(ubtn); mount.appendChild(urow);
+      mount.appendChild(el("div", "note",
+        "Refreshes only displays already showing this dashboard. It never selects or advances a page."));
     }
 
     // Fragment parts (scale individual pieces of the render).

--- a/templates/page_editor.html
+++ b/templates/page_editor.html
@@ -168,6 +168,18 @@
        fields are absent, so the layout survives a cell-option save. #}
 
     {% set cell_opts = plugin_cell_options.get(plugin.id, []) %}
+    {% if plugin.on_change_updates %}
+    <fieldset class="form-group">
+      <legend>Updates</legend>
+      <input type="hidden" name="update_on_change_present" value="1">
+      <label class="switch dx-cell-tweak-switch">
+        <input type="checkbox" name="update_on_change" value="1"
+               {% if cell.update_on_change %}checked{% endif %}>
+        <span>Refresh when this widget's data changes</span>
+      </label>
+      <p class="field-help">Off by default. When enabled, a matching data-change event may refresh this dashboard only on displays already showing it; it never selects or advances a dashboard.</p>
+    </fieldset>
+    {% endif %}
     {% if cell_opts %}
     <fieldset class="form-group">
       <legend>{{ plugin.name }} options</legend>

--- a/tests/test_mcp_api.py
+++ b/tests/test_mcp_api.py
@@ -448,6 +448,45 @@ def test_create_get_set_roundtrip(app: Flask) -> None:
     assert entry["created_by"] == "mcp" and entry["elements"] == 1
 
 
+def test_mcp_canvas_enforces_update_on_change_capability(
+    app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _enable(app)
+    weather = app.config["PLUGIN_REGISTRY"].get("weather_now")
+    assert weather is not None
+    monkeypatch.setitem(
+        weather.manifest,
+        "updates",
+        {"on_change": [{"source": "test.weather"}]},
+    )
+    client = app.test_client()
+    pid = _create_page(client)
+    resp = client.put(
+        f"/api/mcp/pages/{pid}/canvas",
+        json={
+            "els": [
+                {"id": "capable", "widget": "weather_now", "update_on_change": True},
+                {"id": "unsupported", "widget": "clock_analog", "update_on_change": True},
+            ]
+        },
+    )
+    assert resp.status_code == 200
+    doc = client.get(f"/api/mcp/pages/{pid}/canvas").get_json()
+    by_id = {element["id"]: element for element in doc["els"]}
+    assert by_id["capable"]["update_on_change"] is True
+    assert by_id["unsupported"]["update_on_change"] is False
+
+    # A partial MCP widget swap cannot carry the old widget's opt-in forward.
+    resp = client.patch(
+        f"/api/mcp/pages/{pid}/elements/capable",
+        json={"widget": "clock_analog"},
+    )
+    assert resp.status_code == 200
+    doc = client.get(f"/api/mcp/pages/{pid}/canvas").get_json()
+    swapped = next(element for element in doc["els"] if element["id"] == "capable")
+    assert swapped["update_on_change"] is False
+
+
 def test_code_element_sources_a_service(app: Flask) -> None:
     # End-to-end: a code element names a service (rest_service) as a source, and
     # the composer resolves it through the same path a widget uses, injecting the

--- a/tests/test_page_routes.py
+++ b/tests/test_page_routes.py
@@ -13,7 +13,12 @@ from app.main import create_app
 from app.state.page_store import PageStore
 
 
-def _write_test_plugin(plugin_dir: Path, *, cell_options: list[dict[str, Any]]) -> None:
+def _write_test_plugin(
+    plugin_dir: Path,
+    *,
+    cell_options: list[dict[str, Any]],
+    updates: dict[str, Any] | None = None,
+) -> None:
     """Drop a minimal widget plugin at ``plugin_dir`` for editor tests
     that only need a valid plugin id + cell_option defaults."""
     plugin_dir.mkdir(parents=True)
@@ -25,6 +30,8 @@ def _write_test_plugin(plugin_dir: Path, *, cell_options: list[dict[str, Any]]) 
         "supports": {"sizes": ["sm", "md", "lg"]},
         "cell_options": cell_options,
     }
+    if updates is not None:
+        manifest["updates"] = updates
     (plugin_dir / "plugin.json").write_text(json.dumps(manifest))
     (plugin_dir / "client.js").write_text("export default function () {}\n")
 
@@ -43,6 +50,7 @@ def app(tmp_path: Path) -> Flask:
             {"name": "show_date", "type": "boolean", "label": "Show date", "default": True},
             {"name": "show_seconds", "type": "boolean", "label": "Show seconds", "default": False},
         ],
+        updates={"on_change": [{"source": "test.clock", "selector_option": "format"}]},
     )
     _write_test_plugin(plugins_dir / "widget_b", cell_options=[])
 
@@ -757,6 +765,66 @@ def test_change_plugin_resets_options(app: Flask, tmp_path: Path) -> None:
     assert cell.plugin == "widget_b"
     assert "show_seconds" not in cell.options
     assert "format" not in cell.options
+
+
+def test_update_on_change_is_opt_in_and_resets_on_widget_change(app: Flask, tmp_path: Path) -> None:
+    client = app.test_client()
+    _sign_in(client)
+    pid = _new(client, name="Home", layout="1_cell")
+    cell_id = _store(tmp_path).get(pid).cells[0].id
+
+    # Assigning a capable widget retains the compatibility default: off.
+    client.post(f"/pages/{pid}/cells/{cell_id}", data={"plugin": "widget_a"})
+    assert _store(tmp_path).get(pid).cells[0].update_on_change is False
+
+    # The complete editor form can enable and explicitly disable the policy.
+    client.post(
+        f"/pages/{pid}/cells/{cell_id}",
+        data={
+            "plugin": "widget_a",
+            "update_on_change_present": "1",
+            "update_on_change": "1",
+        },
+    )
+    assert _store(tmp_path).get(pid).cells[0].update_on_change is True
+    client.post(
+        f"/pages/{pid}/cells/{cell_id}",
+        data={"plugin": "widget_a", "update_on_change_present": "1"},
+    )
+    assert _store(tmp_path).get(pid).cells[0].update_on_change is False
+
+    # Partial autosaves do not carry the checkbox marker and must preserve it.
+    client.post(
+        f"/pages/{pid}/cells/{cell_id}",
+        data={
+            "plugin": "widget_a",
+            "update_on_change_present": "1",
+            "update_on_change": "1",
+        },
+    )
+    client.post(f"/pages/{pid}/cells/{cell_id}", data={"plugin": "widget_a", "zoom": "1.2"})
+    assert _store(tmp_path).get(pid).cells[0].update_on_change is True
+
+    # A different widget owns a different dependency and always starts off.
+    client.post(f"/pages/{pid}/cells/{cell_id}", data={"plugin": "widget_b"})
+    assert _store(tmp_path).get(pid).cells[0].update_on_change is False
+
+
+def test_grid_editor_only_shows_update_switch_for_capable_widget(
+    app: Flask, tmp_path: Path
+) -> None:
+    client = app.test_client()
+    _sign_in(client)
+    pid = _new(client, name="Home", layout="1_cell")
+    cell_id = _store(tmp_path).get(pid).cells[0].id
+
+    client.post(f"/pages/{pid}/cells/{cell_id}", data={"plugin": "widget_a"})
+    html = client.get(f"/pages/{pid}").get_data(as_text=True)
+    assert 'name="update_on_change"' in html
+
+    client.post(f"/pages/{pid}/cells/{cell_id}", data={"plugin": "widget_b"})
+    html = client.get(f"/pages/{pid}").get_data(as_text=True)
+    assert 'name="update_on_change"' not in html
 
 
 def test_update_cell_zoom_round_trips(app: Flask, tmp_path: Path) -> None:

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -626,6 +626,56 @@ def test_save_and_doc_roundtrip(app: Flask, monkeypatch: pytest.MonkeyPatch) -> 
     assert doc["name"] == "My Panel" and doc["els"][0]["widget"] == "weather_now"
 
 
+def test_save_coerces_update_on_change_to_manifest_capability(
+    app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The save endpoint, not only the editor UI, owns placement policy.
+
+    A capable widget keeps its opt-in. An unsupported widget and a decoration
+    cannot persist meaningless true bits, including after a widget swap that
+    sends the previous placement value back to the server.
+    """
+    monkeypatch.setenv("TESSERAE_EXPERIMENT_COMPOSER", "1")
+    weather = app.config["PLUGIN_REGISTRY"].get("weather_now")
+    assert weather is not None
+    monkeypatch.setitem(
+        weather.manifest,
+        "updates",
+        {"on_change": [{"source": "test.weather"}]},
+    )
+    client = app.test_client()
+    _sign_in(client)
+    cid = client.get("/pages/canvas/").location.rsplit("/", 1)[1]
+    resp = client.post(
+        f"/pages/canvas/c/{cid}/save",
+        json={
+            "els": [
+                {
+                    "id": "capable",
+                    "widget": "weather_now",
+                    "update_on_change": True,
+                },
+                {
+                    "id": "unsupported",
+                    "widget": "clock_analog",
+                    "update_on_change": True,
+                },
+                {
+                    "id": "decoration",
+                    "kind": "line",
+                    "update_on_change": True,
+                },
+            ]
+        },
+    )
+    assert resp.status_code == 200
+    doc = client.get(f"/pages/canvas/c/{cid}/doc.json").get_json()
+    by_id = {element["id"]: element for element in doc["els"]}
+    assert by_id["capable"]["update_on_change"] is True
+    assert by_id["unsupported"]["update_on_change"] is False
+    assert by_id["decoration"]["update_on_change"] is False
+
+
 def test_canvas_management(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TESSERAE_EXPERIMENT_COMPOSER", "1")
     client = app.test_client()

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -237,10 +237,22 @@ def test_fragments_of_declared_and_implicit_full() -> None:
 
 
 def test_catalog_entry_shape() -> None:
-    p = _FakePlugin("w", {"name": "W", "icon": "ph-x", "description": "d"})
+    p = _FakePlugin(
+        "w",
+        {
+            "name": "W",
+            "icon": "ph-x",
+            "description": "d",
+            "updates": {"on_change": [{"source": "personal_data.reminders"}]},
+        },
+    )
     entry = catalog_entry(p)  # type: ignore[arg-type]
     assert entry["key"] == "w" and entry["icon"] == "ph-x"
     assert [f["id"] for f in entry["fragments"]] == ["full"]
+    assert entry["updates_on_change"] is True
+
+    plain = catalog_entry(_FakePlugin("plain", {"name": "Plain"}))  # type: ignore[arg-type]
+    assert plain["updates_on_change"] is False
 
 
 def test_build_catalog_sorts_by_name() -> None:
@@ -268,6 +280,7 @@ def test_element_defaults_and_roundtrip(tmp_path: Path) -> None:
                 widget="weather_now",
                 fragment="temp",
                 options={"units": "metric"},
+                update_on_change=True,
                 x=8,
                 y=8,
                 w=160,
@@ -281,10 +294,12 @@ def test_element_defaults_and_roundtrip(tmp_path: Path) -> None:
     e = reloaded.els[0]
     assert e.widget == "weather_now" and e.fragment == "temp"
     assert e.options["units"] == "metric"
+    assert e.update_on_change is True
     assert e.dither is True and e.visible is True  # defaults
 
     blank = Element(id="e2")
     assert blank.widget == "" and blank.fragment == "full"  # unassigned box
+    assert blank.update_on_change is False
 
 
 def test_decoration_element_roundtrip(tmp_path: Path) -> None:

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -88,6 +88,76 @@ def test_invalid_manifest_is_rejected(tmp_path: Path, schema_path: Path) -> None
     assert any("manifest schema" in err.message for err in registry.errors)
 
 
+def test_on_change_manifest_is_discovered(tmp_path: Path, schema_path: Path) -> None:
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    _write_minimal_plugin(
+        plugins_dir,
+        "reminders",
+        {
+            "cell_options": [{"name": "list_id", "type": "string", "label": "Reminders list"}],
+            "updates": {
+                "on_change": [
+                    {
+                        "source": "personal_data.reminders",
+                        "selector_option": "list_id",
+                    }
+                ]
+            },
+        },
+    )
+    registry = plugin_loader.discover(
+        plugins_dir, schema_path=schema_path, data_root=tmp_path / "data"
+    )
+    assert registry.errors == []
+    assert registry.plugins["reminders"].on_change_updates == [
+        {"source": "personal_data.reminders", "selector_option": "list_id"}
+    ]
+
+
+def test_on_change_selector_must_name_cell_option(tmp_path: Path, schema_path: Path) -> None:
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    _write_minimal_plugin(
+        plugins_dir,
+        "broken_selector",
+        {
+            "updates": {
+                "on_change": [
+                    {
+                        "source": "personal_data.reminders",
+                        "selector_option": "missing",
+                    }
+                ]
+            }
+        },
+    )
+    registry = plugin_loader.discover(
+        plugins_dir, schema_path=schema_path, data_root=tmp_path / "data"
+    )
+    assert "broken_selector" not in registry.plugins
+    assert any("selector_option 'missing'" in err.message for err in registry.errors)
+
+
+def test_only_widgets_may_declare_on_change(tmp_path: Path, schema_path: Path) -> None:
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    _write_minimal_plugin(
+        plugins_dir,
+        "data_source",
+        {
+            "kind": "data",
+            "supports": {"sizes": []},
+            "updates": {"on_change": [{"source": "personal_data.reminders"}]},
+        },
+    )
+    registry = plugin_loader.discover(
+        plugins_dir, schema_path=schema_path, data_root=tmp_path / "data"
+    )
+    assert "data_source" not in registry.plugins
+    assert any("manifest schema" in err.message for err in registry.errors)
+
+
 def test_cell_option_defaults_merged() -> None:
     manifest = {
         "tesserae_compat": "1.x",


### PR DESCRIPTION
## Summary

Adds the Stage 1 contract and placement policy discussed in [Discussion #176](https://github.com/dmellok/tesserae/discussions/176):

- let widget manifests declare supported `updates.on_change` sources, optionally narrowed by a declared `selector_option`
- persist an independent `update_on_change` opt-in on each Grid cell and Canvas widget element
- expose the switch only for capable widgets, default it off, and reset it when the placed widget changes
- document the manifest contract and add loader, Grid, and Canvas regression coverage

## Why

The server needs an explicit widget capability and a host-owned per-placement policy before change events can safely feed the existing page-refresh machinery. Keeping the policy on the placement means the same widget can opt in on one dashboard without affecting another dashboard or another placement.

This is intentionally Stage 1 only. It does not add event delivery, semantic snapshot diffing, debounce/coalescing, expiry timers, or any new scheduling path. Sync request latency and rendering behaviour are unchanged.

## Validation

- `121 passed` across `tests/test_plugin_loader.py`, `tests/test_page_routes.py`, and `tests/test_panels.py`
- Ruff passed for the touched Python source and tests
- mypy passed for the touched source modules
- JSON schema parsing and `node --check static/panels/editor.js` passed
