### PR TITLE
PicPak BWRY calibration

### DIFF
--- a/NOTICES.md
+++ b/NOTICES.md
@@ -48,3 +48,21 @@ the calibration data. The presets live in
 [`app/palette_profiles/bundled.py`](app/palette_profiles/bundled.py);
 user-authored profiles are saved to
 `data/palette_profiles/<slug>.json` and follow the same schema.
+
+## varanu5 — PicPak 4.2" BWRY calibration
+
+The 4-colour BWRY calibrated palette (in
+[app/quantizer.py](app/quantizer.py) as `BWRY_4_CALIBRATED_PALETTE`, and
+shipped as the `picpak-bwry-calibrated` preset in
+[`app/palette_profiles/bundled.py`](app/palette_profiles/bundled.py)) was
+measured against a physical PicPak 4.2" black/white/red/yellow panel by
+[varanu5](https://github.com/varanu5), author of the PicPak community
+firmware. epdoptimize carries no BWRY profile, so these values are an
+independent contribution rather than a port.
+
+The preset carries `based_on` and `attribution` fields that surface as a
+"via varanu5" chip on the picker card, the same way the
+paperlesspaper-derived presets do.
+
+* Upstream: https://github.com/varanu5
+* PicPak firmware: https://github.com/varanu5/picpak-tesserae-client

--- a/app/palette_profiles/bundled.py
+++ b/app/palette_profiles/bundled.py
@@ -258,10 +258,10 @@ BUNDLED_PROFILES: tuple[PaletteProfile, ...] = (
         # the card renders it without a link. ``attribution`` exists to point
         # at an upstream project the data was ported from, which does not
         # apply here.
-        based_on="varanu5 · PicPak 4.2\" BWRY panel calibration",
+        based_on='varanu5 · PicPak 4.2" BWRY panel calibration',
         notes=(
             "The colours this panel actually prints, measured from a real PicPak "
-            "4.2\" by varanu5. The default profile aims for perfect ink the screen "
+            '4.2" by varanu5. The default profile aims for perfect ink the screen '
             "can't make (its yellow is closer to mustard than lemon), which can "
             "leave photos looking muddy. Panels vary a little, so copy this "
             "profile and adjust the colours if yours looks off."

--- a/app/palette_profiles/bundled.py
+++ b/app/palette_profiles/bundled.py
@@ -1,17 +1,27 @@
 """Read-only palette presets shipped in the source tree.
 
-Six Spectra 6 profiles + one seven-colour Inky ACeP profile + one
-nominal (uncalibrated identity) fallback. Every measured profile is
-attributed to its upstream source; the palette hex values for the
-paperlesspaper-attributed profiles are the Apache-2.0 palette data
-from `paperlesspaper/epdoptimize
+Grouped by panel family: Spectra 6, seven-colour Inky ACeP, and 4-colour
+BWRY, each with at least one measured profile plus a nominal
+(uncalibrated identity) fallback. Every profile derived from someone
+else's work is attributed to its upstream source; the palette hex values
+for the paperlesspaper-attributed profiles are the Apache-2.0 palette
+data from `paperlesspaper/epdoptimize
 <https://github.com/paperlesspaper/epdoptimize/blob/main/src/dither/data/default-palettes.json>`_.
+The BWRY values were calibrated against a physical PicPak 4.2" panel by
+`varanu5 <https://github.com/varanu5>`_.
 
 Contributors ordered so the picker's default is Tesserae's tuned
 profile (currently equivalent to paperlesspaper's ``spectra6``), then
 the community-measured alternatives in rough popularity order, then
 Nominal at the bottom as the "start over" option. The order the
 picker renders in comes from :func:`list_bundled`.
+
+**BWRY deliberately inverts that**: its nominal profile is listed first
+and is the family default, so unlocking the Calibration tab for PicPak
+panels does not silently restyle frames that already look right. The
+measured presets are one click away. If BWRY should follow the same
+convention as the other families, reorder here and change
+:func:`default_slug_for`.
 
 Attribution surfaces:
 
@@ -44,17 +54,24 @@ def _profile(
     based_on: str | None = None,
     attribution: str | None = None,
     notes: str = "",
+    dither: DitherSettings | None = None,
 ) -> PaletteProfile:
     """Bundled-profile constructor with the defaults every preset uses:
     tone / dither / edges at their neutral values. Fine-tuning is what
-    user profiles are for."""
+    user profiles are for.
+
+    ``dither`` overrides those neutral defaults. The BWRY presets use it
+    to pin ``serpentine=False``, matching what the renderer does when no
+    profile is applied -- ``DitherSettings`` defaults it to True, so
+    without the pin merely having a profile applied would change output.
+    Omitting the argument keeps every pre-existing preset unchanged."""
     return PaletteProfile(
         slug=slug,
         name=name,
         family=family,
         palette=palette,
         tone=ToneSettings(),
-        dither=DitherSettings(),
+        dither=dither if dither is not None else DitherSettings(),
         edges=EdgeSettings(),
         bundled=True,
         based_on=based_on,
@@ -193,6 +210,87 @@ BUNDLED_PROFILES: tuple[PaletteProfile, ...] = (
         ),
         notes="Ideal-primary sRGB values for the 7-colour ACeP palette.",
     ),
+    # --- bwry_4 (PicPak 4.2" black/white/red/yellow) ---------------------
+    # Only the first four slots are used: the quantizer slices a profile
+    # palette to the gamut's length, and BWRY's canonical order (black,
+    # white, yellow, red) is exactly the first four of the shared slot
+    # order, so no remapping is needed. ``blue`` / ``green`` keep their
+    # dataclass defaults and are sliced off before dithering.
+    #
+    # The nominal profile is FIRST and is the family default, so a PicPak
+    # keeps rendering against the ideal primaries unless the user opts
+    # into a measured one. Its dither block pins the renderer's
+    # no-profile defaults (serpentine off, RGB matching) rather than
+    # ``DitherSettings``' own defaults, which differ -- otherwise merely
+    # having a profile applied would change output.
+    _profile(
+        slug="nominal-bwry",
+        name="Nominal BWRY",
+        family="bwry_4",
+        palette=PaletteColors(
+            black="#000000",
+            white="#FFFFFF",
+            yellow="#FFFF00",
+            red="#FF0000",
+        ),
+        dither=DitherSettings(serpentine=False, color_match="rgb"),
+        notes=(
+            "Standard colours, what Tesserae has always used for this panel. "
+            "Kept as the default so existing screens don't suddenly change "
+            "appearance. Try PicPak Calibrated if photos look muddy."
+        ),
+    ),
+    _profile(
+        slug="picpak-bwry-calibrated",
+        name="PicPak Calibrated",
+        family="bwry_4",
+        palette=PaletteColors(
+            black="#242522",
+            white="#ECE9DF",
+            yellow="#DEB428",
+            red="#BC4248",
+        ),
+        # Same dither block as the nominal profile: switching to this
+        # preset must change the palette and nothing else, so the A/B
+        # isolates one variable.
+        dither=DitherSettings(serpentine=False, color_match="rgb"),
+        # ``based_on`` only, no ``attribution``: the credit line is enough and
+        # the card renders it without a link. ``attribution`` exists to point
+        # at an upstream project the data was ported from, which does not
+        # apply here.
+        based_on="varanu5 · PicPak 4.2\" BWRY panel calibration",
+        notes=(
+            "The colours this panel actually prints, measured from a real PicPak "
+            "4.2\" by varanu5. The default profile aims for perfect ink the screen "
+            "can't make (its yellow is closer to mustard than lemon), which can "
+            "leave photos looking muddy. Panels vary a little, so copy this "
+            "profile and adjust the colours if yours looks off."
+        ),
+    ),
+    # Known characteristic of the measured palette, recorded here rather
+    # than worked around: the real red ink is desaturated enough to sit
+    # geometrically next to neutral mid-grey, so grey levels ~80-160 snap
+    # to red under every matching mode. Antialiased text edges live in
+    # that band, so white-on-black and black-on-white text picks up a
+    # small amount of red speckle (~0.4% of pixels on a text-heavy
+    # frame). A preset with a de-neutralised red (#D4242A) removed it
+    # completely but was dropped as unwanted; Nominal remains the clean
+    # choice for text-heavy dashboards.
+    #
+    # NO LAB / chroma-aware preset here, deliberately. ``color_match="lab"``
+    # silently disables dithering. ``_error_diffusion`` builds buf_l / buf_a
+    # / buf_b_lab once from the ORIGINAL image and never writes diffused
+    # error back into them (only buf_r/g/b get the error), yet the LAB
+    # branch makes its nearest-palette decision from those stale buffers.
+    # Every pixel is therefore judged against its pristine value: plain
+    # nearest-colour quantisation, posterised, no dither texture.
+    #
+    # Pre-existing and NOT BWRY-specific. ``_error_diffusion`` never sees a
+    # gamut, and atkinson / jarvis / stucki all call it (floyd-steinberg
+    # detours into it too when LAB is selected), so this hits every
+    # gamut x every error-diffusion dither x both lab and chroma-aware --
+    # measured as 12/12 combinations collapsing a flat patch to one ink
+    # where RGB uses 4 to 7. Ship no preset that steers users onto it.
 )
 
 
@@ -210,6 +308,11 @@ def default_slug_for(family: str) -> str:
     requested family so an unknown gamut still resolves to something."""
     if family == "inky_7colour":
         return "paperlesspaper-inky7"
+    if family == "bwry_4":
+        # Nominal, not measured: unlocking the Calibration tab must not
+        # silently change how existing PicPak panels render. Measured is
+        # one click away in the picker.
+        return "nominal-bwry"
     return "paperlesspaper-spectra6"
 
 

--- a/app/quantizer.py
+++ b/app/quantizer.py
@@ -205,6 +205,27 @@ INKY_7COLOUR_CALIBRATED_PALETTE: tuple[tuple[int, int, int], ...] = (
     (0xF3, 0xCF, 0x11),  # 5 yellow
     (0xB8, 0x5E, 0x1C),  # 6 orange  (brick)
 )
+# 4-colour BWRY (PicPak class). Calibrated against a physical PicPak 4.2"
+# panel by varanu5 <https://github.com/varanu5>, rather than ported from
+# epdoptimize, which carries no BWRY profile. Panel batches drift, so the
+# Calibration tab lets anyone fork these and adjust.
+#
+# The nominal palette these replace is the *ideal* sRGB primaries, and
+# the gap is what makes uncalibrated BWRY output look muddy. Yellow is
+# the worst case: dithering against (255, 255, 0) treats it as a bright
+# highlight, but the ink lays down a dark mustard, so error diffusion
+# picks yellow for highlights it cannot deliver. The reproducible range
+# is also roughly [36, 236], not [0, 255], so an uncalibrated dither
+# over-drives contrast against endpoints the panel never reaches.
+#
+# Order matches BWRY_4_PALETTE (black, white, yellow, red) so the same
+# identity nibble LUT applies and the on-wire bytes are unchanged.
+BWRY_4_CALIBRATED_PALETTE: tuple[tuple[int, int, int], ...] = (
+    (0x24, 0x25, 0x22),  # 0 black   warm near-black, never a true 0
+    (0xEC, 0xE9, 0xDF),  # 1 white   slightly cream paper
+    (0xDE, 0xB4, 0x28),  # 2 yellow  mustard, not lemon
+    (0xBC, 0x42, 0x48),  # 3 red     dusty brick
+)
 
 
 # Panel colour gamuts the .bin packer can target, keyed by the value
@@ -295,6 +316,7 @@ def canonicalise_gamut(declared: str) -> str:
 _CALIBRATED_PALETTES: dict[str, tuple[tuple[int, int, int], ...]] = {
     "waveshare_e6": WAVESHARE_E6_CALIBRATED_PALETTE,
     "inky_7colour": INKY_7COLOUR_CALIBRATED_PALETTE,
+    "bwry_4": BWRY_4_CALIBRATED_PALETTE,
 }
 
 

--- a/app/settings/devices_routes.py
+++ b/app/settings/devices_routes.py
@@ -1677,7 +1677,15 @@ def devices_test_pattern_preview(instance_id: str) -> Response:
         if len(raw) == 7 and raw.startswith("#"):
             with contextlib.suppress(ValueError):
                 swatches.append((int(raw[1:3], 16), int(raw[3:5], 16), int(raw[5:7], 16)))
-    if len(swatches) >= 6:
+    # How many swatches constitute a complete palette for this panel.
+    # BWRY posts four (it has no blue / green ink); EVERY other gamut
+    # keeps the original constant 6, deliberately. Deriving this from
+    # the gamut's palette length reads better but is not behaviour-
+    # neutral: it moves inky_7colour to 7 and the profile-less gamuts
+    # (bwr_3 / mono / gray_4) to 3 / 2 / 4, and this change is scoped to
+    # PicPak only. Leave the rest exactly as they were.
+    required_swatches = 4 if str(params["gamut"]) == "bwry_4" else 6
+    if len(swatches) >= required_swatches:
         palette_override = tuple(swatches)
 
     custom_path = _custom_image_path_for(instance_id)

--- a/app/settings/index_routes.py
+++ b/app/settings/index_routes.py
@@ -417,6 +417,10 @@ def _build_app_field_groups() -> list[dict[str, Any]]:
 
 _TEST_PATTERN_GAMUT_LABELS: dict[str, tuple[str, ...]] = {
     "waveshare_e6": ("black", "white", "yellow", "red", "blue", "green"),
+    # BWRY has no blue or green ink. Without this entry the lookup below
+    # falls back to the E6 row and the solid-fill picker offers a PicPak
+    # two colours it physically cannot paint.
+    "bwry_4": ("black", "white", "yellow", "red"),
     "inky_7colour": (
         "black",
         "white",
@@ -437,6 +441,11 @@ _TEST_PATTERN_GAMUT_HEXES: dict[str, tuple[str, ...]] = {
         "#0000ff",
         "#00ff00",
     ),
+    # Nominal (not measured) primaries: this picker drives a solid-fill
+    # test pattern, whose point is to send the panel a pure palette index
+    # and see what the ink actually does. Feeding it measured values
+    # would beg the question.
+    "bwry_4": ("#000000", "#ffffff", "#ffff00", "#ff0000"),
     "inky_7colour": (
         "#000000",
         "#ffffff",
@@ -543,11 +552,11 @@ def _palette_family_for(device: Device) -> str:
 
     Maps panel gamut to the bundled profile family: ``waveshare_e6`` /
     ``spectra_6`` → ``spectra6``, ``inky_7colour`` / ``acep_7colour``
-    → ``inky_7colour``. Panels without a matching profile family
-    (mono, ``bwry_4``, ``rgb24``, ``rgb16``, unknown gamut) return
-    empty so the section builder can null out every palette endpoint
-    for them; the whole Calibration-tab palette + tone editor then
-    hides on the template side.
+    → ``inky_7colour``, ``bwry_4`` → ``bwry_4``. Panels without a
+    matching profile family (mono, ``rgb24``, ``rgb16``, unknown gamut)
+    return empty so the section builder can null out every palette
+    endpoint for them; the whole Calibration-tab palette + tone editor
+    then hides on the template side.
 
     Empty gamut is treated as ``spectra6`` (legacy default for the
     fleet majority) so devices that haven't declared a gamut yet
@@ -559,9 +568,11 @@ def _palette_family_for(device: Device) -> str:
         return "inky_7colour"
     if gamut in ("waveshare_e6", "spectra_6", ""):
         return "spectra6"
-    # mono, bwry_4, rgb24, rgb16, unknown: no bundled profile family
-    # applies, hide the picker rather than showing incompatible
-    # Spectra 6 profiles as the pre-v0.69.11 default did.
+    if gamut == "bwry_4":
+        return "bwry_4"
+    # mono, rgb24, rgb16, unknown: no bundled profile family applies,
+    # hide the picker rather than showing incompatible Spectra 6
+    # profiles as the pre-v0.69.11 default did.
     return ""
 
 
@@ -585,9 +596,22 @@ def _palette_profile_colors_for(device: Device) -> list[dict[str, str]] | None:
         {"name": "white", "label": "White", "hex": profile.palette.white},
         {"name": "yellow", "label": "Yellow", "hex": profile.palette.yellow},
         {"name": "red", "label": "Red", "hex": profile.palette.red},
-        {"name": "blue", "label": "Blue", "hex": profile.palette.blue},
-        {"name": "green", "label": "Green", "hex": profile.palette.green},
     ]
+    # A 4-ink BWRY panel stops here. ``PaletteColors`` keeps six slots so
+    # the stored schema is identical for every family, but the quantizer
+    # slices a profile palette to the gamut's length, so blue / green are
+    # discarded before dithering. Offering them would be two swatches
+    # that silently do nothing.
+    #
+    # Scoped to bwry_4 on purpose. Trimming by the gamut's palette length
+    # generalises better, but it is not behaviour-neutral for the other
+    # families (a spectra6 profile carrying an orange would lose it), and
+    # this change is meant to touch PicPak only. Every other gamut takes
+    # the original path below unchanged.
+    if _palette_family_for(device) == "bwry_4":
+        return out
+    out.append({"name": "blue", "label": "Blue", "hex": profile.palette.blue})
+    out.append({"name": "green", "label": "Green", "hex": profile.palette.green})
     if profile.palette.orange:
         out.append({"name": "orange", "label": "Orange", "hex": profile.palette.orange})
     return out

--- a/app/test_patterns.py
+++ b/app/test_patterns.py
@@ -22,6 +22,8 @@ from typing import Any
 from PIL import Image, ImageDraw, ImageFont
 
 from app.quantizer import (
+    BWRY_4_CALIBRATED_PALETTE,
+    BWRY_4_PALETTE,
     INKY_7COLOUR_CALIBRATED_PALETTE,
     INKY_7COLOUR_PALETTE,
     WAVESHARE_E6_CALIBRATED_PALETTE,
@@ -37,6 +39,13 @@ _COLOUR_LABELS_E6: tuple[str, ...] = (
     "red",
     "blue",
     "green",
+)
+# 4-ink BWRY. Order matches BWRY_4_PALETTE.
+_COLOUR_LABELS_BWRY: tuple[str, ...] = (
+    "black",
+    "white",
+    "yellow",
+    "red",
 )
 _COLOUR_LABELS_INKY7: tuple[str, ...] = (
     "black",
@@ -58,6 +67,18 @@ def _palette_for(gamut: str, calibrated: bool) -> tuple[tuple[RGB, ...], tuple[s
     if gamut == "inky_7colour":
         pal = INKY_7COLOUR_CALIBRATED_PALETTE if calibrated else INKY_7COLOUR_PALETTE
         return pal, _COLOUR_LABELS_INKY7
+    if gamut == "bwry_4":
+        # Without this the E6 fallback below hands a 4-ink BWRY panel a
+        # six-colour deck, and three things go wrong at once: the swatch
+        # pattern paints blue and green blocks the panel cannot
+        # reproduce; a 4-entry profile palette is silently discarded by
+        # the ``len(palette_override) >= len(palette)`` guard in
+        # :func:`build_pattern`, so the user's chosen profile never
+        # reaches the pattern; and error diffusion carries the
+        # out-of-gamut columns' residue sideways into neighbouring
+        # swatches, speckling them.
+        pal = BWRY_4_CALIBRATED_PALETTE if calibrated else BWRY_4_PALETTE
+        return pal, _COLOUR_LABELS_BWRY
     pal = WAVESHARE_E6_CALIBRATED_PALETTE if calibrated else WAVESHARE_E6_PALETTE
     return pal, _COLOUR_LABELS_E6
 

--- a/tests/test_bwry_calibration.py
+++ b/tests/test_bwry_calibration.py
@@ -270,18 +270,14 @@ def _text_scene(bg, fg):
 
 def _red_fraction(img, palette):
     """Share of pixels painted with the red ink (palette index 3)."""
-    payload = pack_to_panel_bin(
-        img, width=200, height=60, gamut="bwry_4", palette_override=palette
-    )
+    payload = pack_to_panel_bin(img, width=200, height=60, gamut="bwry_4", palette_override=palette)
     idx = []
     for byte in payload:
         idx += [(byte >> 6) & 3, (byte >> 4) & 3, (byte >> 2) & 3, byte & 3]
     return sum(1 for i in idx if i == 3) / len(idx)
 
 
-@pytest.mark.parametrize(
-    ("bg", "fg"), [((0, 0, 0), (255, 255, 255)), ((255, 255, 255), (0, 0, 0))]
-)
+@pytest.mark.parametrize(("bg", "fg"), [((0, 0, 0), (255, 255, 255)), ((255, 255, 255), (0, 0, 0))])
 def test_nominal_leaves_neutral_text_free_of_red(bg, fg):
     """Documents the trade between the two shipped profiles rather than
     asserting one is correct. Nominal keeps neutral text clean; the

--- a/tests/test_bwry_calibration.py
+++ b/tests/test_bwry_calibration.py
@@ -1,0 +1,441 @@
+"""BWRY (PicPak) palette calibration.
+
+The panel cannot reach the ideal sRGB primaries the nominal palette
+targets, so ``bwry_4`` gains a measured calibrated palette and a bundled
+profile family — the same machinery Spectra 6 and Inky 7-colour already
+had. Every assertion about another gamut here exists to prove the change
+is inert outside ``bwry_4``.
+"""
+
+import pytest
+from PIL import Image
+
+from app.palette_profiles.bundled import BUNDLED_PROFILES, default_slug_for, list_bundled
+from app.quantizer import (
+    _CALIBRATED_PALETTES,
+    BWRY_4_CALIBRATED_PALETTE,
+    BWRY_4_PALETTE,
+    pack_to_panel_bin,
+)
+
+
+def _photo(w: int = 40, h: int = 30) -> Image.Image:
+    """A deterministic gradient with colour, so quantiser changes show up."""
+    img = Image.new("RGB", (w, h))
+    px = img.load()
+    for y in range(h):
+        for x in range(w):
+            px[x, y] = ((x * 255) // w, (y * 255) // h, ((x + y) * 255) // (w + h))
+    return img
+
+
+# -- the calibrated palette itself --------------------------------------
+
+
+def test_bwry_calibrated_palette_registered():
+    assert _CALIBRATED_PALETTES["bwry_4"] is BWRY_4_CALIBRATED_PALETTE
+
+
+def test_calibrated_palette_has_one_entry_per_ink():
+    assert len(BWRY_4_CALIBRATED_PALETTE) == len(BWRY_4_PALETTE) == 4
+
+
+def test_calibrated_values_are_inside_the_reproducible_range():
+    """The whole point: no channel reaches the ideal 0 / 255 endpoints."""
+    black, white, yellow, red = BWRY_4_CALIBRATED_PALETTE
+    assert all(c > 0 for c in black), "measured black is not pure black"
+    assert all(c < 255 for c in white), "measured white is not pure white"
+    # Yellow is a mustard, not a lemon: its blue channel is well off zero
+    # and its green channel well below full.
+    assert yellow[1] < 220 and yellow[2] > 20
+    # Red is dusty: darker than ideal, and not fully desaturated.
+    assert red[0] < 255 and red[1] > 20
+
+
+def test_calibrated_palette_changes_bwry_output():
+    """A calibrated render must actually differ from the nominal one."""
+    img = _photo()
+    nominal = pack_to_panel_bin(img, width=40, height=30, gamut="bwry_4", calibrated=False)
+    calibrated = pack_to_panel_bin(img, width=40, height=30, gamut="bwry_4", calibrated=True)
+    assert len(nominal) == len(calibrated) == 40 * 30 // 4
+    assert nominal != calibrated
+
+
+# -- isolation: no other gamut may move ---------------------------------
+
+
+@pytest.mark.parametrize("gamut", ["waveshare_e6", "inky_7colour", "bwr_3", "mono", "gray_4"])
+@pytest.mark.parametrize("calibrated", [False, True])
+def test_other_gamuts_render_byte_identical(gamut, calibrated, monkeypatch):
+    """Render each non-BWRY gamut, then re-render with the bwry_4 entry
+    removed from the calibrated map. Identical bytes prove nothing about
+    these panels reads the new entry."""
+    img = _photo()
+    before = pack_to_panel_bin(img, width=40, height=30, gamut=gamut, calibrated=calibrated)
+
+    patched = dict(_CALIBRATED_PALETTES)
+    patched.pop("bwry_4")
+    monkeypatch.setattr("app.quantizer._CALIBRATED_PALETTES", patched)
+    after = pack_to_panel_bin(img, width=40, height=30, gamut=gamut, calibrated=calibrated)
+
+    assert before == after, f"{gamut} (calibrated={calibrated}) changed"
+
+
+def test_uncalibrated_bwry_is_unchanged(monkeypatch):
+    """A PicPak with no profile applied and ``calibrated=False`` must
+    render exactly as it did before this change. Same removal trick as
+    the other-gamut test: with the new map entry gone, the code takes
+    the literal pre-change path."""
+    img = _photo()
+    after = pack_to_panel_bin(img, width=40, height=30, gamut="bwry_4", calibrated=False)
+
+    patched = dict(_CALIBRATED_PALETTES)
+    patched.pop("bwry_4")
+    monkeypatch.setattr("app.quantizer._CALIBRATED_PALETTES", patched)
+    before = pack_to_panel_bin(img, width=40, height=30, gamut="bwry_4", calibrated=False)
+
+    assert before == after
+
+
+# -- bundled profile family ---------------------------------------------
+
+
+def test_bwry_family_has_profiles():
+    profiles = list_bundled("bwry_4")
+    assert [p.slug for p in profiles] == [
+        "nominal-bwry",
+        "picpak-bwry-calibrated",
+    ]
+
+
+def test_bwry_default_slug_is_nominal():
+    """The default must stay uncalibrated so unlocking the Calibration
+    tab doesn't silently change how existing panels render."""
+    assert default_slug_for("bwry_4") == "nominal-bwry"
+
+
+def test_default_profile_renders_identically_to_no_profile():
+    """Unlocking the Calibration tab auto-applies the family default via
+    the slug self-heal, so that default must be a true no-op: same bytes
+    as a PicPak with no profile at all. This is why the nominal profile
+    pins serpentine=False / color_match="rgb" (the renderer's no-profile
+    defaults) instead of inheriting DitherSettings' own, which differ."""
+    from app.palette_profiles.bundled import bundled_profile
+
+    img = _photo(60, 40)
+    no_profile = pack_to_panel_bin(img, width=60, height=40, gamut="bwry_4")
+
+    nom = bundled_profile("nominal-bwry")
+    with_default = pack_to_panel_bin(
+        img,
+        width=60,
+        height=40,
+        gamut="bwry_4",
+        palette_override=nom.palette.as_tuples(),
+        serpentine=nom.dither.serpentine,
+        color_match=nom.dither.color_match,
+        diffusion_strength=nom.dither.diffusion_strength,
+    )
+    assert no_profile == with_default
+
+
+def test_nominal_profile_mirrors_the_long_standing_palette():
+    """``nominal-bwry`` is a new object wrapping old values: it must stay
+    an exact copy of BWRY_4_PALETTE, the palette every PicPak frame has
+    been dithered against since bwry_4 support landed. Without this,
+    editing either one could let them drift apart silently."""
+    from app.palette_profiles.bundled import bundled_profile
+
+    nom = bundled_profile("nominal-bwry")
+    assert nom.palette.as_tuples()[:4] == BWRY_4_PALETTE
+
+
+def test_measured_differs_from_nominal_only_by_palette():
+    """The two non-LAB presets must share a dither block so switching
+    between them is a clean single-variable A/B."""
+    from app.palette_profiles.bundled import bundled_profile
+
+    nom = bundled_profile("nominal-bwry")
+    meas = bundled_profile("picpak-bwry-calibrated")
+    assert nom.dither == meas.dither
+    assert nom.palette.as_tuples() != meas.palette.as_tuples()
+
+
+def test_other_families_keep_their_defaults():
+    assert default_slug_for("spectra6") == "paperlesspaper-spectra6"
+    assert default_slug_for("inky_7colour") == "paperlesspaper-inky7"
+
+
+def test_existing_profiles_untouched_by_the_dither_kwarg():
+    """``_profile`` gained an optional ``dither`` argument; every
+    pre-existing preset must still carry the neutral defaults."""
+    for p in BUNDLED_PROFILES:
+        if p.family == "bwry_4":
+            continue
+        assert p.dither.color_match == "rgb"
+        assert p.dither.algorithm == "floyd-steinberg"
+        assert p.dither.diffusion_strength == 100
+
+
+def test_no_bundled_profile_selects_lab_matching():
+    """``color_match="lab"`` silently disables dithering (see the next
+    test), so no shipped preset may steer users onto it."""
+    for p in BUNDLED_PROFILES:
+        assert p.dither.color_match == "rgb", f"{p.slug} selects {p.dither.color_match}"
+
+
+def test_lab_matching_still_loses_dither_feedback():
+    """Regression guard documenting a PRE-EXISTING upstream bug, not a
+    BWRY one: ``_error_diffusion`` builds its LAB buffers once from the
+    original image and never writes diffused error back into them, while
+    the LAB branch reads those stale buffers to pick the nearest ink.
+    Every pixel is judged against its pristine value, so error diffusion
+    is ignored and the result is plain nearest-colour quantisation.
+
+    ``_error_diffusion`` never sees a gamut and is shared by atkinson /
+    jarvis / stucki (floyd-steinberg detours into it when LAB is
+    selected), so this affects every gamut and every error-diffusion
+    dither, under both ``lab`` and ``chroma-aware``.
+
+    Signature: a flat patch must dither into a MIX of inks. Under LAB it
+    collapses to a single ink. If this test starts failing, the upstream
+    bug was fixed and a LAB preset becomes worth reconsidering."""
+    from collections import Counter
+
+    palette = ((36, 37, 34), (236, 233, 223), (222, 180, 40), (188, 66, 72))
+    flat = Image.new("RGB", (40, 40), (128, 128, 128))
+
+    def ink_count(match: str, dither: str) -> int:
+        payload = pack_to_panel_bin(
+            flat,
+            width=40,
+            height=40,
+            gamut="bwry_4",
+            dither=dither,
+            color_match=match,
+            palette_override=palette,
+        )
+        idx = []
+        for byte in payload:
+            idx += [(byte >> 6) & 3, (byte >> 4) & 3, (byte >> 2) & 3, byte & 3]
+        return len(Counter(idx))
+
+    # Every error-diffusion dither routes through the same function, so
+    # every one of them loses the feedback.
+    for dither in ("floyd-steinberg", "atkinson", "jarvis", "stucki"):
+        assert ink_count("rgb", dither) > 1, f"{dither}+rgb should mix inks"
+        for match in ("lab", "chroma-aware"):
+            assert ink_count(match, dither) == 1, (
+                f"{dither}+{match} no longer collapses — upstream bug may be fixed, "
+                "in which case a LAB preset is worth reconsidering"
+            )
+
+
+def test_bwry_profile_palette_slices_to_the_four_inks():
+    """The shared six-slot schema must line up with BWRY's ink order so
+    the quantizer's ``palette_override[:4]`` slice is correct."""
+    measured = next(p for p in BUNDLED_PROFILES if p.slug == "picpak-bwry-calibrated")
+    tuples = measured.palette.as_tuples()
+    assert tuples[:4] == BWRY_4_CALIBRATED_PALETTE
+
+
+def test_profile_override_beats_nominal_for_bwry():
+    img = _photo()
+    measured = next(p for p in BUNDLED_PROFILES if p.slug == "picpak-bwry-calibrated")
+    plain = pack_to_panel_bin(img, width=40, height=30, gamut="bwry_4")
+    with_profile = pack_to_panel_bin(
+        img,
+        width=40,
+        height=30,
+        gamut="bwry_4",
+        palette_override=measured.palette.as_tuples(),
+    )
+    assert plain != with_profile
+
+
+# -- text speckle --------------------------------------------------------
+
+
+def _text_scene(bg, fg):
+    """Antialiased text on a flat background: the case that exposes the
+    measured red sitting next to neutral grey."""
+    from PIL import ImageDraw
+
+    img = Image.new("RGB", (200, 60), bg)
+    draw = ImageDraw.Draw(img)
+    draw.text((8, 8), "Sharp Text 123", fill=fg)
+    draw.text((8, 30), "Hello Panel", fill=fg)
+    return img
+
+
+def _red_fraction(img, palette):
+    """Share of pixels painted with the red ink (palette index 3)."""
+    payload = pack_to_panel_bin(
+        img, width=200, height=60, gamut="bwry_4", palette_override=palette
+    )
+    idx = []
+    for byte in payload:
+        idx += [(byte >> 6) & 3, (byte >> 4) & 3, (byte >> 2) & 3, byte & 3]
+    return sum(1 for i in idx if i == 3) / len(idx)
+
+
+@pytest.mark.parametrize(
+    ("bg", "fg"), [((0, 0, 0), (255, 255, 255)), ((255, 255, 255), (0, 0, 0))]
+)
+def test_nominal_leaves_neutral_text_free_of_red(bg, fg):
+    """Documents the trade between the two shipped profiles rather than
+    asserting one is correct. Nominal keeps neutral text clean; the
+    measured palette speckles it lightly, because the real red ink sits
+    next to neutral mid-grey and antialiased edges land in that band.
+    That is a known characteristic, not a regression."""
+    from app.palette_profiles.bundled import bundled_profile
+
+    img = _text_scene(bg, fg)
+    nominal = bundled_profile("nominal-bwry").palette.as_tuples()[:4]
+    measured = bundled_profile("picpak-bwry-calibrated").palette.as_tuples()[:4]
+
+    assert _red_fraction(img, nominal) == 0.0
+    assert _red_fraction(img, measured) > 0.0, "measured is expected to speckle"
+
+
+# -- test patterns -------------------------------------------------------
+
+
+def test_test_pattern_palette_is_the_bwry_deck():
+    """``_palette_for`` fell through to the six-colour E6 deck for
+    bwry_4. Three things broke at once: the swatch pattern painted blue
+    and green blocks the panel cannot reproduce, a 4-entry profile
+    palette was silently discarded by build_pattern's
+    ``len(override) >= len(palette)`` guard, and error diffusion carried
+    the out-of-gamut columns sideways into their neighbours."""
+    from app.test_patterns import _palette_for
+
+    pal, labels = _palette_for("bwry_4", False)
+    assert pal == BWRY_4_PALETTE
+    assert labels == ("black", "white", "yellow", "red")
+    assert "blue" not in labels and "green" not in labels
+
+    cal, _ = _palette_for("bwry_4", True)
+    assert cal == BWRY_4_CALIBRATED_PALETTE
+
+
+def test_other_gamuts_keep_their_test_pattern_decks():
+    from app.quantizer import INKY_7COLOUR_PALETTE, WAVESHARE_E6_PALETTE
+    from app.test_patterns import _palette_for
+
+    assert _palette_for("waveshare_e6", False)[0] == WAVESHARE_E6_PALETTE
+    assert _palette_for("inky_7colour", False)[0] == INKY_7COLOUR_PALETTE
+    # Unknown gamuts still fall back to E6 rather than raising.
+    assert _palette_for("something_new", False)[0] == WAVESHARE_E6_PALETTE
+
+
+def test_bwry_profile_reaches_the_swatch_pattern():
+    """The override guard needs the deck length to match, otherwise the
+    user's chosen profile never affects the pattern they send."""
+    import io
+
+    from app.palette_profiles.bundled import bundled_profile
+    from app.test_patterns import build_pattern
+
+    pal = bundled_profile("picpak-bwry-calibrated").palette.as_tuples()[:4]
+    png = build_pattern("palette_swatches", 400, 300, gamut="bwry_4", palette_override=pal)
+    img = Image.open(io.BytesIO(png)).convert("RGB")
+    # Four even columns; sample the middle of each, above the label.
+    for i, expected in enumerate(pal):
+        assert img.getpixel((i * 100 + 50, 10)) == expected, f"column {i}"
+
+
+# -- UI surfaces ---------------------------------------------------------
+
+
+def _device(app, gamut: str):
+    from app.device_loader import Device
+
+    reg = app.config["DEVICE_REGISTRY"]
+    base = reg.devices["picpak_4_2"]
+    return Device(
+        id="t",
+        path=base.path,
+        manifest={**base.manifest, "panel": {"w": 400, "h": 300, "gamut": gamut}},
+        module=base.module,
+        data_dir=base.data_dir,
+        kind_of="picpak_4_2",
+    )
+
+
+def test_bwry_swatch_grid_omits_blue_and_green(app):
+    from app.settings.index_routes import _palette_profile_colors_for
+
+    with app.test_request_context():
+        colors = _palette_profile_colors_for(_device(app, "bwry_4"))
+        assert [c["name"] for c in colors] == ["black", "white", "yellow", "red"]
+
+
+def test_only_bwry_is_trimmed(app):
+    """The swatch trim must apply to PicPak and nothing else. Trimming by
+    the gamut's palette length generalises better but is not behaviour-
+    neutral for other families, so it is deliberately not done."""
+    from app.settings.index_routes import _palette_profile_colors_for
+
+    with app.test_request_context():
+        assert len(_palette_profile_colors_for(_device(app, "bwry_4"))) == 4
+        # Everything else keeps the full six-slot grid it always had.
+        for gamut in ("waveshare_e6", "spectra_6", ""):
+            colors = _palette_profile_colors_for(_device(app, gamut))
+            assert len(colors) == 6, f"{gamut!r} grid changed"
+
+
+def test_inky_preview_threshold_is_unchanged():
+    """Regression guard for a real hazard: an earlier revision derived
+    this threshold from the gamut, which silently moved inky_7colour from
+    6 required swatches to 7. Non-BWRY gamuts must keep the constant."""
+    import inspect
+
+    from app.settings import devices_routes
+
+    src = inspect.getsource(devices_routes.devices_test_pattern_preview)
+    assert 'required_swatches = 4 if str(params["gamut"]) == "bwry_4" else 6' in src
+
+
+def test_spectra6_swatch_grid_still_has_six(app):
+    from app.settings.index_routes import _palette_profile_colors_for
+
+    with app.test_request_context():
+        colors = _palette_profile_colors_for(_device(app, "waveshare_e6"))
+        assert [c["name"] for c in colors] == [
+            "black",
+            "white",
+            "yellow",
+            "red",
+            "blue",
+            "green",
+        ]
+
+
+def test_bwry_now_self_heals_onto_its_own_family(app):
+    """The inverse of the old "unsupported gamut" behaviour: a BWRY
+    device with no stored slug is backfilled with the BWRY default, not
+    left blank and not forced onto a Spectra 6 profile."""
+    from app.settings.index_routes import _palette_profile_slug_for
+
+    with app.test_request_context():
+        slug = _palette_profile_slug_for(_device(app, "bwry_4"))
+        assert slug == "nominal-bwry"
+
+
+def test_mono_still_has_no_family(app):
+    """Gamuts that genuinely have no bundled family must stay hidden."""
+    from app.settings.index_routes import _palette_family_for
+
+    with app.test_request_context():
+        assert _palette_family_for(_device(app, "mono")) == ""
+        assert _palette_family_for(_device(app, "bwry_4")) == "bwry_4"
+
+
+def test_test_pattern_colors_exclude_inks_bwry_lacks(app):
+    from app.settings.index_routes import _test_pattern_colors_for
+
+    with app.test_request_context():
+        labels = [c["label"] for c in _test_pattern_colors_for(_device(app, "bwry_4"))]
+        assert labels == ["black", "white", "yellow", "red"]
+        assert "blue" not in labels and "green" not in labels

--- a/tests/test_palette_routes.py
+++ b/tests/test_palette_routes.py
@@ -417,9 +417,13 @@ def test_slug_self_heal_on_empty_slug_for_supported_family(app: Flask, tmp_path:
 
 
 def test_slug_self_heal_leaves_unsupported_gamut_alone(app: Flask, tmp_path: Path) -> None:
-    """Panels whose gamut has no matching profile family (mono / bwry_4
-    / rgb24 / rgb16) should still hide the palette section, not get
-    forced onto a Spectra 6 profile."""
+    """Panels whose gamut has no matching profile family (mono / rgb24
+    / rgb16) should still hide the palette section, not get forced onto
+    a Spectra 6 profile.
+
+    Used ``bwry_4`` as the example until that gamut gained its own
+    bundled family; ``mono`` is now the stand-in, which is what this
+    test's own "force gamut to mono" comment always intended."""
     from app.settings.index_routes import _palette_profile_slug_for, _palette_profile_tone_for
 
     client = app.test_client()
@@ -442,7 +446,7 @@ def test_slug_self_heal_leaves_unsupported_gamut_alone(app: Flask, tmp_path: Pat
         w=device.panel["w"],
         h=device.panel["h"],
         orientation=device.panel.get("orientation", "landscape"),
-        gamut="bwry_4",
+        gamut="mono",
     )
     with app.test_request_context():
         device = app.config["DEVICE_REGISTRY"].get(dev)

--- a/tests/test_settings_routes.py
+++ b/tests/test_settings_routes.py
@@ -694,20 +694,22 @@ def test_device_card_exposes_picture_quality(app_with_gate: Flask) -> None:
     assert 'name="pi_bin__pi_lab:contrast"' in body
 
 
-def test_calibration_tone_dither_survives_bwry_gamut(app_with_gate: Flask) -> None:
+def test_calibration_tone_dither_survives_familyless_gamut(app_with_gate: Flask) -> None:
     """Issue #52 follow-up (r/eink launch feedback, bablokb): the
     renderer picture-quality block (Contrast / Saturation / Dither)
     used to be nested inside the palette-recalibration ``{% if %}``
     guard. Panels whose gamut has no matching palette family
-    (bwry_4 / mono / rgb24 / rgb16) get ``palette_apply_endpoint =
-    None``, so a save that resolved gamut to bwry_4 silently dropped
-    the whole picture-quality block along with the palette one. The
-    block is now guarded independently so the tone & dither sliders
-    remain visible on non-Spectra-6 panels."""
+    (mono / rgb24 / rgb16) get ``palette_apply_endpoint = None``, so
+    such a save silently dropped the whole picture-quality block along
+    with the palette one. The block is now guarded independently so the
+    tone & dither sliders remain visible on non-Spectra-6 panels.
+
+    Used ``bwry_4`` as the familyless example until that gamut gained
+    its own bundled profile family; ``mono`` carries the case now."""
     client = app_with_gate.test_client()
     client.post("/setup", data={"password": "abcdefgh", "password_confirm": "abcdefgh"})
     client.post("/settings/devices/add", data={"id": "kitchen_pi", "kind": "pi_bin_client"})
-    # Save with bwry_4 gamut (Inky4 legacy path).
+    # Save with a gamut that has no bundled palette family.
     client.post(
         "/settings/devices/kitchen_pi/save",
         data={
@@ -716,14 +718,14 @@ def test_calibration_tone_dither_survives_bwry_gamut(app_with_gate: Flask) -> No
             "panel_w": "640",
             "panel_h": "400",
             "panel_orientation": "landscape",
-            "panel_gamut": "bwry_4",
+            "panel_gamut": "mono",
             "quiet_hours_enabled": "0",
             "pi_bin__kitchen_pi:saturation": "1.5",
         },
     )
     body = client.get("/settings/devices").get_data(as_text=True)
-    # Palette recalibration block correctly hidden for a bwry_4 gamut
-    # (no matching palette family).
+    # Palette recalibration block correctly hidden for a familyless
+    # gamut (no matching palette family).
     assert "Palette recalibration" not in body
     # But the tone & dither picture-quality block MUST still render.
     assert "Pi BIN client — tone" in body


### PR DESCRIPTION
# Palette calibration support for the 4-colour BWRY gamut (PicPak)

## Summary

`bwry_4` is the only supported gamut with no palette-profile family, so the
Calibration tab hides entirely for those panels and frames are always dithered
against the ideal sRGB primaries. This adds the missing family and a calibrated
palette, using the machinery Spectra 6 and Inky 7-colour already have.

Everything is scoped to `bwry_4`. No other panel changes behaviour — see
[Isolation](#isolation) for how that is enforced.

Validated on a physical PicPak 4.2" panel, not only in tests.

## Why

`BWRY_4_PALETTE` targets `(0,0,0) / (255,255,255) / (255,255,0) / (255,0,0)`.
Real BWRY ink reaches none of those. Yellow is the worst case: the quantiser
treats `(255,255,0)` as a bright highlight while the panel lays down a dark
mustard, so error diffusion spends yellow on highlights the ink cannot deliver.
The reproducible range is roughly `[36, 236]`, not `[0, 255]`, so an
uncalibrated dither also over-drives contrast against endpoints that do not
exist.

`_CALIBRATED_PALETTES` plus `_compress_to_calibrated_range` already solve this
for other gamuts, but the map only held `waveshare_e6` and `inky_7colour`, so
the calibrated path was unreachable for BWRY. Separately,
`_palette_family_for()` returned `""` for `bwry_4`, which null-gates every
palette endpoint and hides the editor.

## What changed

**`app/quantizer.py`**
- Adds `BWRY_4_CALIBRATED_PALETTE` and registers it in `_CALIBRATED_PALETTES`.
  Measured against a physical PicPak 4.2" panel by
  [varanu5](https://github.com/varanu5); epdoptimize carries no BWRY profile, so
  these are an independent contribution rather than a port.

**`app/palette_profiles/bundled.py`**
- Adds a `bwry_4` family with two presets:

  | preset | slug | purpose |
  |---|---|---|
  | **Nominal BWRY** | `nominal-bwry` | **family default.** Ideal primaries — byte-identical to having no profile applied. |
  | **PicPak Calibrated** | `picpak-bwry-calibrated` | Measured palette. Carries `based_on` so the picker card credits the source. |
- `_profile()` gains an optional `dither=` argument. Every pre-existing preset
  omits it and constructs exactly as before.

**`app/settings/index_routes.py`**
- `_palette_family_for()` maps `bwry_4` to its own family, after the existing
  Inky and Spectra branches.
- The swatch grid drops blue/green for BWRY. `PaletteColors` keeps six slots so
  the stored schema is unchanged for every family, but the quantiser slices a
  profile palette to the gamut's length, so those two would be controls that
  silently do nothing.
- Adds `bwry_4` rows to the test-pattern label/hex maps, so the solid-fill
  picker stops offering a BWRY panel blue and green it cannot paint.

**`app/test_patterns.py`**
- `_palette_for()` knew `inky_7colour` and fell through to the six-colour E6
  deck for everything else, `bwry_4` included. Three failures followed from that
  one gap, all visible when sending **Palette swatches** to a real panel:
  - the pattern painted blue and green blocks the panel has no ink for;
  - `build_pattern` discards an override shorter than the deck
    (`len(override) >= len(palette)`), so a 4-entry BWRY profile never reached
    the pattern and the user's chosen profile had no effect on what was sent;
  - Floyd-Steinberg diffuses error rightward, so the out-of-gamut yellow column
    bled into the red column and speckled it.

**`app/settings/devices_routes.py`**
- The live-preview swatch threshold was a hardcoded `6`; BWRY posts four.

**`NOTICES.md`** — attribution section for the BWRY calibration data.

## Design notes

**The default is deliberately the *uncalibrated* profile.** This inverts the
convention used by the other families, where the default is measured and Nominal
sits last as the "start over" option. The reason: `_palette_profile_slug_for()`
self-heals a blank slug to the family default and persists it, so shipping a
calibrated default would silently restyle every existing BWRY panel on next
render. `nominal-bwry` renders byte-identical to no profile at all, which a test
asserts.

Making that true required pinning `serpentine=False` on the presets —
`DitherSettings` defaults it to `True` while the renderer's no-profile path
defaults it to `False`, so without the pin merely *having* a profile applied
would change output.

If you would rather BWRY follow the same convention as the other families,
reorder the presets in `bundled.py` and change `default_slug_for()`; the
docstring records this.

## Known characteristics, documented rather than worked around

**Light red speckle on neutral text under the calibrated palette.** The real red
ink is desaturated enough to sit next to neutral mid-grey in colour space, so
grey levels ~80–160 snap to red — and antialiased text edges live in that band.
Roughly 0.4% of pixels on a text-heavy frame. A preset with a de-neutralised red
removed it entirely but was dropped as unwanted; **Nominal BWRY** stays clean
here and remains the right choice for text-heavy dashboards.

**Text softening on yellow / red backgrounds** (black pixels 293 → 228 on a
200×60 text scene). That is `_compress_to_calibrated_range` reducing source
contrast before dithering, not a palette problem. It cannot be disabled from a
profile, and fixing it means changing behaviour shared with Spectra 6 and Inky,
so it is deliberately out of scope.

**The swatch pattern is a poor instrument for judging a calibrated profile.**
The swatch is filled with the ink's own value, but the compression pass then
maps it off that value (`212,36,42 → 202,65,65`), so it can never land cleanly
and will always dither (red 78% vs Nominal's 100% flat). Judge on real content.

## Isolation

Every gamut-keyed addition is additive (new dict keys, new list entries) and
read only when the gamut matches. The one shared-code edit is the optional
`dither=` parameter on `_profile()`; every pre-existing preset omits it and
constructs identically.

Verified empirically rather than by inspection:
- All 7 pre-existing bundled profiles serialise **byte-identical** to `main`.
- `_palette_for()` compared across 14 gamuts × 2 calibrated settings — `bwry_4`
  is the only one that differs; unknown gamuts still fall back to E6.
- `waveshare_e6`, `inky_7colour`, `bwr_3`, `mono` and `gray_4` render
  byte-identical with the new `_CALIBRATED_PALETTES` entry present versus
  monkeypatched out, at both `calibrated` settings.
- Uncalibrated `bwry_4` is byte-identical too, so panels without a profile are
  unaffected.
- Non-BWRY swatch grids stay six-slot, and the preview threshold expression is
  pinned by a test — an earlier revision generalised it by gamut and silently
  moved `inky_7colour` from 6 required swatches to 7.

## Upstream bug found along the way (not fixed here)

Surfaced by painting a LAB-matching preset to a real panel: blues came out solid
black and greens solid yellow, with no dither texture anywhere.

`color_match="lab"` silently disables dithering. In `_error_diffusion`, the
`buf_l` / `buf_a` / `buf_b_lab` buffers are built once from the original image
and never receive diffused error — only `buf_r/g/b` do — yet the LAB branch
picks the nearest ink by reading those stale buffers. Every pixel is judged
against its pristine value, so error diffusion is ignored entirely and the
output is plain nearest-colour quantisation.

Signature, on a flat 40×40 mid-grey patch:

```
color_match=rgb  ->  white 48%, black 47%, red 3%
color_match=lab  ->  white 100%
```

**This is not BWRY-specific, and not Floyd-Steinberg-specific.**
`_error_diffusion` never sees a gamut, and `atkinson` / `jarvis` / `stucki` all
call it directly (`floyd-steinberg` detours into it when LAB is selected).
Measured across every combination — a flat patch collapses to **one ink in
12/12** gamut × dither pairings, under both `lab` and `chroma-aware`, where RGB
uses 4 to 7:

| gamut | rgb | lab / chroma-aware |
|---|---|---|
| `bwry_4` (4 inks) | 4 inks | **1** |
| `waveshare_e6` (6 inks) | 6 inks | **1** |
| `inky_7colour` (7 inks) | 5–7 inks | **1** |

So a Spectra 6 or Inky user who selects LAB matching in the Calibration tab —
which is offered as a live control — gets a posterised frame with no dither
texture at all.

Fixing it means recomputing LAB per pixel after each error write, inside a
Python hot loop shared by every panel, so it is out of scope for this PR. No
preset here selects LAB matching, and `tests/test_bwry_calibration.py` carries a
regression guard across all four dithers and both LAB modes that will fail once
the bug is fixed — at which point a LAB preset becomes worth adding.

Recorded here because it is the reason this PR ships no LAB preset, and because
the investigation turned it up. Nothing in this PR depends on it being fixed —
lift it into its own issue if that suits your tracking better.

## Testing

- `tests/test_bwry_calibration.py` — 38 tests covering the palette, the profile
  family, the test-pattern deck, the UI surfaces and the isolation guarantees.
- Two existing tests used `bwry_4` as their stand-in for "a gamut with no
  profile family", a premise this PR reverses. They now use `mono`, which is
  what one of them already said in its own comment. Their assertions are
  otherwise unchanged.
- 710 passing across the palette / quantiser / render / settings / device
  suites. `ruff` clean.

## Hardware validation

Tested visually on a real PicPak 4.2" BWRY panel.

- **Nominal BWRY** — byte-identical to no profile applied (asserted by test),
  i.e. the output this panel has always produced.
- **PicPak Calibrated** — painted to the panel. The red speckle on antialiased
  text and the softening on yellow/red backgrounds were both **observed on glass
  first**; the numbers quoted above were derived afterwards to explain them.
- The palette-swatches bug above was found the same way — by sending the pattern
  to the panel and noticing blue and green blocks it cannot print.
- A LAB-matching preset was built, painted, and **rejected on the panel**, which
  is what led to the upstream bug.

Caveat: the values come from one panel, and batches vary. The profile notes
point users at forking the preset and adjusting the swatches.