### PR TITLE
feat(widgets): refresh opted-in pages on data changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,12 @@ All notable changes to Tesserae are recorded here. Format loosely follows
   expose strict `updates.on_change` source declarations, optionally narrowed
   by a declared `selector_option`. Grid cells and Canvas widget elements now
   persist an independent `update_on_change` policy (off by default), and their
-  editors surface the switch only for capable widgets. This stage defines the
-  placement contract only; data-change delivery remains separate.
+  editors surface the switch only for capable widgets. Accepted semantic data
+  changes are quietly debounced for 10 seconds, then active matching pages
+  refresh through the existing quiet-hours-aware push path while inactive Deck
+  pages are re-warmed without being promoted. TTL-only republishes do not
+  refresh, and personal-data PUT/DELETE responses remain independent from
+  background render or delivery outcomes.
 
 ## [0.259.0], 2026-08-04
 

--- a/app/app_factory.py
+++ b/app/app_factory.py
@@ -927,6 +927,14 @@ def create_app(
         condition_evaluator=condition_evaluator,
     )
     app.config["SCHEDULER"] = scheduler
+    from app.data_change_refresh import DataChangeRefreshCoordinator
+
+    data_change_coordinator = DataChangeRefreshCoordinator(
+        page_store=page_store,
+        plugin_registry=lambda: app.config["PLUGIN_REGISTRY"],
+        refresh_pages=scheduler.refresh_pages_for_data_change,
+    )
+    app.config["DATA_CHANGE_COORDINATOR"] = data_change_coordinator
     if not testing and not is_watcher:
         scheduler.start()
         from app import heartbeat
@@ -1033,6 +1041,7 @@ def create_app(
     import atexit
 
     atexit.register(companion_jobs.shutdown)
+    atexit.register(data_change_coordinator.stop)
     companion_api.register(app)
 
     if not testing:

--- a/app/companion_api.py
+++ b/app/companion_api.py
@@ -51,6 +51,11 @@ from app.companion_history import (
     retained_resend_composition_for_row,
 )
 from app.companion_jobs import CompanionJobs, JobOutcome
+from app.data_change_refresh import (
+    DataChangeEvent,
+    personal_data_delete_event,
+    personal_data_update_event,
+)
 from app.device_loader import Device, DeviceRegistry
 from app.device_preview import retained_device_preview
 from app.net_guard import BlockedURLError, assert_public_url
@@ -206,6 +211,21 @@ def _events() -> EventLog:
 
 def _personal_data() -> PersonalDataSnapshotStore:
     return current_app.config["PERSONAL_DATA_STORE"]  # type: ignore[no-any-return]
+
+
+def _notify_data_change(event: DataChangeEvent | None) -> None:
+    """Enqueue a post-ingestion refresh without changing API semantics."""
+    if event is None:
+        return
+    coordinator = current_app.config.get("DATA_CHANGE_COORDINATOR")
+    if coordinator is None:
+        return
+    try:
+        coordinator.notify(event)
+    except Exception:
+        # Storage already succeeded. Refresh coordination is fire-and-forget
+        # and must never turn an accepted snapshot into a failed upload.
+        logger.exception("could not enqueue personal-data change event")
 
 
 # -- error envelope ------------------------------------------------------
@@ -431,8 +451,9 @@ def revoke_session() -> Any:
 # The phone stays the authority for Apple personal data. It publishes only an
 # explicitly enabled, minimal, expiring snapshot; the server keeps the latest
 # per source (no history), renders it in a widget, and deletes it on disable or
-# expiry. This is synchronous state, not a job: no render / publish / History
-# write happens here.
+# expiry. This is synchronous state, not a job: ingestion itself performs no
+# render / publish / History write. An accepted semantic change may enqueue a
+# detached refresh that runs only after the response path is complete.
 
 
 def _parse_iso(value: Any) -> float | None:
@@ -647,7 +668,12 @@ def put_personal_data(source_id: str) -> Any:
                 )
             # Identical retry: idempotent, don't rewrite.
             return jsonify(_source_status(source_id, gen, exp, now)), 200
+    previous_snapshot = existing.get("snapshot") if isinstance(existing, dict) else None
+    if not isinstance(previous_snapshot, dict):
+        previous_snapshot = None
+    event = personal_data_update_event(source_id, previous_snapshot, snapshot)
     store.put(source_id, snapshot=snapshot, generated_epoch=gen, expires_epoch=exp)
+    _notify_data_change(event)
     return jsonify(_source_status(source_id, gen, exp, now)), 200
 
 
@@ -670,7 +696,8 @@ def personal_data_status() -> Any:
 @_require_companion("personal_data:write")
 def delete_personal_data(source_id: str) -> Any:
     """Idempotently drop a source's snapshot (on disable)."""
-    _personal_data().delete(source_id)
+    if _personal_data().delete(source_id):
+        _notify_data_change(personal_data_delete_event(source_id))
     return Response(status=204)
 
 

--- a/app/data_change_refresh.py
+++ b/app/data_change_refresh.py
@@ -1,0 +1,246 @@
+"""Debounced widget dependency refreshes for server-side data changes.
+
+Data ingestion remains synchronous and authoritative: callers store an accepted
+snapshot first, then enqueue a small event containing only a source id and
+opaque selector ids. A daemon timer waits for a quiet window, resolves the
+currently opted-in widget placements, deduplicates their containing pages, and
+hands those page ids to the existing scheduler refresh machinery.
+
+No reminder titles, list names, or item bodies enter this event path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from app.plugin_loader import PluginRegistry
+from app.state.page_store import Page, PageStore
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DATA_CHANGE_DEBOUNCE_SECONDS = 10.0
+
+
+@dataclass(frozen=True)
+class DataChangeEvent:
+    """A non-sensitive dependency event.
+
+    ``selectors=None`` is a source-wide change. A concrete set narrows the
+    event to matching placement option values, such as Reminders ``list_id``.
+    """
+
+    source: str
+    selectors: frozenset[str] | None = None
+
+
+def _snapshot_data(snapshot: dict[str, Any] | None) -> Any:
+    if not isinstance(snapshot, dict):
+        return None
+    return snapshot.get("data")
+
+
+def _canonical_items(value: Any) -> tuple[str, ...]:
+    """Order-insensitive reminder item representation for semantic diffs."""
+    if not isinstance(value, list):
+        return ()
+    encoded = [json.dumps(item, sort_keys=True, separators=(",", ":")) for item in value]
+    return tuple(sorted(encoded))
+
+
+def _reminder_lists(snapshot: dict[str, Any] | None) -> dict[str, tuple[str, tuple[str, ...]]]:
+    data = _snapshot_data(snapshot)
+    raw_lists = data.get("lists") if isinstance(data, dict) else None
+    if not isinstance(raw_lists, list):
+        return {}
+    out: dict[str, tuple[str, tuple[str, ...]]] = {}
+    for reminder_list in raw_lists:
+        if not isinstance(reminder_list, dict):
+            continue
+        list_id = reminder_list.get("id")
+        title = reminder_list.get("title")
+        if isinstance(list_id, str) and isinstance(title, str):
+            out[list_id] = (title, _canonical_items(reminder_list.get("items")))
+    return out
+
+
+def personal_data_update_event(
+    source_id: str,
+    previous: dict[str, Any] | None,
+    current: dict[str, Any],
+) -> DataChangeEvent | None:
+    """Return the semantic event for an accepted personal-data replacement.
+
+    Envelope timestamps and expiry are deliberately ignored. Reminders events
+    identify only lists whose title or item set changed; list and item ordering
+    alone is not meaningful. The first usable snapshot is source-wide because
+    freshness/missing-source state can affect every configured placement.
+    """
+    source = f"personal_data.{source_id}"
+    previous_data = _snapshot_data(previous)
+    current_data = _snapshot_data(current)
+    if previous_data is None:
+        return DataChangeEvent(source=source)
+    if source_id != "reminders":
+        return None if previous_data == current_data else DataChangeEvent(source=source)
+
+    before = _reminder_lists(previous)
+    after = _reminder_lists(current)
+    changed = {
+        list_id
+        for list_id in before.keys() | after.keys()
+        if before.get(list_id) != after.get(list_id)
+    }
+    if not changed:
+        return None
+    return DataChangeEvent(source=source, selectors=frozenset(changed))
+
+
+def personal_data_delete_event(source_id: str) -> DataChangeEvent:
+    """DELETE invalidates every placement for the removed source."""
+    return DataChangeEvent(source=f"personal_data.{source_id}")
+
+
+def _selector_values(raw: Any) -> set[str]:
+    if isinstance(raw, (list, tuple, set, frozenset)):
+        return {str(value) for value in raw if value is not None and str(value)}
+    if raw is None:
+        return set()
+    value = str(raw)
+    return {value} if value else set()
+
+
+def _placement_matches(
+    *,
+    plugin_id: str | None,
+    options: dict[str, Any],
+    enabled: bool,
+    registry: PluginRegistry,
+    events: dict[str, frozenset[str] | None],
+) -> bool:
+    if not enabled or not plugin_id:
+        return False
+    plugin = registry.get(plugin_id)
+    if plugin is None:
+        return False
+    for spec in plugin.on_change_updates:
+        source = spec["source"]
+        if source not in events:
+            continue
+        changed_selectors = events[source]
+        selector_option = spec.get("selector_option")
+        if selector_option is None or changed_selectors is None:
+            return True
+        if _selector_values(options.get(selector_option)) & set(changed_selectors):
+            return True
+    return False
+
+
+def matching_page_ids(
+    pages: Iterable[Page],
+    registry: PluginRegistry,
+    events: dict[str, frozenset[str] | None],
+) -> set[str]:
+    """Resolve opted-in Grid and Canvas placements to containing page ids."""
+    matched: set[str] = set()
+    for page in pages:
+        for cell in page.cells:
+            if _placement_matches(
+                plugin_id=cell.plugin,
+                options=cell.options,
+                enabled=cell.update_on_change,
+                registry=registry,
+                events=events,
+            ):
+                matched.add(page.id)
+                break
+        if page.id in matched or page.canvas is None:
+            continue
+        for element in page.canvas.els:
+            if element.kind != "widget":
+                continue
+            if _placement_matches(
+                plugin_id=element.widget,
+                options=element.options,
+                enabled=element.update_on_change,
+                registry=registry,
+                events=events,
+            ):
+                matched.add(page.id)
+                break
+    return matched
+
+
+class DataChangeRefreshCoordinator:
+    """Quiet-window debounce from data events to existing page refreshes."""
+
+    def __init__(
+        self,
+        *,
+        page_store: PageStore,
+        plugin_registry: Callable[[], PluginRegistry],
+        refresh_pages: Callable[[set[str]], None],
+        debounce_seconds: float = DEFAULT_DATA_CHANGE_DEBOUNCE_SECONDS,
+    ) -> None:
+        self._page_store = page_store
+        self._plugin_registry = plugin_registry
+        self._refresh_pages = refresh_pages
+        self._debounce_seconds = max(0.0, debounce_seconds)
+        self._lock = threading.Lock()
+        self._pending: dict[str, frozenset[str] | None] = {}
+        self._generation = 0
+        self._timer: threading.Timer | None = None
+        self._stopped = False
+
+    def notify(self, event: DataChangeEvent) -> None:
+        """Merge one event and restart the 10-second quiet window."""
+        with self._lock:
+            if self._stopped:
+                return
+            if event.source not in self._pending:
+                self._pending[event.source] = event.selectors
+            else:
+                current = self._pending[event.source]
+                self._pending[event.source] = (
+                    None
+                    if current is None or event.selectors is None
+                    else current | event.selectors
+                )
+            self._generation += 1
+            generation = self._generation
+            if self._timer is not None:
+                self._timer.cancel()
+            timer = threading.Timer(self._debounce_seconds, self._fire, args=(generation,))
+            timer.daemon = True
+            self._timer = timer
+            timer.start()
+
+    def _fire(self, generation: int) -> None:
+        with self._lock:
+            if self._stopped or generation != self._generation:
+                return
+            events = dict(self._pending)
+            self._pending.clear()
+            self._timer = None
+        try:
+            pages = self._page_store.list()
+            page_ids = matching_page_ids(pages, self._plugin_registry(), events)
+            if page_ids:
+                self._refresh_pages(page_ids)
+        except Exception:
+            # Refresh is explicitly detached from ingestion. Never surface
+            # renderer/delivery failures back through a successful snapshot PUT.
+            logger.exception("data-change refresh failed after ingestion")
+
+    def stop(self) -> None:
+        """Cancel a pending debounce during process shutdown."""
+        with self._lock:
+            self._stopped = True
+            self._pending.clear()
+            if self._timer is not None:
+                self._timer.cancel()
+                self._timer = None

--- a/app/data_change_refresh.py
+++ b/app/data_change_refresh.py
@@ -77,14 +77,23 @@ def personal_data_update_event(
 
     Envelope timestamps and expiry are deliberately ignored. Reminders events
     identify only lists whose title or item set changed; list and item ordering
-    alone is not meaningful. The first usable snapshot is source-wide because
-    freshness/missing-source state can affect every configured placement.
+    alone is not meaningful. The deprecated fridge source likewise treats item
+    ordering as presentation-only. The first usable snapshot is source-wide
+    because freshness/missing-source state can affect every configured placement.
     """
     source = f"personal_data.{source_id}"
     previous_data = _snapshot_data(previous)
     current_data = _snapshot_data(current)
     if previous_data is None:
         return DataChangeEvent(source=source)
+    if source_id == "reminders.fridge":
+        previous_items = previous_data.get("items") if isinstance(previous_data, dict) else None
+        current_items = current_data.get("items") if isinstance(current_data, dict) else None
+        return (
+            None
+            if _canonical_items(previous_items) == _canonical_items(current_items)
+            else DataChangeEvent(source=source)
+        )
     if source_id != "reminders":
         return None if previous_data == current_data else DataChangeEvent(source=source)
 
@@ -214,6 +223,8 @@ class DataChangeRefreshCoordinator:
             generation = self._generation
             if self._timer is not None:
                 self._timer.cancel()
+            # Deliberately a pure quiet-window debounce in v1: there is no
+            # maximum-latency cap, so a sustained stream waits until it pauses.
             timer = threading.Timer(self._debounce_seconds, self._fire, args=(generation,))
             timer.daemon = True
             self._timer = timer

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -842,6 +842,85 @@ class Scheduler:
                 result.status,
             )
 
+    def refresh_pages_for_data_change(
+        self, page_ids: set[str], now: datetime | None = None
+    ) -> None:
+        """Refresh changed pages without choosing or advancing active content.
+
+        Active pages reuse the normal page-refresh delivery path: resolve the
+        devices already showing each page, respect quiet hours, and let
+        PushManager's latest-wins/no-change handling apply. Affected inactive
+        Deck pages are only re-warmed for their bound devices, never promoted.
+        """
+        if self._page_store is None or not page_ids:
+            return
+        now = now or datetime.now(UTC)
+        try:
+            known_page_ids = {page.id for page in self._page_store.list()}
+        except Exception:
+            return
+        affected = page_ids & known_page_ids
+        if not affected:
+            return
+
+        showing = self._devices_showing_pages(now)
+        pusher = self._push_factory()
+        for page_id in sorted(affected):
+            devices = showing.get(page_id) or set()
+            if not devices:
+                continue
+            try:
+                result = pusher.push(
+                    page_id,
+                    device_ids=devices,
+                    respect_quiet_hours=True,
+                    source="data_change",
+                )
+            except Exception:
+                logger.exception("data-change page refresh failed page=%s", page_id)
+                continue
+            with self._lock:
+                self._page_last_refresh[page_id] = now.timestamp()
+            logger.info(
+                "data-change refresh: page=%s devices=%s (%s)",
+                page_id,
+                ",".join(sorted(devices)),
+                result.status,
+            )
+
+        if self._deck_store is None:
+            return
+        warm = getattr(pusher, "warm_deck_page", None)
+        if not callable(warm):
+            return
+        warm_targets: dict[tuple[str, str], set[str]] = {}
+        for deck in self._deck_store.all():
+            if not deck.enabled or not deck.device_ids:
+                continue
+            for deck_page in deck.pages:
+                page_id = deck_page.page_id
+                if page_id not in affected:
+                    continue
+                active_devices = showing.get(page_id) or set()
+                for device_id in deck.device_ids:
+                    if device_id not in active_devices:
+                        warm_targets.setdefault((page_id, device_id), set()).add(deck.id)
+        with self._deck_warm_lock:
+            for (page_id, device_id), deck_ids in sorted(warm_targets.items()):
+                try:
+                    warm(page_id, device_id)
+                except Exception:
+                    logger.exception(
+                        "data-change deck warm failed decks=%s page=%s device=%s",
+                        ",".join(sorted(deck_ids)),
+                        page_id,
+                        device_id,
+                    )
+                    continue
+                for deck_id in deck_ids:
+                    key = f"{deck_id}\x00{device_id}\x00{page_id}"
+                    self._deck_last_warm[key] = now.timestamp()
+
     def _maybe_return_decks_home(self, now: datetime) -> None:
         """Return idle deck panels to the home card (deck editor's
         "returns to home after N min" behaviour).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ ignore_missing_imports = true
 # Strict on the load-bearing contract modules. Everything else uses defaults.
 [[tool.mypy.overrides]]
 module = [
+    "app.data_change_refresh",
     "app.state.*",
     "app.push",
     "app.plugin_loader",

--- a/tests/companion/contract/app-v1.openapi.yaml
+++ b/tests/companion/contract/app-v1.openapi.yaml
@@ -448,6 +448,12 @@ paths:
       tags: [Personal Data]
       operationId: putCompanionPersonalDataSnapshot
       summary: Replace the latest snapshot for one advertised personal-data source
+      description: |
+        Snapshot validation, ordering, storage, latency, and response semantics
+        are independent from rendering. After a 200 response, the server may
+        asynchronously refresh already-active dashboards whose widget placements
+        explicitly opted in to this source. Render or delivery failures never
+        change the accepted PUT response and require no client retry.
       requestBody:
         required: true
         content:
@@ -471,6 +477,9 @@ paths:
       tags: [Personal Data]
       operationId: deleteCompanionPersonalDataSnapshot
       summary: Delete the latest snapshot when its source is disabled
+      description: |
+        Deletion is authoritative and idempotent. Any eligible dashboard refresh
+        is fire-and-forget after the 204 response; no expiry timer is implied.
       responses:
         "204":
           description: Snapshot absent after the request

--- a/tests/companion/test_companion_personal_data.py
+++ b/tests/companion/test_companion_personal_data.py
@@ -13,6 +13,7 @@ import jsonschema
 import pytest
 from flask import Flask
 
+from app.data_change_refresh import DataChangeEvent
 from app.main import REPO_ROOT, create_app
 
 from ._schema import schema_for
@@ -138,6 +139,19 @@ def _put_multi(app: Flask, token: str, snap: dict[str, Any]) -> Any:
     )
 
 
+class _ChangeCapture:
+    def __init__(self) -> None:
+        self.events: list[DataChangeEvent] = []
+
+    def notify(self, event: DataChangeEvent) -> None:
+        self.events.append(event)
+
+
+class _BrokenChangeCapture:
+    def notify(self, event: DataChangeEvent) -> None:
+        raise RuntimeError("coordinator unavailable")
+
+
 def test_capabilities_advertise_personal_data(app: Flask) -> None:
     body = app.test_client().get("/api/app/v1").get_json()
     jsonschema.validate(body, schema_for("Capabilities"), format_checker=_FMT)
@@ -180,6 +194,59 @@ def test_multi_list_put_then_status_round_trip(app: Flask) -> None:
     body = listing.get_json()
     jsonschema.validate(body, schema_for("PersonalDataStatusResponse"), format_checker=_FMT)
     assert [source["source_id"] for source in body["sources"]] == ["reminders"]
+
+
+def test_personal_data_changes_emit_semantic_events_after_storage(app: Flask) -> None:
+    token = _token(app)
+    capture = _ChangeCapture()
+    app.config["DATA_CHANGE_COORDINATOR"] = capture
+    now = datetime.now(UTC).replace(microsecond=0)
+    initial = _multi_list_snapshot(now)
+
+    assert _put_multi(app, token, initial).status_code == 200
+    assert capture.events == [DataChangeEvent("personal_data.reminders")]
+    assert app.config["PERSONAL_DATA_STORE"].get("reminders")["snapshot"] == initial
+
+    # Republishing identical list contents only renews freshness/TTL.
+    capture.events.clear()
+    renewed = _multi_list_snapshot(now + timedelta(seconds=1))
+    assert _put_multi(app, token, renewed).status_code == 200
+    assert capture.events == []
+
+    # A content edit narrows the event to the affected opaque list id.
+    changed_lists = json.loads(json.dumps(renewed["data"]["lists"]))
+    changed_lists[0]["items"][0]["title"] = "Oat milk"
+    changed = _multi_list_snapshot(now + timedelta(seconds=2), lists=changed_lists)
+    assert _put_multi(app, token, changed).status_code == 200
+    assert capture.events == [
+        DataChangeEvent(
+            "personal_data.reminders",
+            selectors=frozenset({changed_lists[0]["id"]}),
+        )
+    ]
+
+    capture.events.clear()
+    response = app.test_client().delete("/api/app/v1/personal-data/reminders", headers=_auth(token))
+    assert response.status_code == 204
+    assert capture.events == [DataChangeEvent("personal_data.reminders")]
+
+    # Idempotent DELETE has no second event.
+    capture.events.clear()
+    response = app.test_client().delete("/api/app/v1/personal-data/reminders", headers=_auth(token))
+    assert response.status_code == 204
+    assert capture.events == []
+
+
+def test_data_change_enqueue_failure_does_not_change_accepted_put(app: Flask) -> None:
+    token = _token(app)
+    app.config["DATA_CHANGE_COORDINATOR"] = _BrokenChangeCapture()
+    now = datetime.now(UTC).replace(microsecond=0)
+    snapshot = _multi_list_snapshot(now)
+
+    response = _put_multi(app, token, snapshot)
+
+    assert response.status_code == 200
+    assert app.config["PERSONAL_DATA_STORE"].get("reminders")["snapshot"] == snapshot
 
 
 def test_empty_list_set_is_a_fresh_enabled_snapshot(app: Flask) -> None:

--- a/tests/test_data_change_refresh.py
+++ b/tests/test_data_change_refresh.py
@@ -92,6 +92,28 @@ def test_reminders_semantic_diff_returns_only_changed_list_ids() -> None:
     )
 
 
+def test_legacy_fridge_semantic_diff_ignores_item_order() -> None:
+    before = {
+        "data": {
+            "items": [
+                _list("food", "Groceries")["items"][0],
+                _list("work", "Work")["items"][0],
+            ]
+        }
+    }
+    after = {"data": {"items": list(reversed(before["data"]["items"]))}}
+
+    assert personal_data_update_event("reminders.fridge", before, after) is None
+
+    after["data"]["items"][0] = {
+        **after["data"]["items"][0],
+        "title": "Updated task",
+    }
+    assert personal_data_update_event("reminders.fridge", before, after) == DataChangeEvent(
+        source="personal_data.reminders.fridge"
+    )
+
+
 def test_first_snapshot_is_source_wide_even_when_it_contains_no_lists() -> None:
     current = _snapshot(
         generated="2026-08-05T00:00:00Z",
@@ -264,12 +286,14 @@ def test_coordinator_debounces_and_unions_selector_bursts(tmp_path: Path) -> Non
         page_store=store,
         plugin_registry=lambda: registry,
         refresh_pages=refresh,
-        debounce_seconds=0.05,
+        debounce_seconds=0.15,
     )
     coordinator.notify(DataChangeEvent("personal_data.reminders", selectors=frozenset({"food"})))
-    time.sleep(0.02)
+    time.sleep(0.10)
     coordinator.notify(DataChangeEvent("personal_data.reminders", selectors=frozenset({"work"})))
 
+    # A pure quiet-window debounce restarts on every event; it has no max cap.
+    assert not fired.wait(0.08)
     assert fired.wait(1.0)
     time.sleep(0.08)
     coordinator.stop()

--- a/tests/test_data_change_refresh.py
+++ b/tests/test_data_change_refresh.py
@@ -1,0 +1,276 @@
+"""Semantic data events, placement matching, and quiet-window debounce."""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+from app.data_change_refresh import (
+    DataChangeEvent,
+    DataChangeRefreshCoordinator,
+    matching_page_ids,
+    personal_data_update_event,
+)
+from app.plugin_loader import Plugin, PluginRegistry
+from app.state.page_store import Cell, Page, PageStore
+from app.state.panel_store import CanvasLayout, Element
+
+
+def _snapshot(*, generated: str, expires: str, lists: list[dict]) -> dict:
+    return {
+        "version": "personal_data_bridge_v1",
+        "source_id": "reminders",
+        "generated_at": generated,
+        "expires_at": expires,
+        "data": {"lists": lists},
+    }
+
+
+def _list(list_id: str, title: str, item_title: str = "Milk") -> dict:
+    return {
+        "id": list_id,
+        "title": title,
+        "items": [
+            {
+                "id": f"item-{list_id}",
+                "title": item_title,
+                "due_date": None,
+                "priority": "none",
+                "completed": False,
+            }
+        ],
+    }
+
+
+def _plugin(tmp_path: Path, plugin_id: str, *, selector: bool = True) -> Plugin:
+    spec = {"source": "personal_data.reminders"}
+    if selector:
+        spec["selector_option"] = "list_id"
+    return Plugin(
+        id=plugin_id,
+        path=tmp_path / plugin_id,
+        manifest={
+            "name": plugin_id,
+            "kind": "widget",
+            "supports": {"sizes": ["md"]},
+            "updates": {"on_change": [spec]},
+        },
+        data_dir=tmp_path / "data" / plugin_id,
+    )
+
+
+def test_reminders_semantic_diff_ignores_ttl_and_order_only_changes() -> None:
+    before = _snapshot(
+        generated="2026-08-05T00:00:00Z",
+        expires="2026-08-06T23:00:00Z",
+        lists=[_list("food", "Groceries"), _list("work", "Work")],
+    )
+    after = _snapshot(
+        generated="2026-08-05T01:00:00Z",
+        expires="2026-08-07T00:00:00Z",
+        lists=[_list("work", "Work"), _list("food", "Groceries")],
+    )
+    assert personal_data_update_event("reminders", before, after) is None
+
+
+def test_reminders_semantic_diff_returns_only_changed_list_ids() -> None:
+    before = _snapshot(
+        generated="2026-08-05T00:00:00Z",
+        expires="2026-08-06T23:00:00Z",
+        lists=[_list("food", "Groceries"), _list("work", "Work")],
+    )
+    after = _snapshot(
+        generated="2026-08-05T01:00:00Z",
+        expires="2026-08-07T00:00:00Z",
+        lists=[_list("food", "Groceries", "Oat milk"), _list("home", "Home")],
+    )
+    event = personal_data_update_event("reminders", before, after)
+    assert event == DataChangeEvent(
+        source="personal_data.reminders",
+        selectors=frozenset({"food", "work", "home"}),
+    )
+
+
+def test_first_snapshot_is_source_wide_even_when_it_contains_no_lists() -> None:
+    current = _snapshot(
+        generated="2026-08-05T00:00:00Z",
+        expires="2026-08-06T23:00:00Z",
+        lists=[],
+    )
+    assert personal_data_update_event("reminders", None, current) == DataChangeEvent(
+        source="personal_data.reminders"
+    )
+
+
+def test_matching_pages_respects_placement_opt_in_and_selector(tmp_path: Path) -> None:
+    registry = PluginRegistry(
+        plugins={
+            "reminders": _plugin(tmp_path, "reminders"),
+            "source_wide": _plugin(tmp_path, "source_wide", selector=False),
+        }
+    )
+    pages = [
+        Page(
+            id="grid_food",
+            name="Food",
+            cells=[
+                Cell(
+                    id="food",
+                    plugin="reminders",
+                    options={"list_id": "food"},
+                    update_on_change=True,
+                    x=0,
+                    y=0,
+                    w=100,
+                    h=100,
+                ),
+                Cell(
+                    id="food-duplicate",
+                    plugin="reminders",
+                    options={"list_id": "food"},
+                    update_on_change=True,
+                    x=100,
+                    y=0,
+                    w=100,
+                    h=100,
+                ),
+            ],
+        ),
+        Page(
+            id="grid_disabled",
+            name="Disabled",
+            cells=[
+                Cell(
+                    id="off",
+                    plugin="reminders",
+                    options={"list_id": "food"},
+                    update_on_change=False,
+                    x=0,
+                    y=0,
+                    w=100,
+                    h=100,
+                )
+            ],
+        ),
+        Page(
+            id="grid_work",
+            name="Work",
+            cells=[
+                Cell(
+                    id="work",
+                    plugin="reminders",
+                    options={"list_id": "work"},
+                    update_on_change=True,
+                    x=0,
+                    y=0,
+                    w=100,
+                    h=100,
+                )
+            ],
+        ),
+        Page(
+            id="canvas_food",
+            name="Canvas",
+            layout_kind="canvas",
+            canvas=CanvasLayout(
+                els=[
+                    Element(
+                        id="food",
+                        widget="reminders",
+                        options={"list_id": "food"},
+                        update_on_change=True,
+                    )
+                ]
+            ),
+        ),
+        Page(
+            id="source_wide",
+            name="Source wide",
+            cells=[
+                Cell(
+                    id="all",
+                    plugin="source_wide",
+                    update_on_change=True,
+                    x=0,
+                    y=0,
+                    w=100,
+                    h=100,
+                )
+            ],
+        ),
+    ]
+    events = {"personal_data.reminders": frozenset({"food"})}
+    assert matching_page_ids(pages, registry, events) == {
+        "grid_food",
+        "canvas_food",
+        "source_wide",
+    }
+
+
+def test_source_wide_event_matches_every_enabled_selector(tmp_path: Path) -> None:
+    registry = PluginRegistry(plugins={"reminders": _plugin(tmp_path, "reminders")})
+    pages = [
+        Page(
+            id="work",
+            name="Work",
+            cells=[
+                Cell(
+                    id="work",
+                    plugin="reminders",
+                    options={"list_id": "work"},
+                    update_on_change=True,
+                    x=0,
+                    y=0,
+                    w=100,
+                    h=100,
+                )
+            ],
+        )
+    ]
+    assert matching_page_ids(pages, registry, {"personal_data.reminders": None}) == {"work"}
+
+
+def test_coordinator_debounces_and_unions_selector_bursts(tmp_path: Path) -> None:
+    registry = PluginRegistry(plugins={"reminders": _plugin(tmp_path, "reminders")})
+    store = PageStore(tmp_path / "pages.json")
+    for list_id in ("food", "work"):
+        store.save(
+            Page(
+                id=list_id,
+                name=list_id,
+                cells=[
+                    Cell(
+                        id=list_id,
+                        plugin="reminders",
+                        options={"list_id": list_id},
+                        update_on_change=True,
+                        x=0,
+                        y=0,
+                        w=100,
+                        h=100,
+                    )
+                ],
+            )
+        )
+    fired = threading.Event()
+    refreshes: list[set[str]] = []
+
+    def refresh(page_ids: set[str]) -> None:
+        refreshes.append(page_ids)
+        fired.set()
+
+    coordinator = DataChangeRefreshCoordinator(
+        page_store=store,
+        plugin_registry=lambda: registry,
+        refresh_pages=refresh,
+        debounce_seconds=0.05,
+    )
+    coordinator.notify(DataChangeEvent("personal_data.reminders", selectors=frozenset({"food"})))
+    time.sleep(0.02)
+    coordinator.notify(DataChangeEvent("personal_data.reminders", selectors=frozenset({"work"})))
+
+    assert fired.wait(1.0)
+    time.sleep(0.08)
+    coordinator.stop()
+    assert refreshes == [{"food", "work"}]

--- a/tests/test_page_refresh.py
+++ b/tests/test_page_refresh.py
@@ -23,6 +23,7 @@ T0 = datetime(2026, 6, 15, 12, 0, tzinfo=UTC)
 @dataclass
 class FakePush:
     pushes: list[tuple[str, frozenset, bool, str]] = field(default_factory=list)
+    warms: list[tuple[str, str]] = field(default_factory=list)
     # device_id -> latest render record (as the real PushManager stores it).
     latest: dict[str, dict] = field(default_factory=dict)
 
@@ -39,6 +40,10 @@ class FakePush:
 
     def latest_render_for(self, device_id: str):
         return self.latest.get(device_id)
+
+    def warm_deck_page(self, page_id: str, device_id: str) -> bool:
+        self.warms.append((page_id, device_id))
+        return True
 
 
 def _pages(tmp_path: Path, *pages: Page) -> PageStore:
@@ -161,3 +166,60 @@ def test_multi_bound_device_refreshes_the_shown_page(tmp_path: Path) -> None:
     sched._maybe_refresh_pages(T0)
     pushed = {p[0] for p in pusher.pushes}
     assert pushed == {"b"}
+
+
+def test_data_change_refreshes_active_page_and_only_warms_inactive_deck_page(
+    tmp_path: Path,
+) -> None:
+    ps = _pages(
+        tmp_path,
+        Page(id="active", name="Active", device_ids=["panel"]),
+        Page(id="inactive", name="Inactive", device_ids=["panel"]),
+        Page(id="unrelated", name="Unrelated", device_ids=["panel"]),
+    )
+    decks = DeckStore(tmp_path / "decks.json")
+    decks.upsert(
+        Deck(
+            id="kitchen",
+            name="Kitchen",
+            device_ids=["panel"],
+            pages=[DeckPage(page_id="active"), DeckPage(page_id="inactive")],
+        )
+    )
+    nav = DeckNavStore(tmp_path / "nav.json")
+    nav.set("panel", "kitchen", "active")
+    pusher = FakePush()
+    sched = _sched(tmp_path, ps, pusher, deck_store=decks, deck_nav_store=nav)
+
+    sched.refresh_pages_for_data_change({"active", "inactive"}, now=T0)
+
+    assert pusher.pushes == [("active", frozenset({"panel"}), True, "data_change")]
+    assert pusher.warms == [("inactive", "panel")]
+
+
+def test_data_change_warms_shared_deck_page_once_per_device(tmp_path: Path) -> None:
+    ps = _pages(
+        tmp_path,
+        Page(id="shared", name="Shared", device_ids=["panel"]),
+        Page(id="current", name="Current", device_ids=["panel"]),
+    )
+    decks = DeckStore(tmp_path / "decks.json")
+    for deck_id in ("morning", "evening"):
+        decks.upsert(
+            Deck(
+                id=deck_id,
+                name=deck_id.title(),
+                device_ids=["panel"],
+                pages=[DeckPage(page_id="shared")],
+            )
+        )
+    pusher = FakePush()
+    sched = _sched(tmp_path, ps, pusher, deck_store=decks)
+
+    sched.refresh_pages_for_data_change({"shared"}, now=T0)
+
+    assert pusher.pushes == []
+    assert pusher.warms == [("shared", "panel")]
+    assert sched._deck_last_warm == {
+        f"{deck_id}\x00panel\x00shared": T0.timestamp() for deck_id in ("morning", "evening")
+    }


### PR DESCRIPTION
## Summary

- emit non-sensitive semantic events after accepted personal-data PUT and DELETE requests
- debounce change bursts for a 10-second quiet window, then resolve only opted-in widget placements against their current manifest declarations
- refresh active matching pages through the existing quiet-hours-aware push path and warm inactive Deck pages without promoting them
- narrow Apple Reminders changes to affected opaque `list_id` values while ignoring generated/expiry timestamps and ordering-only republishes

This implements Stage 2 of the change-driven widget refresh design discussed in #176, on top of the per-placement policy and manifest contract merged in #185.

## Contract and behavior

- personal-data storage and response semantics remain synchronous and independent from rendering or delivery outcomes
- refresh coordination is fire-and-forget after storage; enqueue, render, and push failures do not turn an accepted upload into a client retry
- DELETE invalidates all opted-in placements for its source; TTL expiry does not schedule a refresh in v1
- matching Grid and Canvas placements are deduplicated to one refresh per page
- a page shared by multiple Decks is warmed only once per device while all Deck warm timestamps are retained
- active refresh History entries use the `data_change` source

## Validation

- `python -m pytest -q tests/test_data_change_refresh.py tests/test_page_refresh.py tests/test_deck_refresh.py tests/test_deck_prerender.py tests/companion/test_companion_personal_data.py tests/companion/test_contract_fixtures.py tests/test_plugin_loader.py tests/test_page_routes.py tests/test_panels.py` — 203 passed
- `ruff check .`
- `ruff format --check .` — 463 files already formatted
- strict type check of `app/data_change_refresh.py`
