### PR TITLE
Group refresh-on-change with widget options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are
 [SemVer](https://semver.org/) (pre-1.0, so minors can carry breaking changes).
 
+## [Unreleased]
+
+### Fixed
+
+- **Refresh-on-change now appears with the Widget options it affects.**
+  Both Dashboard editors group the per-placement update policy inside the
+  selected Widget's options instead of presenting it like an unrelated or
+  dashboard-wide setting. Its scope and persistence are unchanged.
+
 ## [0.267.0], 2026-08-05
 
 ### Added

--- a/app/panels_routes.py
+++ b/app/panels_routes.py
@@ -697,9 +697,11 @@ def _materialised_options(plugin: Any) -> list[dict[str, Any]]:
 @bp.post("/source-form")
 def source_form() -> Response:
     """Render a widget's ``cell_options`` as an HTML form fragment for the
-    source-config drawer. Body: ``{key, sid, options}``. Reuses the grid
-    editor's ``auto_field`` macros so the controls (location search, entity
-    overrides, selects) stay identical to per-cell config."""
+    source-config drawer. Body: ``{key, sid, options, placement?,
+    update_on_change?}``. Reuses the grid editor's ``auto_field`` macros so
+    the controls (location search, entity overrides, selects) stay identical
+    to per-cell config. A direct capable placement also gets the host-owned
+    update policy in this drawer; nested data sources do not."""
     _guard()
     body = request.get_json(silent=True) or {}
     key = body.get("key")
@@ -707,11 +709,14 @@ def source_form() -> Response:
     if plugin is None:
         abort(404)
     values = body.get("options")
+    show_update_on_change = body.get("placement") is True and bool(plugin.on_change_updates)
     html = render_template(
         "panels_source_form.html",
         opts=_materialised_options(plugin),
         values=values if isinstance(values, dict) else {},
         sid=str(body.get("sid") or "new"),
+        show_update_on_change=show_update_on_change,
+        update_on_change=show_update_on_change and body.get("update_on_change") is True,
     )
     return current_app.response_class(html, mimetype="text/html")
 

--- a/static/panels/editor.js
+++ b/static/panels/editor.js
@@ -2547,28 +2547,6 @@
       cfgrow.appendChild(cfg); mount.appendChild(cfgrow);
     }
 
-    // Host-owned placement policy. The widget only declares that it can
-    // consume change events; each element opts in independently and defaults
-    // off. Actual event delivery lands in a later server stage.
-    var selectedWidget = widgetFor(e.widget);
-    if (selectedWidget && selectedWidget.updates_on_change) {
-      mount.appendChild(el("div", "psec", '<i class="ph-bold ph-arrows-clockwise"></i>Updates'));
-      var urow = el("div", "prow");
-      urow.innerHTML = '<span class="plab">Data changes</span>';
-      var ubtn = el("button", "minibtn",
-        e.update_on_change
-          ? '<i class="ph-bold ph-check-square"></i> Refresh'
-          : '<i class="ph-bold ph-square"></i> Off');
-      ubtn.addEventListener("click", function () {
-        pushHistory();
-        e.update_on_change = !e.update_on_change;
-        scheduleSave(); paint();
-      });
-      urow.appendChild(ubtn); mount.appendChild(urow);
-      mount.appendChild(el("div", "note",
-        "Refreshes only displays already showing this dashboard. It never selects or advances a page."));
-    }
-
     // Fragment parts (scale individual pieces of the render).
     if (e.widget) partsSection(mount, e);
 
@@ -2750,7 +2728,13 @@
     fetch(S.cfg.sourceFormUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ key: key, sid: e.id, options: opts }),
+      body: JSON.stringify({
+        key: key,
+        sid: e.id,
+        options: opts,
+        placement: !hasSidx && isWidget(e),
+        update_on_change: !!e.update_on_change,
+      }),
     })
       .then(function (r) { return r.ok ? r.text() : Promise.reject(r.status); })
       .then(function (html) {
@@ -2796,12 +2780,19 @@
     });
     var sidx = body.dataset.sidx;
     var srcSel = (sidx !== "" && e.sources && e.sources[+sidx]) ? e.sources[+sidx] : null;
+    var updateMarker = body.querySelector('input[name="update_on_change_present"]');
+    var updateEnabled = !!body.querySelector('input[name="update_on_change"]:checked');
     form.append("key", srcSel ? srcSel.key : sourceOf(e));
     fetch(S.cfg.sourceOptionsUrl, { method: "POST", body: form })
       .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
       .then(function (j) {
         pushHistory();
-        if (srcSel) srcSel.options = j.options || {}; else e.options = j.options || {};
+        if (srcSel) {
+          srcSel.options = j.options || {};
+        } else {
+          e.options = j.options || {};
+          if (updateMarker) e.update_on_change = updateEnabled;
+        }
         scheduleSave(); closeConfig(); paint(); renderProps();
       })
       .catch(function () { var s = $("panels-status"); if (s) s.textContent = "config save failed"; });

--- a/static/style/forms.css
+++ b/static/style/forms.css
@@ -124,6 +124,30 @@
   line-height: 1.5;
 }
 
+/* Host-owned placement controls that belong visually with a widget's own
+   options. The value still lives on the dashboard placement, not in the
+   plugin options payload. */
+.widget-option-section {
+  display: grid;
+  gap: var(--t-space-1);
+  margin-top: var(--t-space-4);
+  padding-top: var(--t-space-3);
+  border-top: 1px solid var(--t-border);
+}
+.widget-option-section--only {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: 0;
+}
+.widget-option-section > .field-label {
+  margin-bottom: var(--t-space-1);
+  font-size: var(--t-size-sm);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--t-fg-soft);
+}
+
 .actions {
   display: flex;
   gap: var(--t-space-2);

--- a/templates/page_editor.html
+++ b/templates/page_editor.html
@@ -168,19 +168,7 @@
        fields are absent, so the layout survives a cell-option save. #}
 
     {% set cell_opts = plugin_cell_options.get(plugin.id, []) %}
-    {% if plugin.on_change_updates %}
-    <fieldset class="form-group">
-      <legend>Updates</legend>
-      <input type="hidden" name="update_on_change_present" value="1">
-      <label class="switch dx-cell-tweak-switch">
-        <input type="checkbox" name="update_on_change" value="1"
-               {% if cell.update_on_change %}checked{% endif %}>
-        <span>Refresh when this widget's data changes</span>
-      </label>
-      <p class="field-help">Off by default. When enabled, a matching data-change event may refresh this dashboard only on displays already showing it; it never selects or advances a dashboard.</p>
-    </fieldset>
-    {% endif %}
-    {% if cell_opts %}
+    {% if cell_opts or plugin.on_change_updates %}
     <fieldset class="form-group">
       <legend>{{ plugin.name }} options</legend>
       {% for opt in cell_opts %}
@@ -188,6 +176,16 @@
         {% set value = cell.options.get(opt.name, opt.get('default', '')) %}
         {{ auto_field(field_id, 'opt_' ~ opt.name, opt, value) }}
       {% endfor %}
+      {% if plugin.on_change_updates %}
+      <div class="widget-option-section{% if not cell_opts %} widget-option-section--only{% endif %}">
+        <span class="field-label">Updates</span>
+        <input type="hidden" name="update_on_change_present" value="1">
+        {{ switch('cell-' ~ cell.id ~ '-update-on-change', 'update_on_change',
+                  "Refresh this dashboard when this widget's data changes",
+                  checked=cell.update_on_change) }}
+        <p class="field-help">Off by default. Only refreshes displays already showing this dashboard; it never selects or advances a dashboard.</p>
+      </div>
+      {% endif %}
     </fieldset>
     {% endif %}
 

--- a/templates/panels_source_form.html
+++ b/templates/panels_source_form.html
@@ -4,14 +4,26 @@
    drawer. Reuses the grid editor's ``auto_field`` macro so a canvas data
    source is configured with the exact same controls as a grid cell. The
    drawer submits this form to ``panels.source_options``, which parses it back
-   into an options dict via the shared per-cell coercion. #}
-{% from "_components.html" import auto_field %}
+   into an options dict via the shared per-cell coercion. A direct widget
+   placement may also render the host-owned update policy here so it belongs
+   visually with these options without entering the plugin options payload. #}
+{% from "_components.html" import auto_field, switch %}
 {% if opts %}
   {% for opt in opts %}
     {% set field_id = 'src-' ~ sid ~ '-opt-' ~ opt.name %}
     {% set value = values.get(opt.name, opt.get('default', '')) %}
     {{ auto_field(field_id, 'opt_' ~ opt.name, opt, value) }}
   {% endfor %}
-{% else %}
+{% elif not show_update_on_change %}
   <p class="note" style="padding:8px 2px">This widget has no configurable options.</p>
+{% endif %}
+{% if show_update_on_change %}
+  <div class="widget-option-section{% if not opts %} widget-option-section--only{% endif %}">
+    <span class="field-label">Updates</span>
+    <input type="hidden" name="update_on_change_present" value="1">
+    {{ switch('src-' ~ sid ~ '-update-on-change', 'update_on_change',
+              "Refresh this dashboard when this widget's data changes",
+              checked=update_on_change) }}
+    <p class="field-help">Off by default. Only refreshes displays already showing this dashboard; it never selects or advances a dashboard.</p>
+  </div>
 {% endif %}

--- a/tests/test_page_routes.py
+++ b/tests/test_page_routes.py
@@ -821,6 +821,11 @@ def test_grid_editor_only_shows_update_switch_for_capable_widget(
     client.post(f"/pages/{pid}/cells/{cell_id}", data={"plugin": "widget_a"})
     html = client.get(f"/pages/{pid}").get_data(as_text=True)
     assert 'name="update_on_change"' in html
+    options_start = html.index("<legend>Widget A options</legend>")
+    options_end = html.index("</fieldset>", options_start)
+    update_switch = html.index('name="update_on_change"')
+    assert options_start < update_switch < options_end
+    assert "<legend>Updates</legend>" not in html
 
     client.post(f"/pages/{pid}/cells/{cell_id}", data={"plugin": "widget_b"})
     html = client.get(f"/pages/{pid}").get_data(as_text=True)

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -788,6 +788,44 @@ def test_source_form_renders_widget_options(app: Flask, monkeypatch: pytest.Monk
     assert 'name="opt_units"' in resp.get_data(as_text=True)
 
 
+def test_source_form_groups_placement_updates_with_widget_options(
+    app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A capable widget's placement policy lives in its Configure drawer,
+    while data/code source configuration never receives the placement toggle."""
+    monkeypatch.setenv("TESSERAE_EXPERIMENT_COMPOSER", "1")
+    plugin = app.config["PLUGIN_REGISTRY"].get("weather_now")
+    assert plugin is not None
+    plugin.manifest["updates"] = {
+        "on_change": [{"source": "test.weather", "selector_option": "location"}]
+    }
+    client = app.test_client()
+    _sign_in(client)
+
+    resp = client.post(
+        "/pages/canvas/source-form",
+        json={
+            "key": "weather_now",
+            "sid": "e1",
+            "placement": True,
+            "update_on_change": True,
+        },
+    )
+    html = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert 'name="opt_units"' in html
+    assert 'name="update_on_change_present"' in html
+    assert 'name="update_on_change"' in html
+    update_input = html[html.index('name="update_on_change"') :].split(">", 1)[0]
+    assert "checked" in update_input
+
+    source_html = client.post(
+        "/pages/canvas/source-form",
+        json={"key": "weather_now", "sid": "e1", "placement": False},
+    ).get_data(as_text=True)
+    assert 'name="update_on_change"' not in source_html
+
+
 def test_widget_data_live_with_sample_fallback(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
     """The editor's live-data endpoint fetches real data; with no location
     configured, weather_now errors and falls back to its dev-gallery sample so


### PR DESCRIPTION
## What changed

- Moves the host-owned refresh-on-change control into the selected widget's options group in the grid Dashboard editor.
- Moves the same control from the Canvas element inspector into that widget's **Configure** drawer.
- Keeps the value on the individual dashboard placement; it does not enter the plugin options payload, affect another placement, or appear for nested data/code sources.
- Adds focused regression coverage and an Unreleased changelog entry.

## Why

The control was rendered as a separate **Updates** block outside Apple Reminders options. That made a placement-specific behavior look like an unrelated or dashboard-wide setting. Grouping it with the widget options matches where users expect to configure the selected widget while preserving the existing core-owned scope and event contract.

## Validation

- `108 passed` - `tests/test_page_routes.py` and `tests/test_panels.py`
- Ruff check and format check on the touched Python files
- `node --check static/panels/editor.js`
- Browser flow: place a capable widget, confirm no standalone Updates section in the element inspector, open Configure, enable the control, save, reopen, and confirm the checked state persists
