### PR TITLE
fix: isolate personal data publishers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are
 [SemVer](https://semver.org/) (pre-1.0, so minors can carry breaking changes).
 
+## [Unreleased]
+
+### Fixed
+
+- **Personal-data snapshots are isolated per paired Companion installation.**
+  Two household phones can publish Apple Reminders without overwriting each
+  other, each phone sees only its own sync status, and disabling sync cannot
+  delete another phone's publication. Existing single-publisher data remains
+  readable and is replaced by the first authenticated publisher that next
+  syncs that source.
+
 ## [0.266.0], 2026-08-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 ### Fixed
 
 - **Personal-data snapshots are isolated per paired Companion installation.**
-  Two household phones can publish Apple Reminders without overwriting each
-  other, each phone sees only its own sync status, and disabling sync cannot
-  delete another phone's publication. Existing single-publisher data remains
-  readable and is replaced by the first authenticated publisher that next
-  syncs that source.
+  Independently identified household phones can publish Apple Reminders
+  without replacing each other, each phone sees only its own sync status, and
+  disabling sync deletes only the publication associated with its pairing.
+  Existing single-publisher data remains readable and is replaced by the first
+  authenticated publisher that next syncs that source.
 
 ## [0.266.0], 2026-08-05
 

--- a/app/companion_api.py
+++ b/app/companion_api.py
@@ -25,6 +25,7 @@ mypy --strict applies to this module, see pyproject.toml.
 
 from __future__ import annotations
 
+import hashlib
 import json as _json
 import logging
 import re
@@ -211,6 +212,20 @@ def _events() -> EventLog:
 
 def _personal_data() -> PersonalDataSnapshotStore:
     return current_app.config["PERSONAL_DATA_STORE"]  # type: ignore[no-any-return]
+
+
+def _personal_data_publisher() -> tuple[str, str]:
+    """Stable, non-PII publisher identity derived from the paired app install."""
+    record = g.companion
+    client = record.client if isinstance(record.client, dict) else {}
+    installation_id = client.get("installation_id")
+    stable_input = (
+        installation_id
+        if isinstance(installation_id, str) and installation_id
+        else str(record.token_id)
+    )
+    digest = hashlib.sha256(f"companion-publisher:{stable_input}".encode()).hexdigest()[:24]
+    return f"companion_{digest}", record.name
 
 
 def _notify_data_change(event: DataChangeEvent | None) -> None:
@@ -656,7 +671,8 @@ def put_personal_data(source_id: str) -> Any:
     snapshot, gen, exp = result
     now = time.time()
     store = _personal_data()
-    existing = store.get(source_id)
+    publisher_id, publisher_name = _personal_data_publisher()
+    existing = store.get(source_id, publisher_id=publisher_id)
     if isinstance(existing, dict) and isinstance(existing.get("generated_epoch"), (int, float)):
         existing_gen = float(existing["generated_epoch"])
         if gen < existing_gen:
@@ -672,7 +688,14 @@ def put_personal_data(source_id: str) -> Any:
     if not isinstance(previous_snapshot, dict):
         previous_snapshot = None
     event = personal_data_update_event(source_id, previous_snapshot, snapshot)
-    store.put(source_id, snapshot=snapshot, generated_epoch=gen, expires_epoch=exp)
+    store.put(
+        source_id,
+        snapshot=snapshot,
+        generated_epoch=gen,
+        expires_epoch=exp,
+        publisher_id=publisher_id,
+        publisher_name=publisher_name,
+    )
     _notify_data_change(event)
     return jsonify(_source_status(source_id, gen, exp, now)), 200
 
@@ -683,9 +706,10 @@ def personal_data_status() -> Any:
     """Freshness metadata only, never the stored values."""
     now = time.time()
     store = _personal_data()
+    publisher_id, _publisher_name = _personal_data_publisher()
     store.purge_expired(now)
     sources = []
-    for source_id, rec in sorted(store.all().items()):
+    for source_id, rec in sorted(store.all(publisher_id=publisher_id).items()):
         gen, exp = rec.get("generated_epoch"), rec.get("expires_epoch")
         if isinstance(gen, (int, float)) and isinstance(exp, (int, float)):
             sources.append(_source_status(source_id, float(gen), float(exp), now))
@@ -696,8 +720,14 @@ def personal_data_status() -> Any:
 @_require_companion("personal_data:write")
 def delete_personal_data(source_id: str) -> Any:
     """Idempotently drop a source's snapshot (on disable)."""
-    if _personal_data().delete(source_id):
-        _notify_data_change(personal_data_delete_event(source_id))
+    store = _personal_data()
+    publisher_id, _publisher_name = _personal_data_publisher()
+    existing = store.get(source_id, publisher_id=publisher_id)
+    previous_snapshot = existing.get("snapshot") if isinstance(existing, dict) else None
+    if not isinstance(previous_snapshot, dict):
+        previous_snapshot = None
+    if store.delete(source_id, publisher_id=publisher_id):
+        _notify_data_change(personal_data_delete_event(source_id, previous_snapshot))
     return Response(status=204)
 
 

--- a/app/data_change_refresh.py
+++ b/app/data_change_refresh.py
@@ -85,6 +85,10 @@ def personal_data_update_event(
     previous_data = _snapshot_data(previous)
     current_data = _snapshot_data(current)
     if previous_data is None:
+        if source_id == "reminders":
+            current_lists = _reminder_lists(current)
+            if current_lists:
+                return DataChangeEvent(source=source, selectors=frozenset(current_lists))
         return DataChangeEvent(source=source)
     if source_id == "reminders.fridge":
         previous_items = previous_data.get("items") if isinstance(previous_data, dict) else None
@@ -109,9 +113,16 @@ def personal_data_update_event(
     return DataChangeEvent(source=source, selectors=frozenset(changed))
 
 
-def personal_data_delete_event(source_id: str) -> DataChangeEvent:
-    """DELETE invalidates every placement for the removed source."""
-    return DataChangeEvent(source=f"personal_data.{source_id}")
+def personal_data_delete_event(
+    source_id: str, previous: dict[str, Any] | None = None
+) -> DataChangeEvent:
+    """DELETE invalidates only known selectors, else the complete source."""
+    source = f"personal_data.{source_id}"
+    if source_id == "reminders":
+        previous_lists = _reminder_lists(previous)
+        if previous_lists:
+            return DataChangeEvent(source=source, selectors=frozenset(previous_lists))
+    return DataChangeEvent(source=source)
 
 
 def _selector_values(raw: Any) -> set[str]:

--- a/app/state/personal_data_store.py
+++ b/app/state/personal_data_store.py
@@ -1,19 +1,24 @@
 """Latest-only personal-data snapshots for the Companion bridge (#176).
 
 The iOS Companion publishes minimal, expiring Apple Reminders snapshots; the
-server keeps only the *latest* snapshot per source and renders it in a widget.
-The generic source may group several explicitly selected lists, while the
-legacy fridge source keeps its original one-list shape. No history: exactly one
-snapshot per ``source_id``, replaced on each accepted PUT and deleted on disable
-or expiry. The server never connects to iCloud, it only stores what the phone
-explicitly publishes, and drops it once expired. Contract:
+server keeps only the *latest* snapshot per paired publisher and source, then
+renders it in a widget. The generic source may group several explicitly
+selected lists, while the legacy fridge source keeps its original one-list
+shape. No history: exactly one snapshot per ``(publisher_id, source_id)``,
+replaced on each accepted PUT and deleted on disable or expiry. The server
+never connects to iCloud, it only stores what each phone explicitly publishes,
+and drops it once expired. Contract:
 ``tests/companion/contract/app-v1.openapi.yaml`` (Companion 0.7.0).
 
 Each stored record wraps the raw snapshot with the two epochs the API needs for
 ordering and freshness, so this store never parses ISO timestamps itself::
 
-    { "snapshot": {...}, "generated_epoch": float, "expires_epoch": float,
-      "stored_at": float }
+    { "_format": 2, "publishers": {
+        "companion_<digest>": { "name": "Kitchen iPhone", "sources": {
+          "reminders": { "snapshot": {...}, "generated_epoch": float,
+            "expires_epoch": float, "stored_at": float }
+        }}
+    }}
 
 After expiry the raw ``snapshot`` key is removed while the non-sensitive
 timestamps remain as an ``expired`` tombstone. That lets status surfaces and
@@ -31,9 +36,18 @@ import time
 from pathlib import Path
 from typing import Any
 
+_FORMAT_VERSION = 2
+_LEGACY_PUBLISHER_ID = "legacy"
+_LEGACY_PUBLISHER_NAME = "Previously synced Companion"
+
 
 class PersonalDataSnapshotStore:
-    """Thread-safe single-file store of the latest snapshot per ``source_id``."""
+    """Thread-safe latest snapshot per publisher and source.
+
+    Calls that omit ``publisher_id`` retain the original single-publisher API:
+    writes target a legacy namespace and reads return the most recently stored
+    publication. New authenticated API paths always pass a publisher id.
+    """
 
     def __init__(self, path: Path) -> None:
         self._path = path
@@ -41,12 +55,34 @@ class PersonalDataSnapshotStore:
 
     def _load(self) -> dict[str, Any]:
         if not self._path.exists():
-            return {}
+            return {"_format": _FORMAT_VERSION, "publishers": {}}
         try:
             raw = json.loads(self._path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
-            return {}
-        return raw if isinstance(raw, dict) else {}
+            return {"_format": _FORMAT_VERSION, "publishers": {}}
+        if not isinstance(raw, dict):
+            return {"_format": _FORMAT_VERSION, "publishers": {}}
+        publishers = raw.get("publishers")
+        if raw.get("_format") == _FORMAT_VERSION and isinstance(publishers, dict):
+            return raw
+
+        # v1 stored ``{source_id: record}``. Keep it readable under an
+        # explicit legacy publisher until the first authenticated publisher
+        # replaces that source; no personal values are duplicated.
+        legacy_sources = {key: value for key, value in raw.items() if isinstance(value, dict)}
+        return {
+            "_format": _FORMAT_VERSION,
+            "publishers": (
+                {
+                    _LEGACY_PUBLISHER_ID: {
+                        "name": _LEGACY_PUBLISHER_NAME,
+                        "sources": legacy_sources,
+                    }
+                }
+                if legacy_sources
+                else {}
+            ),
+        }
 
     def _save(self, data: dict[str, Any]) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
@@ -54,14 +90,93 @@ class PersonalDataSnapshotStore:
         tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         tmp.replace(self._path)
 
-    def get(self, source_id: str) -> dict[str, Any] | None:
-        self.redact_expired(time.time())
-        entry = self._load().get(source_id)
-        return entry if isinstance(entry, dict) else None
+    @staticmethod
+    def _sources(data: dict[str, Any], publisher_id: str) -> dict[str, Any] | None:
+        publishers = data.get("publishers")
+        if not isinstance(publishers, dict):
+            return None
+        publisher = publishers.get(publisher_id)
+        if not isinstance(publisher, dict):
+            return None
+        sources = publisher.get("sources")
+        return sources if isinstance(sources, dict) else None
 
-    def all(self) -> dict[str, dict[str, Any]]:
+    def get(self, source_id: str, *, publisher_id: str | None = None) -> dict[str, Any] | None:
         self.redact_expired(time.time())
-        return {k: v for k, v in self._load().items() if isinstance(v, dict)}
+        data = self._load()
+        if publisher_id is not None:
+            sources = self._sources(data, publisher_id)
+            entry = sources.get(source_id) if sources is not None else None
+            return entry if isinstance(entry, dict) else None
+
+        # Backward-compatible read for existing widgets: return the newest
+        # publisher's record. Multi-publisher-aware widgets use publications().
+        newest: dict[str, Any] | None = None
+        newest_stored = float("-inf")
+        for publication in self.publications(source_id):
+            stored = publication.get("stored_at")
+            stored_value = float(stored) if isinstance(stored, (int, float)) else 0.0
+            if newest is None or stored_value > newest_stored:
+                newest = {
+                    key: value
+                    for key, value in publication.items()
+                    if not key.startswith("publisher_")
+                }
+                newest_stored = stored_value
+        return newest
+
+    def all(self, *, publisher_id: str | None = None) -> dict[str, dict[str, Any]]:
+        self.redact_expired(time.time())
+        data = self._load()
+        if publisher_id is not None:
+            sources = self._sources(data, publisher_id) or {}
+            return {key: value for key, value in sources.items() if isinstance(value, dict)}
+
+        source_ids: set[str] = set()
+        publishers = data.get("publishers")
+        if isinstance(publishers, dict):
+            for raw_publisher in publishers.values():
+                if not isinstance(raw_publisher, dict):
+                    continue
+                raw_sources = raw_publisher.get("sources")
+                if isinstance(raw_sources, dict):
+                    source_ids.update(str(key) for key in raw_sources)
+        out: dict[str, dict[str, Any]] = {}
+        for source_id in source_ids:
+            record = self.get(source_id)
+            if record is not None:
+                out[source_id] = record
+        return out
+
+    def publications(self, source_id: str) -> list[dict[str, Any]]:
+        """Return every publisher record for one source, with safe metadata."""
+        self.redact_expired(time.time())
+        data = self._load()
+        publishers = data.get("publishers")
+        if not isinstance(publishers, dict):
+            return []
+        out: list[dict[str, Any]] = []
+        for publisher_id, raw_publisher in publishers.items():
+            if not isinstance(publisher_id, str) or not isinstance(raw_publisher, dict):
+                continue
+            sources = raw_publisher.get("sources")
+            record = sources.get(source_id) if isinstance(sources, dict) else None
+            if not isinstance(record, dict):
+                continue
+            name = raw_publisher.get("name")
+            out.append(
+                {
+                    **record,
+                    "publisher_id": publisher_id,
+                    "publisher_name": (
+                        name.strip() if isinstance(name, str) and name.strip() else publisher_id
+                    ),
+                }
+            )
+        return sorted(
+            out,
+            key=lambda item: (str(item["publisher_name"]).casefold(), str(item["publisher_id"])),
+        )
 
     def put(
         self,
@@ -70,11 +185,35 @@ class PersonalDataSnapshotStore:
         snapshot: dict[str, Any],
         generated_epoch: float,
         expires_epoch: float,
+        publisher_id: str = _LEGACY_PUBLISHER_ID,
+        publisher_name: str | None = None,
     ) -> None:
-        """Replace the latest snapshot for ``source_id``."""
+        """Replace the latest snapshot for one publisher and source."""
         with self._lock:
             data = self._load()
-            data[source_id] = {
+            publishers = data.get("publishers")
+            if not isinstance(publishers, dict):
+                publishers = {}
+                data["publishers"] = publishers
+
+            if publisher_id != _LEGACY_PUBLISHER_ID:
+                legacy_sources = self._sources(data, _LEGACY_PUBLISHER_ID)
+                if legacy_sources is not None:
+                    legacy_sources.pop(source_id, None)
+                    if not legacy_sources:
+                        publishers.pop(_LEGACY_PUBLISHER_ID, None)
+
+            publisher = publishers.get(publisher_id)
+            if not isinstance(publisher, dict):
+                publisher = {"name": publisher_name or publisher_id, "sources": {}}
+                publishers[publisher_id] = publisher
+            if isinstance(publisher_name, str) and publisher_name.strip():
+                publisher["name"] = publisher_name.strip()
+            sources = publisher.get("sources")
+            if not isinstance(sources, dict):
+                sources = {}
+                publisher["sources"] = sources
+            sources[source_id] = {
                 "snapshot": snapshot,
                 "generated_epoch": generated_epoch,
                 "expires_epoch": expires_epoch,
@@ -82,13 +221,17 @@ class PersonalDataSnapshotStore:
             }
             self._save(data)
 
-    def delete(self, source_id: str) -> bool:
-        """Remove a source's snapshot. Returns whether one existed."""
+    def delete(self, source_id: str, *, publisher_id: str = _LEGACY_PUBLISHER_ID) -> bool:
+        """Remove one publisher's source. Returns whether one existed."""
         with self._lock:
             data = self._load()
-            if source_id not in data:
+            sources = self._sources(data, publisher_id)
+            if sources is None or source_id not in sources:
                 return False
-            del data[source_id]
+            del sources[source_id]
+            publishers = data.get("publishers")
+            if not sources and isinstance(publishers, dict):
+                publishers.pop(publisher_id, None)
             self._save(data)
             return True
 
@@ -102,18 +245,25 @@ class PersonalDataSnapshotStore:
         with self._lock:
             data = self._load()
             redacted: list[str] = []
-            for source_id in list(data):
-                entry = data.get(source_id)
-                exp = entry.get("expires_epoch") if isinstance(entry, dict) else None
-                if (
-                    isinstance(entry, dict)
-                    and isinstance(exp, (int, float))
-                    and now >= exp
-                    and "snapshot" in entry
-                ):
-                    del entry["snapshot"]
-                    entry["expired"] = True
-                    redacted.append(source_id)
+            publishers = data.get("publishers")
+            if isinstance(publishers, dict):
+                for raw_publisher in publishers.values():
+                    if not isinstance(raw_publisher, dict):
+                        continue
+                    sources = raw_publisher.get("sources")
+                    if not isinstance(sources, dict):
+                        continue
+                    for source_id, entry in sources.items():
+                        exp = entry.get("expires_epoch") if isinstance(entry, dict) else None
+                        if (
+                            isinstance(entry, dict)
+                            and isinstance(exp, (int, float))
+                            and now >= exp
+                            and "snapshot" in entry
+                        ):
+                            del entry["snapshot"]
+                            entry["expired"] = True
+                            redacted.append(str(source_id))
             if redacted:
                 self._save(data)
             return redacted

--- a/app/state/personal_data_store.py
+++ b/app/state/personal_data_store.py
@@ -44,9 +44,10 @@ _LEGACY_PUBLISHER_NAME = "Previously synced Companion"
 class PersonalDataSnapshotStore:
     """Thread-safe latest snapshot per publisher and source.
 
-    Calls that omit ``publisher_id`` retain the original single-publisher API:
-    writes target a legacy namespace and reads return the most recently stored
-    publication. New authenticated API paths always pass a publisher id.
+    Reads that omit ``publisher_id`` retain the original single-publisher API
+    by returning the publication with the newest generated timestamp. Writes
+    and deletes require an explicit publisher so no caller can accidentally
+    create new data in the migration-only legacy namespace.
     """
 
     def __init__(self, path: Path) -> None:
@@ -112,17 +113,19 @@ class PersonalDataSnapshotStore:
         # Backward-compatible read for existing widgets: return the newest
         # publisher's record. Multi-publisher-aware widgets use publications().
         newest: dict[str, Any] | None = None
-        newest_stored = float("-inf")
+        newest_generated = float("-inf")
         for publication in self.publications(source_id):
-            stored = publication.get("stored_at")
-            stored_value = float(stored) if isinstance(stored, (int, float)) else 0.0
-            if newest is None or stored_value > newest_stored:
+            generated = publication.get("generated_epoch")
+            generated_value = (
+                float(generated) if isinstance(generated, (int, float)) else float("-inf")
+            )
+            if newest is None or generated_value > newest_generated:
                 newest = {
                     key: value
                     for key, value in publication.items()
                     if not key.startswith("publisher_")
                 }
-                newest_stored = stored_value
+                newest_generated = generated_value
         return newest
 
     def all(self, *, publisher_id: str | None = None) -> dict[str, dict[str, Any]]:
@@ -185,7 +188,7 @@ class PersonalDataSnapshotStore:
         snapshot: dict[str, Any],
         generated_epoch: float,
         expires_epoch: float,
-        publisher_id: str = _LEGACY_PUBLISHER_ID,
+        publisher_id: str,
         publisher_name: str | None = None,
     ) -> None:
         """Replace the latest snapshot for one publisher and source."""
@@ -221,7 +224,7 @@ class PersonalDataSnapshotStore:
             }
             self._save(data)
 
-    def delete(self, source_id: str, *, publisher_id: str = _LEGACY_PUBLISHER_ID) -> bool:
+    def delete(self, source_id: str, *, publisher_id: str) -> bool:
         """Remove one publisher's source. Returns whether one existed."""
         with self._lock:
             data = self._load()

--- a/tests/companion/contract/app-v1.openapi.yaml
+++ b/tests/companion/contract/app-v1.openapi.yaml
@@ -433,9 +433,9 @@ paths:
       operationId: getCompanionPersonalDataStatus
       summary: List snapshot freshness metadata without returning personal values
       description: >-
-        Returns only sources published by this authenticated Companion
-        installation. Another paired installation's freshness metadata and
-        personal values are never exposed.
+        Returns only sources associated with the publisher identity bound to
+        this authenticated pairing. Installation descriptors supplied during
+        pairing are trusted within the Companion pairing boundary.
       responses:
         "200":
           description: Metadata for currently stored or expired snapshot sources
@@ -453,10 +453,12 @@ paths:
       operationId: putCompanionPersonalDataSnapshot
       summary: Replace the latest snapshot for one advertised personal-data source
       description: |
-        The authenticated pairing determines a stable, server-derived publisher
-        identity; clients do not add publisher fields to the snapshot. Replacement
-        and generated_at ordering are scoped to that publisher and source, so two
-        paired Companion installations cannot overwrite one another.
+        The authenticated pairing determines a stable publisher identity from
+        the installation descriptor accepted during pairing; clients do not add
+        publisher fields to the snapshot. Replacement and generated_at ordering
+        are scoped to that publisher and source, so independently identified
+        Companion installations do not replace one another. Installation
+        descriptors are trusted within the Companion pairing boundary.
 
         Snapshot validation, storage, latency, and response semantics are
         independent from rendering. After a 200 response, the server may
@@ -487,10 +489,12 @@ paths:
       operationId: deleteCompanionPersonalDataSnapshot
       summary: Delete the latest snapshot when its source is disabled
       description: |
-        Deletion is authoritative and idempotent only for the authenticated
-        Companion installation's publication. It cannot delete another paired
-        installation's snapshot. Any eligible dashboard refresh is
-        fire-and-forget after the 204 response; no expiry timer is implied.
+        Deletion is authoritative and idempotent for the publisher identity
+        bound to the authenticated pairing. Another independently identified
+        installation's snapshot is not addressable through this request.
+        Installation descriptors are trusted within the Companion pairing
+        boundary. Any eligible dashboard refresh is fire-and-forget after the
+        204 response; no expiry timer is implied.
       responses:
         "204":
           description: Snapshot absent after the request

--- a/tests/companion/contract/app-v1.openapi.yaml
+++ b/tests/companion/contract/app-v1.openapi.yaml
@@ -432,6 +432,10 @@ paths:
       tags: [Personal Data]
       operationId: getCompanionPersonalDataStatus
       summary: List snapshot freshness metadata without returning personal values
+      description: >-
+        Returns only sources published by this authenticated Companion
+        installation. Another paired installation's freshness metadata and
+        personal values are never exposed.
       responses:
         "200":
           description: Metadata for currently stored or expired snapshot sources
@@ -449,8 +453,13 @@ paths:
       operationId: putCompanionPersonalDataSnapshot
       summary: Replace the latest snapshot for one advertised personal-data source
       description: |
-        Snapshot validation, ordering, storage, latency, and response semantics
-        are independent from rendering. After a 200 response, the server may
+        The authenticated pairing determines a stable, server-derived publisher
+        identity; clients do not add publisher fields to the snapshot. Replacement
+        and generated_at ordering are scoped to that publisher and source, so two
+        paired Companion installations cannot overwrite one another.
+
+        Snapshot validation, storage, latency, and response semantics are
+        independent from rendering. After a 200 response, the server may
         asynchronously refresh already-active dashboards whose widget placements
         explicitly opted in to this source. Render or delivery failures never
         change the accepted PUT response and require no client retry.
@@ -478,8 +487,10 @@ paths:
       operationId: deleteCompanionPersonalDataSnapshot
       summary: Delete the latest snapshot when its source is disabled
       description: |
-        Deletion is authoritative and idempotent. Any eligible dashboard refresh
-        is fire-and-forget after the 204 response; no expiry timer is implied.
+        Deletion is authoritative and idempotent only for the authenticated
+        Companion installation's publication. It cannot delete another paired
+        installation's snapshot. Any eligible dashboard refresh is
+        fire-and-forget after the 204 response; no expiry timer is implied.
       responses:
         "204":
           description: Snapshot absent after the request
@@ -1255,6 +1266,9 @@ components:
         Incomplete items grouped by user-approved Apple Reminders lists. List
         identifiers are opaque Companion publication identifiers rather than
         EventKit calendar identifiers and must be unique within one snapshot;
+        they remain the widget selector across multiple paired publishers.
+        Widgets may distinguish duplicate list titles with the paired client's
+        display name, while publisher identity itself remains server-derived;
         duplicate ids are rejected as invalid_snapshot (400). At most 200 items
         may appear across all lists in one snapshot. Exceeding that aggregate
         cap is rejected as invalid_snapshot (400), never truncated by the

--- a/tests/companion/test_companion_personal_data.py
+++ b/tests/companion/test_companion_personal_data.py
@@ -41,11 +41,11 @@ def app(tmp_path: Path) -> Flask:
     return a
 
 
-def _token(app: Flask) -> str:
+def _token(app: Flask, client: dict[str, str] | None = None) -> str:
     code = app.config["COMPANION_PAIRING_STORE"].issue(note="t").code
     resp = app.test_client().post(
         "/api/app/v1/pair",
-        data=json.dumps({"code": code, "client": _CLIENT}),
+        data=json.dumps({"code": code, "client": client or _CLIENT}),
         content_type="application/json",
     )
     return str(resp.get_json()["token"])
@@ -204,7 +204,10 @@ def test_personal_data_changes_emit_semantic_events_after_storage(app: Flask) ->
     initial = _multi_list_snapshot(now)
 
     assert _put_multi(app, token, initial).status_code == 200
-    assert capture.events == [DataChangeEvent("personal_data.reminders")]
+    initial_list_ids = frozenset(str(item["id"]) for item in initial["data"]["lists"])
+    assert capture.events == [
+        DataChangeEvent("personal_data.reminders", selectors=initial_list_ids)
+    ]
     assert app.config["PERSONAL_DATA_STORE"].get("reminders")["snapshot"] == initial
 
     # Republishing identical list contents only renews freshness/TTL.
@@ -228,7 +231,9 @@ def test_personal_data_changes_emit_semantic_events_after_storage(app: Flask) ->
     capture.events.clear()
     response = app.test_client().delete("/api/app/v1/personal-data/reminders", headers=_auth(token))
     assert response.status_code == 204
-    assert capture.events == [DataChangeEvent("personal_data.reminders")]
+    assert capture.events == [
+        DataChangeEvent("personal_data.reminders", selectors=initial_list_ids)
+    ]
 
     # Idempotent DELETE has no second event.
     capture.events.clear()
@@ -266,6 +271,91 @@ def test_empty_list_set_is_a_fresh_enabled_snapshot(app: Flask) -> None:
     )
     assert status.status_code == 200
     assert status.get_json()["sources"][0]["state"] == "fresh"
+
+
+def test_publishers_cannot_overwrite_or_delete_each_others_reminders(app: Flask) -> None:
+    client_a = {
+        **_CLIENT,
+        "name": "Alice iPhone",
+        "installation_id": "11111111-1111-4111-8111-111111111111",
+    }
+    client_b = {
+        **_CLIENT,
+        "name": "Bob iPhone",
+        "installation_id": "22222222-2222-4222-8222-222222222222",
+    }
+    token_a = _token(app, client_a)
+    token_b = _token(app, client_b)
+    now = datetime.now(UTC).replace(microsecond=0)
+    alice = _multi_list_snapshot(
+        now,
+        lists=[{"id": "alice-list", "title": "Groceries", "items": []}],
+    )
+    # Deliberately older than Alice: publisher-local ordering must still accept it.
+    bob = _multi_list_snapshot(
+        now - timedelta(minutes=5),
+        lists=[{"id": "bob-list", "title": "Groceries", "items": []}],
+    )
+
+    assert _put_multi(app, token_a, alice).status_code == 200
+    assert _put_multi(app, token_b, bob).status_code == 200
+
+    publications = app.config["PERSONAL_DATA_STORE"].publications("reminders")
+    assert [item["publisher_name"] for item in publications] == ["Alice iPhone", "Bob iPhone"]
+    assert {item["snapshot"]["data"]["lists"][0]["id"] for item in publications} == {
+        "alice-list",
+        "bob-list",
+    }
+
+    alice_status = app.test_client().get("/api/app/v1/personal-data/status", headers=_auth(token_a))
+    bob_status = app.test_client().get("/api/app/v1/personal-data/status", headers=_auth(token_b))
+    assert alice_status.get_json()["sources"][0]["generated_at"] == _iso(now)
+    assert bob_status.get_json()["sources"][0]["generated_at"] == _iso(now - timedelta(minutes=5))
+
+    assert (
+        app.test_client()
+        .delete("/api/app/v1/personal-data/reminders", headers=_auth(token_a))
+        .status_code
+        == 204
+    )
+    assert (
+        app.test_client()
+        .get("/api/app/v1/personal-data/status", headers=_auth(token_a))
+        .get_json()["sources"]
+        == []
+    )
+    assert [
+        source["source_id"]
+        for source in app.test_client()
+        .get("/api/app/v1/personal-data/status", headers=_auth(token_b))
+        .get_json()["sources"]
+    ] == ["reminders"]
+    remaining = app.config["PERSONAL_DATA_STORE"].publications("reminders")
+    assert [item["publisher_name"] for item in remaining] == ["Bob iPhone"]
+
+
+def test_repairing_the_same_installation_keeps_one_publisher(app: Flask) -> None:
+    first_token = _token(app)
+    second_token = _token(app)
+    now = datetime.now(UTC).replace(microsecond=0)
+    first = _multi_list_snapshot(
+        now,
+        lists=[{"id": "food", "title": "Groceries", "items": []}],
+    )
+    second = _multi_list_snapshot(
+        now + timedelta(minutes=1),
+        lists=[{"id": "food", "title": "Groceries", "items": []}],
+    )
+
+    assert _put_multi(app, first_token, first).status_code == 200
+    assert _put_multi(app, second_token, second).status_code == 200
+
+    publications = app.config["PERSONAL_DATA_STORE"].publications("reminders")
+    assert len(publications) == 1
+    assert publications[0]["snapshot"]["generated_at"] == _iso(now + timedelta(minutes=1))
+    for token in (first_token, second_token):
+        status = app.test_client().get("/api/app/v1/personal-data/status", headers=_auth(token))
+        assert status.get_json()["sources"][0]["generated_at"] == _iso(now + timedelta(minutes=1))
 
 
 def test_put_ordering(app: Flask) -> None:
@@ -390,11 +480,13 @@ def test_expiry_redacts_values_but_preserves_metadata_state(app: Flask) -> None:
     token = _token(app)
     now = datetime.now(UTC).replace(microsecond=0)
     store = app.config["PERSONAL_DATA_STORE"]
-    store.put(
-        "reminders",
-        snapshot=_multi_list_snapshot(now - timedelta(hours=49)),
-        generated_epoch=(now - timedelta(hours=49)).timestamp(),
-        expires_epoch=(now - timedelta(hours=1)).timestamp(),
+    assert (
+        _put_multi(
+            app,
+            token,
+            _multi_list_snapshot(now - timedelta(hours=49), ttl_hours=48),
+        ).status_code
+        == 200
     )
 
     response = app.test_client().get(

--- a/tests/test_data_change_refresh.py
+++ b/tests/test_data_change_refresh.py
@@ -10,6 +10,7 @@ from app.data_change_refresh import (
     DataChangeEvent,
     DataChangeRefreshCoordinator,
     matching_page_ids,
+    personal_data_delete_event,
     personal_data_update_event,
 )
 from app.plugin_loader import Plugin, PluginRegistry
@@ -123,6 +124,24 @@ def test_first_snapshot_is_source_wide_even_when_it_contains_no_lists() -> None:
     assert personal_data_update_event("reminders", None, current) == DataChangeEvent(
         source="personal_data.reminders"
     )
+
+
+def test_first_nonempty_snapshot_and_delete_are_narrowed_to_known_lists() -> None:
+    current = _snapshot(
+        generated="2026-08-05T12:00:00Z",
+        expires="2026-08-07T12:00:00Z",
+        lists=[
+            _list("food", "Groceries", "Milk"),
+            _list("work", "Tasks", "Review PR"),
+        ],
+    )
+    expected = DataChangeEvent(
+        source="personal_data.reminders",
+        selectors=frozenset({"food", "work"}),
+    )
+
+    assert personal_data_update_event("reminders", None, current) == expected
+    assert personal_data_delete_event("reminders", current) == expected
 
 
 def test_matching_pages_respects_placement_opt_in_and_selector(tmp_path: Path) -> None:

--- a/tests/test_personal_data_store.py
+++ b/tests/test_personal_data_store.py
@@ -64,3 +64,27 @@ def test_delete_is_scoped_to_one_publisher(tmp_path: Path) -> None:
     assert store.get("reminders", publisher_id="companion_a") is None
     assert store.get("reminders", publisher_id="companion_b") is not None
     assert [item["publisher_name"] for item in store.publications("reminders")] == ["Bob"]
+
+
+def test_legacy_read_fallback_prefers_newest_generated_snapshot(tmp_path: Path) -> None:
+    store = PersonalDataSnapshotStore(tmp_path / "personal.json")
+    store.put(
+        "reminders",
+        snapshot=_snapshot("Semantically newest"),
+        generated_epoch=200.0,
+        expires_epoch=9_999_999_999.0,
+        publisher_id="companion_first",
+        publisher_name="First",
+    )
+    # Stored second, but generated earlier: delayed upload must not win the
+    # compatibility fallback used by widgets that predate publications().
+    store.put(
+        "reminders",
+        snapshot=_snapshot("Uploaded later"),
+        generated_epoch=100.0,
+        expires_epoch=9_999_999_999.0,
+        publisher_id="companion_second",
+        publisher_name="Second",
+    )
+
+    assert store.get("reminders")["snapshot"] == _snapshot("Semantically newest")

--- a/tests/test_personal_data_store.py
+++ b/tests/test_personal_data_store.py
@@ -1,0 +1,66 @@
+"""Publisher isolation and legacy migration for personal-data snapshots."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.state.personal_data_store import PersonalDataSnapshotStore
+
+
+def _snapshot(title: str) -> dict:
+    return {"data": {"lists": [{"id": title.lower(), "title": title, "items": []}]}}
+
+
+def test_reads_v1_single_source_file_and_claims_it_on_first_publisher_put(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "personal.json"
+    path.write_text(
+        json.dumps(
+            {
+                "reminders": {
+                    "snapshot": _snapshot("Legacy"),
+                    "generated_epoch": 1.0,
+                    "expires_epoch": 9_999_999_999.0,
+                    "stored_at": 2.0,
+                }
+            }
+        )
+    )
+    store = PersonalDataSnapshotStore(path)
+
+    assert store.get("reminders")["snapshot"] == _snapshot("Legacy")
+    assert store.publications("reminders")[0]["publisher_name"] == "Previously synced Companion"
+
+    store.put(
+        "reminders",
+        snapshot=_snapshot("Alice"),
+        generated_epoch=3.0,
+        expires_epoch=9_999_999_999.0,
+        publisher_id="companion_alice",
+        publisher_name="Alice iPhone",
+    )
+
+    publications = store.publications("reminders")
+    assert len(publications) == 1
+    assert publications[0]["publisher_id"] == "companion_alice"
+    assert publications[0]["snapshot"] == _snapshot("Alice")
+
+
+def test_delete_is_scoped_to_one_publisher(tmp_path: Path) -> None:
+    store = PersonalDataSnapshotStore(tmp_path / "personal.json")
+    for publisher_id, name in (("companion_a", "Alice"), ("companion_b", "Bob")):
+        store.put(
+            "reminders",
+            snapshot=_snapshot(name),
+            generated_epoch=1.0,
+            expires_epoch=9_999_999_999.0,
+            publisher_id=publisher_id,
+            publisher_name=name,
+        )
+
+    assert store.delete("reminders", publisher_id="companion_a") is True
+    assert store.get("reminders", publisher_id="companion_a") is None
+    assert store.get("reminders", publisher_id="companion_b") is not None
+    assert [item["publisher_name"] for item in store.publications("reminders")] == ["Bob"]


### PR DESCRIPTION
## What changed

- key personal-data snapshots by paired Companion installation and source instead of source alone
- scope PUT ordering, status, and DELETE to the publisher identity bound to the authenticated pairing
- expose all publications to server-side widgets with the paired client name as display metadata
- migrate the previous single-publisher JSON shape in memory and retire each legacy source on its first authenticated sync
- narrow first-sync and delete refresh events to the affected Reminders list IDs when they are known
- document the unchanged client payload contract and the trusted installation-descriptor boundary

## Why

The previous store used only `source_id` as its key. In a household with two paired Companion apps, the second phone could replace the first phone’s Reminders snapshot, an older snapshot from the second phone could be rejected by the first phone’s timestamp, and either phone could delete the shared record when disabling sync.

Publisher identity is derived from the stable installation descriptor already bound to the authenticated pairing. No publisher or user field is added to the snapshot payload. Installation descriptors are trusted within the Companion pairing boundary; independently identified installations receive separate publications, while re-pairing the same app installation continues to address one publication.

## User impact

Independently identified household phones can publish the same personal-data source without replacing each other. Each phone sees the freshness status and controls the publication associated with its pairing. Multi-publisher-aware widgets can enumerate every publication and distinguish duplicate list titles using the paired client name. Existing widgets retain a newest-generated-publication fallback until updated.

## Validation

- full `python -m pytest -q` before the upstream-only rebase: 2919 passed
- post-rebase focused personal-data, contract, and change-refresh tests: 68 passed
- Ruff format/check on changed Python files: passed
- strict mypy on `personal_data_store.py` and `data_change_refresh.py`: passed
- Apple Reminders widget compatibility smoke tests against this branch: 11 passed