### PR TITLE
Widget/calendar native refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ All notable changes to Tesserae are recorded here. Format loosely follows
   always accepted anything up to a day, but a value the dropdown didn't offer
   had no matching option and the list drew it as "only when pushed", so opening
   the dropdown and picking anything silently rewrote it.
+- **All-day events no longer disappear from calendar_day/week/month/schedule
+  in the evening.** Every calendar widget's shared event-fetching layer
+  compared an all-day event's date against the requested time window as if
+  both were full timestamps; once the UTC calendar day rolled past local
+  midnight — any evening in a timezone behind UTC, such as US timezones —
+  today's all-day events silently dropped out of the response.
+- **calendar_day's all-day events span the full width of the event column.**
+  They were laid out in a wrapping flex row, so each pill was only as wide as
+  its own title and stopped short of the column's right edge, reading as a
+  small tag instead of a bar covering the day it applies to.
 
 ## [0.283.0], 2026-08-09
 
@@ -439,6 +449,17 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Fixed
 
+- **Multi-day events now display correctly in calendar_day and
+  calendar_week.** A multi-day all-day event (e.g. a 3-day conference)
+  previously appeared only on its first day, or as a separately-labeled
+  pill repeated on each day instead of one bar spanning them. A
+  multi-day *timed* event (an overnight block, a multi-day trip) is a
+  more common case and had it worse: it vanished entirely after its
+  first day, could render at the wrong time or run past midnight on
+  later days, and could overflow the visible timetable when
+  `day_start_hour`/`day_end_hour` narrowed it. All-day pills in both
+  widgets could also draw shifted left of their true day column. Every
+  day an event covers now renders correctly clamped to that day.
 - **Personal-data snapshots are isolated per paired Companion installation.**
   Independently identified household phones can publish Apple Reminders
   without replacing each other, each phone sees only its own sync status, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -424,6 +424,19 @@ All notable changes to Tesserae are recorded here. Format loosely follows
   already-registered device. The client protocol doc now spells out the
   attribute's behaviour on both `/discover` and `/register`.
 
+### Added
+
+- **Configurable text sizing for calendar_day, calendar_week, and
+  calendar_month.** Per-text-type scale sliders (title, header, axis
+  label, event title/location/time, 0.01–10.0×), a `date_label_style`
+  choice with a full-word option, and a `show_location` toggle for
+  the widgets that lacked one. calendar_day also gets configurable
+  `day_start_hour`/`day_end_hour` and a `show_density` toggle;
+  calendar_week gets a `range_mode` option so its 7-day window can
+  either stay anchored to the chosen week-start day or roll from
+  today (`rolling_7`), and correctly labels/shades each day by its
+  actual weekday rather than its column position in either mode.
+
 ### Fixed
 
 - **Personal-data snapshots are isolated per paired Companion installation.**

--- a/app/calendar_time.py
+++ b/app/calendar_time.py
@@ -11,6 +11,18 @@ def local_midnight_utc(day: date, zone: tzinfo) -> datetime:
     return datetime.combine(day, time.min, tzinfo=zone).astimezone(UTC)
 
 
+def _local_datetime(raw: str, zone: tzinfo) -> datetime | None:
+    if not raw:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(zone)
+
+
 def event_local_date_key(event: dict[str, Any], zone: tzinfo) -> str:
     """Bucket a calendar event by the date a user sees in ``zone``."""
     start = str(event.get("start") or "")
@@ -18,13 +30,42 @@ def event_local_date_key(event: dict[str, Any], zone: tzinfo) -> str:
         return ""
     if event.get("all_day") or "T" not in start:
         return start.split("T")[0]
-    try:
-        parsed = datetime.fromisoformat(start)
-    except ValueError:
-        return start.split("T")[0]
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=UTC)
-    return parsed.astimezone(zone).date().isoformat()
+    local = _local_datetime(start, zone)
+    return local.date().isoformat() if local else start.split("T")[0]
+
+
+def timed_event_date_keys(
+    event: dict[str, Any], zone: tzinfo, window_start: date, window_end: date
+) -> list[str]:
+    """Return local date keys a timed (non-all-day) event's [start, end)
+    span occupies inside ``[window_start, window_end)``.
+
+    A multi-day timed event (an overnight block, or a genuinely
+    multi-day timed span) must appear in every day's bucket it runs
+    through, not just the day it starts — otherwise it silently
+    vanishes from every day after the first.
+    """
+    start_raw = str(event.get("start") or "")
+    start_local = _local_datetime(start_raw, zone)
+    if start_local is None:
+        return [start_raw.split("T")[0]] if start_raw else []
+    end_local = _local_datetime(str(event.get("end") or ""), zone) or start_local
+
+    start_date = start_local.date()
+    end_date = end_local.date()
+    # End is exclusive: an event ending exactly at local midnight doesn't
+    # spill into that next day (same convention as all-day DTEND).
+    if end_date > start_date and end_local.time() == time.min:
+        end_date -= timedelta(days=1)
+    end_date = max(start_date, end_date)
+
+    cur = max(start_date, window_start)
+    stop = min(end_date + timedelta(days=1), window_end)
+    keys: list[str] = []
+    while cur < stop:
+        keys.append(cur.isoformat())
+        cur += timedelta(days=1)
+    return keys
 
 
 def _all_day_bounds(event: dict[str, Any]) -> tuple[date, date] | None:

--- a/plugins/calendar_core/server.py
+++ b/plugins/calendar_core/server.py
@@ -281,11 +281,26 @@ def _expand_events_cached(
     # Slice the warm-cached list to the widget's specific window.
     start_iso = start.astimezone(UTC).isoformat()
     end_iso = end.astimezone(UTC).isoformat()
-    return [
-        e
-        for e in events
-        if (e.get("end") or e.get("start", "")) >= start_iso and (e.get("start") or "") < end_iso
-    ]
+    # All-day events store bare "YYYY-MM-DD" dates (no timezone), which
+    # can't compare correctly against the full UTC datetime bounds above:
+    # a bare date string sorts as "less than" any same-day timestamp
+    # string, so once the UTC calendar day rolls past local midnight
+    # (e.g. any evening in a negative-UTC-offset timezone), today's
+    # all-day event silently drops out. Widen by a day on each side for
+    # all-day events instead — every widget already re-filters all-day
+    # events against the real local date downstream, so over-inclusion
+    # here is harmless.
+    all_day_start = (start - timedelta(days=1)).date().isoformat()
+    all_day_end = (end + timedelta(days=1)).date().isoformat()
+
+    def _in_window(e: dict[str, Any]) -> bool:
+        if e.get("all_day"):
+            return (e.get("end") or e.get("start", "")) >= all_day_start and (
+                e.get("start") or ""
+            ) < all_day_end
+        return (e.get("end") or e.get("start", "")) >= start_iso and (e.get("start") or "") < end_iso
+
+    return [e for e in events if _in_window(e)]
 
 
 # Public API for the calendar_* widgets uses the cached path. Direct

--- a/plugins/calendar_core/server.py
+++ b/plugins/calendar_core/server.py
@@ -298,7 +298,9 @@ def _expand_events_cached(
             return (e.get("end") or e.get("start", "")) >= all_day_start and (
                 e.get("start") or ""
             ) < all_day_end
-        return (e.get("end") or e.get("start", "")) >= start_iso and (e.get("start") or "") < end_iso
+        return (e.get("end") or e.get("start", "")) >= start_iso and (
+            e.get("start") or ""
+        ) < end_iso
 
     return [e for e in events if _in_window(e)]
 

--- a/plugins/calendar_day/client.js
+++ b/plugins/calendar_day/client.js
@@ -78,6 +78,64 @@ function fmtHm(iso) {
   return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 }
 
+// A timed (non-all-day) event's end can land on a different local
+// calendar day than its start (an overnight event, or a genuinely
+// multi-day timed block like a trip). Subtracting raw hour-of-day
+// across two different dates is meaningless — it previously produced
+// negative/near-zero heights and corrupted computeRange's auto-fit
+// window. Treat "ends on a later day" as "runs to the bottom of this
+// day" instead.
+function eventEndHour(ev, s) {
+  const e = parseTime(ev.end);
+  if (e == null) return s != null ? s + 1 : null;
+  if (s == null) return e;
+  const sameDay = new Date(ev.start).toDateString() === new Date(ev.end).toDateString();
+  return sameDay ? e : 24;
+}
+
+function localDateKey(d) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+// calendar_core includes an event in "today"'s list whenever it overlaps
+// today, even if it started on an earlier day or ends on a later one (an
+// overnight block, a multi-day trip). Rendering it at the event's
+// *original* start hour is wrong on any day that isn't its real start
+// day — e.g. a trip that started yesterday would redraw at yesterday's
+// start hour today too. Clamp to the day actually being rendered: only
+// the real start day keeps the real start hour (else 00:00), and only
+// the real end day keeps the real end hour (else 24:00).
+export function clampToDay(ev, dayDate) {
+  const s = parseTime(ev.start);
+  if (s == null) return null;
+  const startKey = localDateKey(new Date(ev.start));
+  const endDate = ev.end ? new Date(ev.end) : null;
+  const endKey = endDate ? localDateKey(endDate) : startKey;
+  const isStartDay = !dayDate || dayDate === startKey;
+  const isEndDay = !dayDate || dayDate === endKey;
+  const top = isStartDay ? s : 0;
+  let bottom = isEndDay ? (endDate ? parseTime(ev.end) : top + 1) : 24;
+  if (bottom == null || bottom <= top) bottom = Math.min(24, top + 1);
+  return { s: top, e: bottom };
+}
+
+// Converts an [s, e) hour-space block into a top/height percentage pair
+// against the visible [rangeStart, rangeStart + spanHours] lane, clamping
+// each edge independently into [0,100] *before* deriving height. A
+// multi-day event on a day other than its own start/end runs the full
+// 0-24h logical day (clampToDay), which routinely runs past a narrowed
+// day_start_hour/day_end_hour window — deriving height from the
+// unclamped span first would let it exceed 100% and, since nothing
+// upstream clips overflow, spill the block out past the lane's bottom
+// edge instead of stopping at it.
+export function pctSpan(s, e, rangeStart, spanHours) {
+  const rawTop = ((s - rangeStart) / spanHours) * 100;
+  const rawBottom = ((e - rangeStart) / spanHours) * 100;
+  const top = Math.max(0, Math.min(rawTop, 100));
+  const bottom = Math.max(0, Math.min(rawBottom, 100));
+  return { top, height: Math.max(2, bottom - top) };
+}
+
 // Auto-fit the hour axis to the actual events with one hour of padding
 // each side. Default to a 9 → 18 business window when there are no
 // timed events. Clamped to [0, 24].
@@ -94,7 +152,7 @@ export function computeRange(timed, startOverride = -1, endOverride = -1) {
     for (const ev of timed) {
       const s = parseTime(ev.start);
       if (s != null) lo = Math.min(lo, s);
-      const e = parseTime(ev.end) ?? (s != null ? s + 1 : null);
+      const e = eventEndHour(ev, s);
       if (e != null) hi = Math.max(hi, e);
     }
     range = {
@@ -154,7 +212,7 @@ function densityStrip(range, timed) {
       const hEnd = hStart + 1;
       return timed.reduce((acc, ev) => {
         const s = parseTime(ev.start);
-        const e = parseTime(ev.end) ?? (s != null ? s + 1 : null);
+        const e = eventEndHour(ev, s);
         if (s == null || e == null) return acc;
         return s < hEnd && e > hStart ? acc + 1 : acc;
       }, 0);
@@ -163,7 +221,7 @@ function densityStrip(range, timed) {
   for (let h = range.start; h < range.end; h++) {
     const count = timed.reduce((acc, ev) => {
       const s = parseTime(ev.start);
-      const e = parseTime(ev.end) ?? (s != null ? s + 1 : null);
+      const e = eventEndHour(ev, s);
       if (s == null || e == null) return acc;
       return s < h + 1 && e > h ? acc + 1 : acc;
     }, 0);
@@ -212,11 +270,10 @@ export default function render(shadow, ctx) {
   const showLocations = options.show_location !== false;
 
   const eventBlocks = timed.map((ev) => {
-    const s = parseTime(ev.start);
-    if (s == null) return "";
-    const e = parseTime(ev.end) ?? s + 1;
-    const top = Math.max(0, ((s - range.start) / span) * 100);
-    const height = Math.max(2, ((e - s) / span) * 100);
+    const clamped = clampToDay(ev, isoDate);
+    if (clamped == null) return "";
+    const { s, e } = clamped;
+    const { top, height } = pctSpan(s, e, range.start, span);
     const colour = ev.colour || "var(--accent-4)";
     const tint = `color-mix(in oklab, ${colour} 28%, var(--surface))`;
     const time = `${fmtHm(ev.start)}${ev.end ? `–${fmtHm(ev.end)}` : ""}`;
@@ -231,8 +288,15 @@ export default function render(shadow, ctx) {
       </div>`;
   }).join("");
 
+  // Placed as a grid item of .tt itself (grid-column:2/-1) rather than
+  // a full-width sibling above it: a sibling starts at the widget's
+  // left edge, offset from the lane below it by the hour gutter's
+  // width, so pills didn't line up with the events they sit above.
+  // Sharing .tt's own auto/1fr column tracks guarantees the same
+  // pixels as the lane, no nested-grid track-matching needed since
+  // there's only one lane column in day view.
   const allDayStrip = allDay.length
-    ? `<div class="tt-allday">${allDay.map((ev) => {
+    ? `<div class="tt-allday" style="grid-column:2/-1">${allDay.map((ev) => {
         const colour = ev.colour || "var(--accent-4)";
         const tint = `color-mix(in oklab, ${colour} 28%, var(--surface))`;
         return `<span class="tt-allday-pill" style="border-left-color:${colour};--tt-bg:${tint}">${escapeHtml(ev.summary || "")}</span>`;
@@ -339,6 +403,15 @@ export default function render(shadow, ctx) {
        that event_title_scale never reached; scope the override here so
        all-day events resize with the same slider as timed events. */
     .tt-allday-pill { font-size: calc(var(--fs-caption) * var(--tt-title-scale, 1)); }
+    /* The shared .tt-allday is a wrapping flex *row*, so pills sized to
+       their own text and stopped well short of the lane's right edge —
+       an all-day event read as a small tag rather than a bar covering
+       the day it applies to. Day view has exactly one lane, so stack
+       pills vertically and let each stretch it end to end.
+       calendar_week/-three-day don't need this: their own
+       .tt-allday-row grid already spans each pill across its day
+       columns via an explicit grid-column span. */
+    .tt-allday { flex-direction: column; align-items: stretch; }
     /* event_row_padding_em adds on top of the shared spectra-widgets.css
        padding, so 0 (default) reproduces the previous fixed spacing. */
     .tt-event { padding: calc(var(--space-1) + var(--tt-row-pad, 0em)) var(--space-2); }
@@ -364,10 +437,10 @@ export default function render(shadow, ctx) {
           </div>
           <div class="cal-head-rule"></div>
         </div>
-        ${allDayStrip}
         ${density}
         <div class="tt-body" style="--tt-hours:${span};flex:1 1 auto;min-height:0;display:flex;flex-direction:column">
-          <div class="tt" style="flex:1 1 auto;min-height:0">
+          <div class="tt" style="flex:1 1 auto;min-height:0;grid-template-rows:${allDay.length ? "auto 1fr" : "1fr"}">
+            ${allDayStrip}
             <div class="tt-hours">${hourLabels(range)}</div>
             <div class="tt-lane has-rule">
               ${eventBlocks}

--- a/plugins/calendar_day/client.js
+++ b/plugins/calendar_day/client.js
@@ -22,10 +22,40 @@ const WEEKDAY_FULL = [
   "Friday", "Saturday", "Sunday",
 ];
 
+// date_label_style cell option: "full" (default, current behaviour),
+// "short" (3-letter), or "minimal" (1-2 chars, just enough to stay
+// unambiguous across the 7 weekdays / 12 months).
+const DOW_MINIMAL = { Monday: "M", Tuesday: "Tu", Wednesday: "W", Thursday: "Th", Friday: "F", Saturday: "Sa", Sunday: "Su" };
+const MONTH_MINIMAL = { January: "Ja", February: "F", March: "Mr", April: "Ap", May: "My", June: "Jn", July: "Jl", August: "Au", September: "S", October: "O", November: "N", December: "D" };
+
+export function styleLabel(full, style, minimalMap) {
+  if (style === "minimal") return (minimalMap[full] || full.slice(0, 2)).toUpperCase();
+  if (style === "short") return full.slice(0, 3).toUpperCase();
+  return full.toUpperCase();
+}
+
 function escapeHtml(s) {
   return String(s ?? "").replace(/[&<>"']/g, (c) => ({
     "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
   }[c]));
+}
+
+// Clamps a cell-option slider value, defaulting on missing/non-numeric
+// input. Ported from server.py's _coerce_scale — server.py used to clamp
+// event_title_scale / event_time_scale before sending them down; now the
+// raw slider value comes straight through in ctx.cell.options and this
+// does the clamping client-side instead.
+export function clampScale(raw, def, lo, hi) {
+  const v = raw === null || raw === undefined || raw === "" ? def : Number(raw);
+  return Number.isFinite(v) ? Math.max(lo, Math.min(hi, v)) : def;
+}
+
+// Cell options live at ctx.cell.options (see docs/widgets.md's ctx shape),
+// not top-level ctx.options. Named + exported so a regression back to the
+// wrong path is a one-line, testable fact instead of silently no-op-ing
+// every slider (the bug this shipped with for a while).
+export function readOptions(ctx) {
+  return ctx?.cell?.options ?? {};
 }
 
 // Parse the ISO timestamp through Date so the hour is in the
@@ -51,19 +81,31 @@ function fmtHm(iso) {
 // Auto-fit the hour axis to the actual events with one hour of padding
 // each side. Default to a 9 → 18 business window when there are no
 // timed events. Clamped to [0, 24].
-function computeRange(timed) {
-  if (!timed.length) return { start: 9, end: 18 };
-  let lo = 24, hi = 0;
-  for (const ev of timed) {
-    const s = parseTime(ev.start);
-    if (s != null) lo = Math.min(lo, s);
-    const e = parseTime(ev.end) ?? (s != null ? s + 1 : null);
-    if (e != null) hi = Math.max(hi, e);
+//
+// day_start_hour / day_end_hour cell options override either edge
+// (-1 = keep auto-fitting that edge); set both to 0/24 to always show
+// the whole day regardless of events.
+export function computeRange(timed, startOverride = -1, endOverride = -1) {
+  let range;
+  if (!timed.length) {
+    range = { start: 9, end: 18 };
+  } else {
+    let lo = 24, hi = 0;
+    for (const ev of timed) {
+      const s = parseTime(ev.start);
+      if (s != null) lo = Math.min(lo, s);
+      const e = parseTime(ev.end) ?? (s != null ? s + 1 : null);
+      if (e != null) hi = Math.max(hi, e);
+    }
+    range = {
+      start: Math.max(0, Math.floor(lo) - 1),
+      end: Math.min(24, Math.ceil(hi) + 1),
+    };
   }
-  return {
-    start: Math.max(0, Math.floor(lo) - 1),
-    end: Math.min(24, Math.ceil(hi) + 1),
-  };
+  if (startOverride >= 0) range.start = Math.min(24, startOverride);
+  if (endOverride >= 0) range.end = Math.min(24, endOverride);
+  if (range.end <= range.start) range.end = Math.min(24, range.start + 1);
+  return range;
 }
 
 // Time-of-day icon for canonical solar transitions. Returns an icon
@@ -149,19 +191,25 @@ export default function render(shadow, ctx) {
     return;
   }
 
+  const options = readOptions(ctx);
+  const labelStyle = ["full", "short", "minimal"].includes(options.date_label_style) ? options.date_label_style : "full";
+
   const isoDate = data.date || new Date().toISOString().slice(0, 10);
   const [y, m, d] = isoDate.split("-").map(Number);
   const localDate = new Date(y, m - 1, d);
   const dayNum = String(d);
-  const monthName = (MONTH_FULL[m - 1] || "").toUpperCase();
-  const weekday = WEEKDAY_FULL[(localDate.getDay() + 6) % 7].toUpperCase();
+  const monthName = styleLabel(MONTH_FULL[m - 1] || "", labelStyle, MONTH_MINIMAL);
+  const weekday = styleLabel(WEEKDAY_FULL[(localDate.getDay() + 6) % 7], labelStyle, DOW_MINIMAL);
 
   const events = Array.isArray(data.events) ? data.events : [];
   const allDay = events.filter((e) => e.all_day);
   const timed = events.filter((e) => !e.all_day);
 
-  const range = computeRange(timed);
+  const startHour = clampScale(options.day_start_hour, -1, -1, 24);
+  const endHour = clampScale(options.day_end_hour, -1, -1, 24);
+  const range = computeRange(timed, startHour, endHour);
   const span = Math.max(1, range.end - range.start);
+  const showLocations = options.show_location !== false;
 
   const eventBlocks = timed.map((ev) => {
     const s = parseTime(ev.start);
@@ -174,7 +222,7 @@ export default function render(shadow, ctx) {
     const time = `${fmtHm(ev.start)}${ev.end ? `–${fmtHm(ev.end)}` : ""}`;
     const showSub = height > 5;
     const location = ev.location || "";
-    const showLocation = location && height > 8;
+    const showLocation = showLocations && location && height > 8;
     return `
       <div class="tt-event" style="top:${top.toFixed(2)}%;height:${height.toFixed(2)}%;border-left-color:${colour};--tt-bg:${tint}" title="${escapeHtml(time)} ${escapeHtml(ev.summary || "")}${location ? ` · ${escapeHtml(location)}` : ""}">
         <span class="tt-name">${escapeHtml(ev.summary || "")}</span>
@@ -204,7 +252,16 @@ export default function render(shadow, ctx) {
     ? `<div class="tt-now" style="top:${nowPct.toFixed(2)}%"></div>`
     : "";
 
-  const density = timed.length ? densityStrip(range, timed) : "";
+  const showDensity = options.show_density !== false;
+  const density = (showDensity && timed.length) ? densityStrip(range, timed) : "";
+
+  const titleScale = clampScale(options.event_title_scale, 1.0, 0.01, 10.0);
+  const timeScale = clampScale(options.event_time_scale, 1.0, 0.01, 10.0);
+  const locScale = clampScale(options.event_location_scale, 1.0, 0.01, 10.0);
+  const rowPad = clampScale(options.event_row_padding_em, 0.0, 0.0, 3.0);
+  const headerScale = clampScale(options.header_scale, 1.0, 0.01, 10.0);
+  const axisScale = clampScale(options.axis_label_scale, 1.0, 0.01, 10.0);
+  const styleAttr = `--tt-title-scale:${titleScale};--tt-time-scale:${timeScale};--tt-loc-scale:${locScale};--tt-row-pad:${rowPad}em;--tt-header-scale:${headerScale};--tt-axis-scale:${axisScale};`;
 
   // Inline layout for the visual-pass additions (density strip, sun-
   // cycle icons in the hour gutter, location pin row inside events).
@@ -250,7 +307,7 @@ export default function render(shadow, ctx) {
       display: inline-flex;
       align-items: center;
       gap: 0.25em;
-      font-size: var(--fs-caption);
+      font-size: calc(var(--fs-caption) * var(--tt-loc-scale, 1));
       font-weight: var(--fw-bold);
       color: var(--text-muted);
       letter-spacing: var(--ls-label);
@@ -271,12 +328,34 @@ export default function render(shadow, ctx) {
       .tt-density { display: none; }
       .tt-event .tt-loc { display: none; }
     }
+
+    /* User-tunable event text sizing (event_title_scale /
+       event_time_scale / event_location_scale cell options),
+       multiplies the base spectra-widgets.css font-size so 1.0
+       matches the previous fixed size exactly. */
+    .tt-event .tt-name { font-size: calc(var(--fs-body) * var(--tt-title-scale, 1)); }
+    .tt-event .tt-sub { font-size: calc(var(--fs-caption) * var(--tt-time-scale, 1)); }
+    /* spectra-widgets.css's shared .tt-allday-pill has a fixed font-size
+       that event_title_scale never reached; scope the override here so
+       all-day events resize with the same slider as timed events. */
+    .tt-allday-pill { font-size: calc(var(--fs-caption) * var(--tt-title-scale, 1)); }
+    /* event_row_padding_em adds on top of the shared spectra-widgets.css
+       padding, so 0 (default) reproduces the previous fixed spacing. */
+    .tt-event { padding: calc(var(--space-1) + var(--tt-row-pad, 0em)) var(--space-2); }
+
+    /* header_scale: the "WEEKDAY 12" / "MONTH YYYY" head row.
+       axis_label_scale: the 08:00/10:00.../sun-icon hour gutter labels.
+       Both override shared spectra-widgets.css fixed sizes, scoped to
+       this widget instance only. */
+    .cal-head-title { font-size: calc(1em * var(--tt-header-scale, 1)); }
+    .cal-head-meta { font-size: calc(1em * var(--tt-header-scale, 1)); }
+    .tt-hours { font-size: calc(var(--fs-caption) * var(--tt-axis-scale, 1)); }
   `;
 
   shadow.innerHTML = `
     ${css}
     <style>${layout}</style>
-    <div class="w" data-widget="calendar_day">
+    <div class="w" data-widget="calendar_day" style="${styleAttr}">
       <div class="w-body" style="gap:var(--space-3)">
         <div class="cal-head">
           <div class="cal-head-row">

--- a/plugins/calendar_day/plugin.json
+++ b/plugins/calendar_day/plugin.json
@@ -1,9 +1,9 @@
 {
   "tesserae_compat": "1.x",
   "name": "Calendar, Day",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "kind": "widget",
-  "description": "Today's agenda Reads from feeds configured in Widgets \u2192 Calendar Feeds; each feed's colour drives the stripe / marker / fill colour.",
+  "description": "Today's agenda with tunable event text sizing, a configurable visible-hour range, and a location toggle. Reads from feeds configured in Widgets \u2192 Calendar Feeds; each feed's colour drives the stripe / marker / fill colour.",
   "icon": "ph-calendar-check",
   "supports": {
     "sizes": [
@@ -31,6 +31,118 @@
       "type": "string",
       "label": "Feed IDs (comma-separated; blank = all enabled)",
       "default": ""
+    },
+    {
+      "name": "day_start_hour",
+      "type": "slider",
+      "label": "Day starts at",
+      "default": -1,
+      "min": -1,
+      "max": 24,
+      "step": 1,
+      "unit": "h",
+      "help": "Hour the visible timetable starts (0-24). -1 = auto-fit to events. Set to 0 (with Day ends at = 24) to always show the whole day."
+    },
+    {
+      "name": "day_end_hour",
+      "type": "slider",
+      "label": "Day ends at",
+      "default": -1,
+      "min": -1,
+      "max": 24,
+      "step": 1,
+      "unit": "h",
+      "help": "Hour the visible timetable ends (0-24). -1 = auto-fit to events. Set to 24 (with Day starts at = 0) to always show the whole day."
+    },
+    {
+      "name": "show_location",
+      "type": "boolean",
+      "label": "Show event locations",
+      "default": true
+    },
+    {
+      "name": "show_density",
+      "type": "boolean",
+      "label": "Show event-density strip",
+      "default": true,
+      "help": "The heatmap strip above the timetable showing which hours are busiest. Off removes it entirely."
+    },
+    {
+      "name": "date_label_style",
+      "type": "select",
+      "label": "Weekday / month label style",
+      "default": "full",
+      "choices": [
+        {"value": "full", "label": "Full word (Monday, January)"},
+        {"value": "short", "label": "Short (MON, JAN)"},
+        {"value": "minimal", "label": "Minimal (M, JA)"}
+      ]
+    },
+    {
+      "name": "header_scale",
+      "type": "slider",
+      "label": "Header size (weekday / date)",
+      "default": 1.0,
+      "min": 0.01,
+      "max": 10.0,
+      "step": 0.05,
+      "unit": "×",
+      "help": "Multiplier on the top weekday/day-number/month-year header text."
+    },
+    {
+      "name": "axis_label_scale",
+      "type": "slider",
+      "label": "Time axis label size",
+      "default": 1.0,
+      "min": 0.01,
+      "max": 10.0,
+      "step": 0.05,
+      "unit": "×",
+      "help": "Multiplier on the hour-gutter time labels (08:00, 10:00, ...)."
+    },
+    {
+      "name": "event_title_scale",
+      "type": "slider",
+      "label": "Event title size",
+      "default": 1.0,
+      "min": 0.01,
+      "max": 10.0,
+      "step": 0.05,
+      "unit": "×",
+      "help": "Multiplier on the event title font size. 1.0 = default."
+    },
+    {
+      "name": "event_time_scale",
+      "type": "slider",
+      "label": "Event time size",
+      "default": 1.0,
+      "min": 0.01,
+      "max": 10.0,
+      "step": 0.05,
+      "unit": "×",
+      "help": "Multiplier on the event time-range font size."
+    },
+    {
+      "name": "event_location_scale",
+      "type": "slider",
+      "label": "Event location size",
+      "default": 1.0,
+      "min": 0.01,
+      "max": 10.0,
+      "step": 0.05,
+      "unit": "×",
+      "help": "Multiplier on the location text font size."
+    },
+    {
+      "name": "event_row_padding_em",
+      "type": "slider",
+      "label": "Event block spacing",
+      "default": 0.0,
+      "min": 0.0,
+      "max": 3.0,
+      "step": 0.05,
+      "unit": "em",
+      "help": "Extra padding added inside each event block, on top of the default. 0 = default."
     }
   ],
   "render": {

--- a/plugins/calendar_day/server.py
+++ b/plugins/calendar_day/server.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 from flask import current_app
+
+from app.calendar_time import all_day_event_overlaps_date
+from app.tz_resolve import app_timezone
 
 
 def _parse_feeds_filter(s: str) -> list[str] | None:
@@ -14,43 +17,6 @@ def _parse_feeds_filter(s: str) -> list[str] | None:
     if not s:
         return None
     return [x.strip() for x in s.split(",") if x.strip()]
-
-
-def _app_timezone() -> Any:
-    """Resolve the app timezone via core's helper; UTC when it's not on
-    the path (standalone tests outside a Tesserae install)."""
-    try:
-        from app.tz_resolve import app_timezone
-
-        return app_timezone()
-    except ImportError:
-        return UTC
-
-
-def _all_day_event_overlaps_date(event: dict[str, Any], target: date) -> bool:
-    """Whether an all-day event covers ``target``. Delegates to core's
-    helper when importable; falls back to the same exclusive-end-date
-    logic standalone (mirrors app.calendar_time.all_day_event_overlaps_date)."""
-    try:
-        from app.calendar_time import all_day_event_overlaps_date
-
-        return all_day_event_overlaps_date(event, target)
-    except ImportError:
-        start_raw = str(event.get("start") or "")
-        if not start_raw:
-            return False
-        try:
-            start = date.fromisoformat(start_raw.split("T")[0])
-        except ValueError:
-            return False
-        end_raw = str(event.get("end") or "")
-        try:
-            end = date.fromisoformat(end_raw.split("T")[0]) if end_raw else start + timedelta(days=1)
-        except ValueError:
-            end = start + timedelta(days=1)
-        if end <= start:
-            end = start + timedelta(days=1)
-        return start <= target < end
 
 
 def fetch(
@@ -66,7 +32,7 @@ def fetch(
     max_events = int(options.get("max_events") or 0)
     feeds_filter = _parse_feeds_filter(options.get("feeds_filter") or "")
 
-    zone = _app_timezone()
+    zone = app_timezone()
     now_local = datetime.now(zone)
     now = now_local.astimezone(UTC)
     end = now + timedelta(hours=hours_ahead)
@@ -82,7 +48,7 @@ def fetch(
 
     target_date = now_local.date()
     visible_events = [
-        e for e in events if not e.get("all_day") or _all_day_event_overlaps_date(e, target_date)
+        e for e in events if not e.get("all_day") or all_day_event_overlaps_date(e, target_date)
     ]
     slim = [
         {

--- a/plugins/calendar_day/server.py
+++ b/plugins/calendar_day/server.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 from flask import current_app
-
-from app.calendar_time import all_day_event_overlaps_date
-from app.tz_resolve import app_timezone
 
 
 def _parse_feeds_filter(s: str) -> list[str] | None:
@@ -17,6 +14,43 @@ def _parse_feeds_filter(s: str) -> list[str] | None:
     if not s:
         return None
     return [x.strip() for x in s.split(",") if x.strip()]
+
+
+def _app_timezone() -> Any:
+    """Resolve the app timezone via core's helper; UTC when it's not on
+    the path (standalone tests outside a Tesserae install)."""
+    try:
+        from app.tz_resolve import app_timezone
+
+        return app_timezone()
+    except ImportError:
+        return UTC
+
+
+def _all_day_event_overlaps_date(event: dict[str, Any], target: date) -> bool:
+    """Whether an all-day event covers ``target``. Delegates to core's
+    helper when importable; falls back to the same exclusive-end-date
+    logic standalone (mirrors app.calendar_time.all_day_event_overlaps_date)."""
+    try:
+        from app.calendar_time import all_day_event_overlaps_date
+
+        return all_day_event_overlaps_date(event, target)
+    except ImportError:
+        start_raw = str(event.get("start") or "")
+        if not start_raw:
+            return False
+        try:
+            start = date.fromisoformat(start_raw.split("T")[0])
+        except ValueError:
+            return False
+        end_raw = str(event.get("end") or "")
+        try:
+            end = date.fromisoformat(end_raw.split("T")[0]) if end_raw else start + timedelta(days=1)
+        except ValueError:
+            end = start + timedelta(days=1)
+        if end <= start:
+            end = start + timedelta(days=1)
+        return start <= target < end
 
 
 def fetch(
@@ -32,7 +66,7 @@ def fetch(
     max_events = int(options.get("max_events") or 0)
     feeds_filter = _parse_feeds_filter(options.get("feeds_filter") or "")
 
-    zone = app_timezone()
+    zone = _app_timezone()
     now_local = datetime.now(zone)
     now = now_local.astimezone(UTC)
     end = now + timedelta(hours=hours_ahead)
@@ -48,7 +82,7 @@ def fetch(
 
     target_date = now_local.date()
     visible_events = [
-        e for e in events if not e.get("all_day") or all_day_event_overlaps_date(e, target_date)
+        e for e in events if not e.get("all_day") or _all_day_event_overlaps_date(e, target_date)
     ]
     slim = [
         {

--- a/plugins/calendar_day/tests/clamp_check.mjs
+++ b/plugins/calendar_day/tests/clamp_check.mjs
@@ -1,0 +1,51 @@
+// Plain-node self-check for clampScale (no test framework in this repo).
+// Run: node tests/clamp_check.mjs
+// Mirrors the cases previously covered by test_smoke.py's
+// test_scale_sliders_clamp_to_bounds before the clamp moved from
+// server.py to client.js.
+import assert from "node:assert/strict";
+import { clampScale, readOptions, computeRange, styleLabel } from "../client.js";
+
+assert.equal(clampScale(undefined, 1.0, 0.7, 1.5), 1.0, "missing falls back to default");
+assert.equal(clampScale(null, 1.0, 0.7, 1.5), 1.0, "null falls back to default");
+assert.equal(clampScale("not-a-number", 1.0, 0.7, 1.5), 1.0, "unparsable falls back to default");
+assert.equal(clampScale(1.3, 1.0, 0.7, 1.5), 1.3, "in-range value passes through");
+assert.equal(clampScale(9, 1.0, 0.7, 1.5), 1.5, "above max clamps down");
+assert.equal(clampScale(0.01, 1.0, 0.7, 1.5), 0.7, "below min clamps up");
+
+// readOptions must pull from ctx.cell.options (the real ctx shape the
+// composer sends) — not top-level ctx.options, which doesn't exist and
+// would silently no-op every slider on this widget.
+assert.deepEqual(
+  readOptions({ cell: { options: { event_title_scale: 1.3 } } }),
+  { event_title_scale: 1.3 },
+  "reads from ctx.cell.options"
+);
+assert.deepEqual(readOptions({ options: { event_title_scale: 1.3 } }), {}, "ignores top-level ctx.options");
+assert.deepEqual(readOptions({}), {}, "missing cell falls back to {}");
+
+// computeRange: day_start_hour/day_end_hour overrides (-1 = auto-fit).
+assert.deepEqual(computeRange([]), { start: 9, end: 18 }, "no events falls back to 9-18");
+assert.deepEqual(
+  computeRange([{ start: "2026-01-01T10:00:00", end: "2026-01-01T11:00:00" }]),
+  { start: 9, end: 12 },
+  "auto-fits with 1h padding around events"
+);
+assert.deepEqual(computeRange([], 0, 24), { start: 0, end: 24 }, "explicit 0/24 shows the whole day");
+assert.deepEqual(
+  computeRange([{ start: "2026-01-01T10:00:00", end: "2026-01-01T11:00:00" }], 0, -1),
+  { start: 0, end: 12 },
+  "start override pins start, end still auto-fits"
+);
+assert.deepEqual(computeRange([], 20, 21), { start: 20, end: 21 }, "inverted-looking override kept as given");
+assert.deepEqual(computeRange([], 20, 20), { start: 20, end: 21 }, "equal start/end widened by 1h to stay renderable");
+
+// date_label_style: full / short / minimal (1-2 chars, disambiguated).
+const DOW_MINIMAL = { Tuesday: "Tu", Thursday: "Th" };
+assert.equal(styleLabel("Monday", "full", {}), "MONDAY", "full keeps the whole word, upper-cased");
+assert.equal(styleLabel("Tuesday", "short", {}), "TUE", "short is a 3-letter abbreviation");
+assert.equal(styleLabel("Tuesday", "minimal", DOW_MINIMAL), "TU", "minimal uses the disambiguation map");
+assert.equal(styleLabel("Thursday", "minimal", DOW_MINIMAL), "TH", "Tue/Thu don't collide at 1 char");
+assert.equal(styleLabel("Zzyzx", "minimal", {}), "ZZ", "unmapped label falls back to first 2 chars");
+
+console.log("clamp_check.mjs: all assertions passed");

--- a/plugins/calendar_day/tests/clamp_check.mjs
+++ b/plugins/calendar_day/tests/clamp_check.mjs
@@ -4,7 +4,7 @@
 // test_scale_sliders_clamp_to_bounds before the clamp moved from
 // server.py to client.js.
 import assert from "node:assert/strict";
-import { clampScale, readOptions, computeRange, styleLabel } from "../client.js";
+import { clampScale, clampToDay, computeRange, pctSpan, readOptions, styleLabel } from "../client.js";
 
 assert.equal(clampScale(undefined, 1.0, 0.7, 1.5), 1.0, "missing falls back to default");
 assert.equal(clampScale(null, 1.0, 0.7, 1.5), 1.0, "null falls back to default");
@@ -39,6 +39,30 @@ assert.deepEqual(
 );
 assert.deepEqual(computeRange([], 20, 21), { start: 20, end: 21 }, "inverted-looking override kept as given");
 assert.deepEqual(computeRange([], 20, 20), { start: 20, end: 21 }, "equal start/end widened by 1h to stay renderable");
+
+// clampToDay: calendar_core includes a multi-day event in "today"'s list
+// whenever it overlaps today, even on a day that isn't its start/end —
+// each such day must clamp to *that* day, not redraw at the event's
+// original start hour.
+const trip = { start: "2026-08-09T16:00:00", end: "2026-08-11T10:00:00" };
+assert.deepEqual(clampToDay(trip, "2026-08-09"), { s: 16, e: 24 }, "start day keeps the real start hour, runs to midnight");
+assert.deepEqual(clampToDay(trip, "2026-08-10"), { s: 0, e: 24 }, "a pass-through day runs the full 24h, not the start hour");
+assert.deepEqual(clampToDay(trip, "2026-08-11"), { s: 0, e: 10 }, "end day starts at midnight, keeps the real end hour");
+assert.deepEqual(
+  clampToDay({ start: "2026-08-09T16:00:00", end: "2026-08-09T17:00:00" }, "2026-08-09"),
+  { s: 16, e: 17 },
+  "single-day event is unaffected"
+);
+
+// pctSpan: a block's [s,e) hour span must clamp to the visible lane
+// without ever exceeding 100% height, even when day_start_hour/
+// day_end_hour narrows the range well below a pass-through day's full
+// 0-24h span (regression: height used to be derived from the
+// *unclamped* span, so it could exceed 100% and spill past the lane's
+// bottom edge).
+assert.deepEqual(pctSpan(9, 17, 8, 10), { top: 10, height: 80 }, "fully inside the range renders normally");
+assert.deepEqual(pctSpan(0, 24, 8, 4), { top: 0, height: 100 }, "a full 0-24h pass-through day clamps to exactly the lane, not beyond");
+assert.deepEqual(pctSpan(20, 24, 8, 4), { top: 100, height: 2 }, "a span entirely after the visible range clamps to the bottom edge, not off it");
 
 // date_label_style: full / short / minimal (1-2 chars, disambiguated).
 const DOW_MINIMAL = { Tuesday: "Tu", Thursday: "Th" };

--- a/plugins/calendar_day/tests/test_smoke.py
+++ b/plugins/calendar_day/tests/test_smoke.py
@@ -1,0 +1,91 @@
+"""Smoke tests for the calendar_day (custom) widget.
+
+Mirrors the calendar_schedule community widget's test setup: stub
+``current_app`` + the calendar_core plugin so the tests exercise
+fetch()'s own logic (event slimming and cap) without reaching real ICS
+feeds or the Tesserae core.
+
+The event_title_scale / event_time_scale styling-slider clamp used to
+live here too; it's moved to client.js's clampScale (see
+tests/clamp_check.mjs) since ctx.cell.options already carries the raw
+slider value to the browser unclamped.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import server
+
+
+def _stub_calendar_core(events: list[dict[str, Any]]) -> MagicMock:
+    core = MagicMock()
+    core.server_module.load_events.return_value = events
+    core.data_dir = "/tmp/calendar_core_unused"
+    return core
+
+
+def _stub_app(events: list[dict[str, Any]]) -> MagicMock:
+    registry = MagicMock()
+    registry.get.return_value = _stub_calendar_core(events)
+    app = MagicMock()
+    app.config = {"PLUGIN_REGISTRY": registry}
+    return app
+
+
+def _future_iso(hours: float) -> str:
+    return (datetime.now(UTC) + timedelta(hours=hours)).isoformat()
+
+
+def test_missing_calendar_core_surfaces_error() -> None:
+    registry = MagicMock()
+    registry.get.return_value = None
+    app = MagicMock()
+    app.config = {"PLUGIN_REGISTRY": registry}
+    with patch.object(server, "current_app", app):
+        out = server.fetch(options={}, settings={}, ctx={})
+    assert "error" in out
+    assert out["events"] == []
+
+
+def test_fetch_slims_events() -> None:
+    app = _stub_app(
+        [
+            {
+                "summary": "Standup",
+                "start": _future_iso(1),
+                "end": _future_iso(1.5),
+                "all_day": False,
+                "feed_colour": "#3366CC",
+                "feed_name": "Work",
+                "location": "Zoom",
+            },
+        ]
+    )
+    with patch.object(server, "current_app", app):
+        out = server.fetch(options={}, settings={}, ctx={})
+    assert out["count"] == 1
+    assert out["events"][0]["summary"] == "Standup"
+    assert "event_title_scale" not in out
+    assert "event_time_scale" not in out
+
+
+def test_max_events_truncates() -> None:
+    events = [
+        {
+            "summary": f"event {i}",
+            "start": _future_iso(1 + i),
+            "end": _future_iso(1.5 + i),
+            "all_day": False,
+        }
+        for i in range(5)
+    ]
+    app = _stub_app(events)
+    with patch.object(server, "current_app", app):
+        out = server.fetch(options={"max_events": 2}, settings={}, ctx={})
+    assert out["count"] == 2

--- a/plugins/calendar_day/tests/test_smoke.py
+++ b/plugins/calendar_day/tests/test_smoke.py
@@ -1,7 +1,6 @@
-"""Smoke tests for the calendar_day (custom) widget.
+"""Smoke tests for the calendar_day widget.
 
-Mirrors the calendar_schedule community widget's test setup: stub
-``current_app`` + the calendar_core plugin so the tests exercise
+Stubs ``current_app`` + the calendar_core plugin so the tests exercise
 fetch()'s own logic (event slimming and cap) without reaching real ICS
 feeds or the Tesserae core.
 
@@ -89,3 +88,10 @@ def test_max_events_truncates() -> None:
     with patch.object(server, "current_app", app):
         out = server.fetch(options={"max_events": 2}, settings={}, ctx={})
     assert out["count"] == 2
+
+
+if __name__ == "__main__":
+    test_missing_calendar_core_surfaces_error()
+    test_fetch_slims_events()
+    test_max_events_truncates()
+    print("test_smoke.py: all assertions passed")

--- a/plugins/calendar_month/client.js
+++ b/plugins/calendar_month/client.js
@@ -1,8 +1,21 @@
-// calendar_month, Spectra month-grid. Same per-text-type sizing/spacing/
-// label controls as the other calendar_* widgets: dashboard title scale, day
-// header (mc-num) scale, event title scale, event block spacing, a
-// show_location toggle (appends location in text-display mode; absent
-// from the bundled widget), and date_label_style (short/minimal weekday
+// calendar_month, Spectra month-grid. Each day cell carries:
+//
+//   - A heat tint on the cell background scaled by event count, so a
+//     glance over the grid reveals which days are stacked vs quiet.
+//   - Up to 4 feed-colour micro-strips at the bottom of the cell -
+//     one per unique feed that has events that day, so it reads
+//     "this day has work + personal + bills" without spelling it out.
+//   - A +N chip when the day's event count exceeds what the visible
+//     strips / text rows could show.
+//
+// Today's cell keeps the filled accent-1 block behind the day number;
+// out-of-month days fade via the existing is-out class.
+//
+// Same per-text-type sizing/spacing/label controls as the other
+// calendar_* widgets: dashboard title scale, day header (mc-num)
+// scale, event title scale, event block spacing, a show_location
+// toggle (appends location in text-display mode; absent from the
+// bundled widget), and date_label_style (short/minimal weekday
 // abbreviations). No hourly timeline here, so there's no day start/end
 // hour option — every other widget's configurability that applies to a
 // grid-of-days layout is carried over.
@@ -35,7 +48,11 @@ export function clampScale(raw, def, lo, hi) {
   return Number.isFinite(v) ? Math.max(lo, Math.min(hi, v)) : def;
 }
 
-// Dedupe feed colours preserving first-seen order.
+// Dedupe feed colours preserving first-seen order. The cell shows
+// one strip per unique colour rather than one per event, so a day
+// with three "work" meetings doesn't paint three identical blue
+// strips, it paints one wide blue strip alongside whatever other
+// feeds the day touches.
 function uniqueColours(events) {
   const seen = new Set();
   const out = [];
@@ -50,7 +67,9 @@ function uniqueColours(events) {
 }
 
 // Heat-tint background, scales the cell's background from surface
-// (0 events) up to a `color-mix` overlay of accent-4 at increasing alpha.
+// (0 events) up to a `color-mix` overlay of accent-4 (teal) at
+// increasing alpha. Capped at 5+ events so a single day with 20
+// meetings doesn't drown out the rest of the grid's distinctions.
 function heatBackground(count) {
   if (count <= 0) return "";
   const intensity = Math.min(1, count / 5);
@@ -63,6 +82,9 @@ export default function render(shadow, ctx) {
   const opts = ctx?.cell?.options || {};
   const display = opts.event_display === "text" ? "text" : "bars";
   const maxPerDay = Math.max(1, Number(opts.max_events_per_day) || 3);
+  // Heat-tint on by default; cell option flips it off for users who
+  // want the month-grid to read as a uniform field of cells instead
+  // of "busy days darker".
   const heatmap = opts.heatmap !== false;
   const showLocations = opts.show_location === true;
   const labelStyle = ["short", "minimal", "full"].includes(opts.date_label_style) ? opts.date_label_style : "short";
@@ -103,6 +125,9 @@ export default function render(shadow, ctx) {
 
     let body = "";
     if (display === "text") {
+      // Original "title text with feed colour bar" rendering kept
+      // intact so existing dashboards with that cell option stay
+      // visually consistent.
       const visible = events.slice(0, maxPerDay);
       const remainder = Math.max(0, count - maxPerDay);
       body = `
@@ -114,6 +139,10 @@ export default function render(shadow, ctx) {
         }).join("")}
         ${remainder > 0 ? `<span class="mc-more">+${remainder}</span>` : ""}`;
     } else {
+      // bars mode (default), strips per unique feed-colour. Cap at
+      // 4 strips so a day with 7 distinct feeds doesn't paint a
+      // rainbow stack that pushes the day number out of frame; the
+      // rest are summarised by the +N chip.
       const colours = uniqueColours(events);
       const visibleColours = colours.slice(0, 4);
       const overflow = colours.length - visibleColours.length;
@@ -135,6 +164,9 @@ export default function render(shadow, ctx) {
       </div>`;
   }).join("");
 
+  // Inline layout for the visual-pass additions (heat tints handled
+  // via inline style above; strips + chip styling below). Strip
+  // height bumps at LG so the row reads cleanly on a wide cell.
   const layout = `
     .mc-strips {
       display: flex;

--- a/plugins/calendar_month/client.js
+++ b/plugins/calendar_month/client.js
@@ -1,15 +1,11 @@
-// calendar_month, Spectra month-grid. Each day cell carries:
-//
-//   - A heat tint on the cell background scaled by event count, so a
-//     glance over the grid reveals which days are stacked vs quiet.
-//   - Up to 4 feed-colour micro-strips at the bottom of the cell -
-//     one per unique feed that has events that day, so it reads
-//     "this day has work + personal + bills" without spelling it out.
-//   - A +N chip when the day's event count exceeds what the visible
-//     strips / text rows could show.
-//
-// Today's cell keeps the filled accent-1 block behind the day number;
-// out-of-month days fade via the existing is-out class.
+// calendar_month, Spectra month-grid. Same per-text-type sizing/spacing/
+// label controls as the other calendar_* widgets: dashboard title scale, day
+// header (mc-num) scale, event title scale, event block spacing, a
+// show_location toggle (appends location in text-display mode; absent
+// from the bundled widget), and date_label_style (short/minimal weekday
+// abbreviations). No hourly timeline here, so there's no day start/end
+// hour option — every other widget's configurability that applies to a
+// grid-of-days layout is carried over.
 
 function escapeHtml(s) {
   return String(s ?? "").replace(/[&<>"']/g, (c) => ({
@@ -20,11 +16,26 @@ function escapeHtml(s) {
 const DOW = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const DOW_SUN = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
-// Dedupe feed colours preserving first-seen order. The cell shows
-// one strip per unique colour rather than one per event, so a day
-// with three "work" meetings doesn't paint three identical blue
-// strips, it paints one wide blue strip alongside whatever other
-// feeds the day touches.
+// date_label_style cell option: "short" (default, current 3-letter
+// behaviour), "minimal" (1-2 chars, just enough to stay unambiguous), or
+// "full" (the whole word).
+const DOW_MINIMAL = { Sun: "Su", Mon: "M", Tue: "Tu", Wed: "W", Thu: "Th", Fri: "F", Sat: "Sa" };
+const DOW_FULL = { Sun: "Sunday", Mon: "Monday", Tue: "Tuesday", Wed: "Wednesday", Thu: "Thursday", Fri: "Friday", Sat: "Saturday" };
+
+export function styleShortLabel(label, style, minimalMap, fullMap) {
+  if (style === "minimal") return minimalMap[label] || label.slice(0, 2);
+  if (style === "full") return (fullMap && fullMap[label]) || label;
+  return label;
+}
+
+// Clamps a cell-option slider value, defaulting on missing/non-numeric
+// input. Same shape as the other calendar_* widgets' clampScale.
+export function clampScale(raw, def, lo, hi) {
+  const v = raw === null || raw === undefined || raw === "" ? def : Number(raw);
+  return Number.isFinite(v) ? Math.max(lo, Math.min(hi, v)) : def;
+}
+
+// Dedupe feed colours preserving first-seen order.
 function uniqueColours(events) {
   const seen = new Set();
   const out = [];
@@ -39,9 +50,7 @@ function uniqueColours(events) {
 }
 
 // Heat-tint background, scales the cell's background from surface
-// (0 events) up to a `color-mix` overlay of accent-4 (teal) at
-// increasing alpha. Capped at 5+ events so a single day with 20
-// meetings doesn't drown out the rest of the grid's distinctions.
+// (0 events) up to a `color-mix` overlay of accent-4 at increasing alpha.
 function heatBackground(count) {
   if (count <= 0) return "";
   const intensity = Math.min(1, count / 5);
@@ -54,10 +63,14 @@ export default function render(shadow, ctx) {
   const opts = ctx?.cell?.options || {};
   const display = opts.event_display === "text" ? "text" : "bars";
   const maxPerDay = Math.max(1, Number(opts.max_events_per_day) || 3);
-  // Heat-tint on by default; cell option flips it off for users who
-  // want the month-grid to read as a uniform field of cells instead
-  // of "busy days darker".
   const heatmap = opts.heatmap !== false;
+  const showLocations = opts.show_location === true;
+  const labelStyle = ["short", "minimal", "full"].includes(opts.date_label_style) ? opts.date_label_style : "short";
+  const titleScale = clampScale(opts.title_scale, 1.0, 0.01, 10.0);
+  const headerScale = clampScale(opts.header_scale, 1.0, 0.01, 10.0);
+  const eventScale = clampScale(opts.event_title_scale, 1.0, 0.01, 10.0);
+  const rowPad = clampScale(opts.event_row_padding_em, 0.0, 0.0, 3.0);
+  const styleAttr = `--mc-dash-title-scale:${titleScale};--mc-header-scale:${headerScale};--mc-event-scale:${eventScale};--mc-row-pad:${rowPad}em;`;
   const css = `<link rel="stylesheet" href="/static/style/spectra-widgets.css">`;
 
   if (data.error) {
@@ -75,7 +88,9 @@ export default function render(shadow, ctx) {
   const year = data.year || "";
   const weekStartLabel = (data.week_start === "sunday") ? "WEEK STARTS SUN" : "WEEK STARTS MON";
 
-  const dowHeader = dowNames.map((name) => `<span>${escapeHtml(name)}</span>`).join("");
+  const dowHeader = dowNames
+    .map((name) => `<span>${escapeHtml(styleShortLabel(name, labelStyle, DOW_MINIMAL, DOW_FULL))}</span>`)
+    .join("");
 
   const cells = days.map((d) => {
     const classes = ["mc-cell"];
@@ -88,22 +103,17 @@ export default function render(shadow, ctx) {
 
     let body = "";
     if (display === "text") {
-      // Original "title text with feed colour bar" rendering kept
-      // intact so existing dashboards with that cell option stay
-      // visually consistent.
       const visible = events.slice(0, maxPerDay);
       const remainder = Math.max(0, count - maxPerDay);
       body = `
         ${visible.map((ev) => {
           const colour = ev.colour || "var(--accent-4)";
-          return `<span class="mc-text" style="border-left-color:${colour}" title="${escapeHtml(ev.summary || "")}">${escapeHtml(ev.summary || "")}</span>`;
+          const location = showLocations && ev.location ? ev.location : "";
+          const text = location ? `${ev.summary || ""} · ${location}` : (ev.summary || "");
+          return `<span class="mc-text" style="border-left-color:${colour}" title="${escapeHtml(text)}">${escapeHtml(text)}</span>`;
         }).join("")}
         ${remainder > 0 ? `<span class="mc-more">+${remainder}</span>` : ""}`;
     } else {
-      // bars mode (default), strips per unique feed-colour. Cap at
-      // 4 strips so a day with 7 distinct feeds doesn't paint a
-      // rainbow stack that pushes the day number out of frame; the
-      // rest are summarised by the +N chip.
       const colours = uniqueColours(events);
       const visibleColours = colours.slice(0, 4);
       const overflow = colours.length - visibleColours.length;
@@ -125,13 +135,7 @@ export default function render(shadow, ctx) {
       </div>`;
   }).join("");
 
-  // Inline layout for the visual-pass additions (heat tints handled
-  // via inline style above; strips + chip styling below). Strip
-  // height bumps at LG so the row reads cleanly on a wide cell.
   const layout = `
-    /* Feed-colour micro-strips row at the bottom of each cell. One
-       strip per unique feed colour on that day; capped at 4 so the
-       row doesn't elbow the day number. */
     .mc-strips {
       display: flex;
       gap: var(--stroke-1);
@@ -147,30 +151,35 @@ export default function render(shadow, ctx) {
       flex-direction: column;
       gap: 0.15em;
     }
-    /* Refined +N chip, small numeric badge in the bottom-right of
-       cells with more events than the visible strips count. Sits
-       inside .mc-dots so it stacks naturally above the strips when
-       in bars mode and below the text rows when in text mode. */
     .mc-more {
       align-self: flex-end;
-      font-size: var(--fs-caption);
+      font-size: calc(var(--fs-caption) * var(--mc-event-scale, 1));
       font-weight: var(--fw-black);
       letter-spacing: var(--ls-label);
       color: var(--text-muted);
       font-variant-numeric: tabular-nums;
       line-height: 1;
     }
-    /* Slightly chunkier strips at lg so they read as deliberate
-       feed-colour indicators rather than hairlines. */
     @container (min-width: 700px) {
       .mc-strips { height: calc(var(--stroke-3) * 1.4); }
     }
+
+    /* header_scale: the day-number badge in each cell.
+       event_title_scale: event text in text-display mode.
+       event_row_padding_em: extra padding inside each cell, on top of
+       the shared spectra-widgets.css default (0 = default).
+       title_scale: the "MONTH YYYY" dashboard title. */
+    .mc-num { font-size: calc(var(--fs-body) * var(--mc-header-scale, 1)); }
+    .mc-text { font-size: calc(var(--fs-caption) * var(--mc-event-scale, 1)); }
+    .mc-cell { padding: calc(var(--space-1) + var(--mc-row-pad, 0em)) var(--space-2); }
+    .cal-head-title { font-size: calc(1em * var(--mc-dash-title-scale, 1)); }
+    .cal-head-meta { font-size: calc(1em * var(--mc-dash-title-scale, 1)); }
   `;
 
   shadow.innerHTML = `
     ${css}
     <style>${layout}</style>
-    <div class="w" data-widget="calendar_month">
+    <div class="w" data-widget="calendar_month" style="${styleAttr}">
       <div class="w-body" style="gap:var(--space-3)">
         <div class="cal-head">
           <div class="cal-head-row">

--- a/plugins/calendar_month/plugin.json
+++ b/plugins/calendar_month/plugin.json
@@ -1,9 +1,9 @@
 {
   "tesserae_compat": "1.x",
   "name": "Calendar, Month",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "kind": "widget",
-  "description": "Month-grid view Reads from feeds configured in Widgets \u2192 Calendar Feeds; each feed's colour drives the bar / dot / stripe colour.",
+  "description": "Month-grid view with tunable dashboard title/day-number/event text sizing, cell spacing, and a location toggle for text-display mode. Each feed's colour drives the bar / dot / stripe colour.",
   "icon": "ph-calendar",
   "supports": {
     "sizes": [
@@ -18,15 +18,15 @@
       "label": "Week starts on",
       "default": "monday",
       "choices": [
-        {
-          "value": "sunday",
-          "label": "Sunday"
-        },
-        {
-          "value": "monday",
-          "label": "Monday"
-        }
+        {"value": "sunday", "label": "Sunday"},
+        {"value": "monday", "label": "Monday"}
       ]
+    },
+    {
+      "name": "feeds_filter",
+      "type": "string",
+      "label": "Feed IDs (comma-separated; blank = all enabled)",
+      "default": ""
     },
     {
       "name": "max_events_per_day",
@@ -40,14 +40,8 @@
       "label": "Event style",
       "default": "bars",
       "choices": [
-        {
-          "value": "bars",
-          "label": "Coloured bars"
-        },
-        {
-          "value": "text",
-          "label": "Title text with feed colour bar"
-        }
+        {"value": "bars", "label": "Coloured bars"},
+        {"value": "text", "label": "Title text with feed colour bar"}
       ]
     },
     {
@@ -57,10 +51,66 @@
       "default": true
     },
     {
-      "name": "feeds_filter",
-      "type": "string",
-      "label": "Feed IDs (comma-separated; blank = all enabled)",
-      "default": ""
+      "name": "date_label_style",
+      "type": "select",
+      "label": "Weekday label style",
+      "default": "short",
+      "choices": [
+        {"value": "full", "label": "Full word (Monday, Tuesday)"},
+        {"value": "short", "label": "Short (Mon, Tue)"},
+        {"value": "minimal", "label": "Minimal (M, Tu)"}
+      ]
+    },
+    {
+      "name": "show_location",
+      "type": "boolean",
+      "label": "Show event locations",
+      "default": false,
+      "help": "Text-display mode only: appends '· location' after each event title. Off by default since month cells are the tightest on space of any calendar widget."
+    },
+    {
+      "name": "title_scale",
+      "type": "slider",
+      "label": "Dashboard title size",
+      "default": 1.0,
+      "min": 0.01,
+      "max": 10.0,
+      "step": 0.05,
+      "unit": "×",
+      "help": "Multiplier on the 'MONTH YYYY' header row at the top of the widget."
+    },
+    {
+      "name": "header_scale",
+      "type": "slider",
+      "label": "Day number size",
+      "default": 1.0,
+      "min": 0.01,
+      "max": 10.0,
+      "step": 0.05,
+      "unit": "×",
+      "help": "Multiplier on each cell's day-number badge."
+    },
+    {
+      "name": "event_title_scale",
+      "type": "slider",
+      "label": "Event text size",
+      "default": 1.0,
+      "min": 0.01,
+      "max": 10.0,
+      "step": 0.05,
+      "unit": "×",
+      "help": "Multiplier on event text in text-display mode (and the '+N' overflow chip)."
+    },
+    {
+      "name": "event_row_padding_em",
+      "type": "slider",
+      "label": "Cell spacing",
+      "default": 0.0,
+      "min": 0.0,
+      "max": 1.5,
+      "step": 0.05,
+      "unit": "em",
+      "help": "Extra padding added inside each day cell, on top of the default. 0 = default."
     }
   ],
   "render": {
@@ -70,26 +120,10 @@
   "data_schema": {
     "color": "#4F6F36",
     "fields": [
-      {
-        "name": "month",
-        "type": "num",
-        "label": "Month"
-      },
-      {
-        "name": "year",
-        "type": "num",
-        "label": "Year"
-      },
-      {
-        "name": "month_name",
-        "type": "str",
-        "label": "Month name"
-      },
-      {
-        "name": "days",
-        "type": "arr",
-        "label": "Days"
-      }
+      {"name": "month", "type": "num", "label": "Month"},
+      {"name": "year", "type": "num", "label": "Year"},
+      {"name": "month_name", "type": "str", "label": "Month name"},
+      {"name": "days", "type": "arr", "label": "Days"}
     ],
     "sample": {
       "month": 7,
@@ -101,7 +135,9 @@
           "day": 10,
           "in_month": true,
           "is_today": true,
-          "events": [],
+          "events": [
+            {"summary": "Standup", "location": "Zoom", "colour": "#4F6F36"}
+          ],
           "total": 2,
           "extra": 0
         },

--- a/plugins/calendar_month/plugin.json
+++ b/plugins/calendar_month/plugin.json
@@ -51,6 +51,13 @@
       "default": true
     },
     {
+      "name": "show_location",
+      "type": "boolean",
+      "label": "Show event locations",
+      "default": false,
+      "help": "Text-display mode only: appends '· location' after each event title. Off by default since month cells are the tightest on space of any calendar widget."
+    },
+    {
       "name": "date_label_style",
       "type": "select",
       "label": "Weekday label style",
@@ -60,13 +67,6 @@
         {"value": "short", "label": "Short (Mon, Tue)"},
         {"value": "minimal", "label": "Minimal (M, Tu)"}
       ]
-    },
-    {
-      "name": "show_location",
-      "type": "boolean",
-      "label": "Show event locations",
-      "default": false,
-      "help": "Text-display mode only: appends '· location' after each event title. Off by default since month cells are the tightest on space of any calendar widget."
     },
     {
       "name": "title_scale",
@@ -107,7 +107,7 @@
       "label": "Cell spacing",
       "default": 0.0,
       "min": 0.0,
-      "max": 1.5,
+      "max": 3.0,
       "step": 0.05,
       "unit": "em",
       "help": "Extra padding added inside each day cell, on top of the default. 0 = default."

--- a/plugins/calendar_month/server.py
+++ b/plugins/calendar_month/server.py
@@ -100,6 +100,7 @@ def fetch(
                         "end": e.get("end"),
                         "all_day": e.get("all_day", False),
                         "colour": e.get("feed_colour"),
+                        "location": e.get("location") or "",
                     }
                     for e in visible
                 ],

--- a/plugins/calendar_month/tests/clamp_check.mjs
+++ b/plugins/calendar_month/tests/clamp_check.mjs
@@ -1,0 +1,22 @@
+// Plain-node self-check (no test framework in this repo).
+// Run: node tests/clamp_check.mjs
+import assert from "node:assert/strict";
+import { clampScale, styleShortLabel } from "../client.js";
+
+assert.equal(clampScale(undefined, 1.0, 0.1, 5.0), 1.0, "missing falls back to default");
+assert.equal(clampScale(null, 1.0, 0.1, 5.0), 1.0, "null falls back to default");
+assert.equal(clampScale("not-a-number", 1.0, 0.1, 5.0), 1.0, "unparsable falls back to default");
+assert.equal(clampScale(2.5, 1.0, 0.1, 5.0), 2.5, "in-range value passes through");
+assert.equal(clampScale(9, 1.0, 0.1, 5.0), 5.0, "above max clamps down");
+assert.equal(clampScale(0.0, 1.0, 0.1, 5.0), 0.1, "below min clamps up");
+
+// date_label_style: short (current) / minimal (1-2 chars) / full (whole word).
+const DOW_MINIMAL = { Tue: "Tu", Thu: "Th" };
+const DOW_FULL = { Tue: "Tuesday" };
+assert.equal(styleShortLabel("Tue", "short", DOW_MINIMAL), "Tue", "short passes the existing label through unchanged");
+assert.equal(styleShortLabel("Tue", "minimal", DOW_MINIMAL), "Tu", "minimal uses the disambiguation map");
+assert.equal(styleShortLabel("Zzz", "minimal", {}), "Zz", "unmapped label falls back to first 2 chars");
+assert.equal(styleShortLabel("Tue", "full", DOW_MINIMAL, DOW_FULL), "Tuesday", "full looks up the whole word");
+assert.equal(styleShortLabel("Zzz", "full", {}, {}), "Zzz", "unmapped full falls back to the short label as-is");
+
+console.log("clamp_check.mjs: all assertions passed");

--- a/plugins/calendar_week/client.js
+++ b/plugins/calendar_week/client.js
@@ -1,9 +1,11 @@
-// calendar_week, Spectra timetable, seven columns. Display header
-// shows the date range ("JUN 1 → 7 · 2026"), columns show DOW + day
-// number with today picked out via an inverse accent-1 chip and
-// weekend columns tinted to read distinct from weekdays. Each
-// column head also carries a small event-count chip so a glance
-// answers "which day is the busiest?" without scrolling the lane.
+// calendar_week, Spectra timetable, seven columns. Same per-text-type
+// sizing/spacing/label controls as calendar_day / calendar_three /
+// calendar_schedule:
+// event title/location scale, event row spacing, header/axis label
+// scale, dashboard title scale, configurable day_start_hour/day_end_hour
+// (or "always show the whole day"), a show_location toggle + rendering
+// (absent from the bundled widget), and date_label_style (short/minimal
+// weekday+month abbreviations).
 
 const MONTH_SHORT = [
   "JAN", "FEB", "MAR", "APR", "MAY", "JUN",
@@ -12,18 +14,37 @@ const MONTH_SHORT = [
 const DOW = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"];
 const DOW_SUN = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
 
+// date_label_style cell option: "short" (default, current 3-letter
+// behaviour), "minimal" (1-2 chars, just enough to stay unambiguous), or
+// "full" (the whole word, derived from the short code since that's all
+// this widget stores).
+const DOW_MINIMAL = { SUN: "SU", MON: "M", TUE: "TU", WED: "W", THU: "TH", FRI: "F", SAT: "SA" };
+const MONTH_MINIMAL = { JAN: "JA", FEB: "F", MAR: "MR", APR: "AP", MAY: "MY", JUN: "JN", JUL: "JL", AUG: "AU", SEP: "S", OCT: "O", NOV: "N", DEC: "D" };
+const DOW_FULL = { SUN: "Sunday", MON: "Monday", TUE: "Tuesday", WED: "Wednesday", THU: "Thursday", FRI: "Friday", SAT: "Saturday" };
+const MONTH_FULL = { JAN: "January", FEB: "February", MAR: "March", APR: "April", MAY: "May", JUN: "June", JUL: "July", AUG: "August", SEP: "September", OCT: "October", NOV: "November", DEC: "December" };
+
+export function styleShortLabel(label, style, minimalMap, fullMap) {
+  if (style === "minimal") return minimalMap[label] || label.slice(0, 2);
+  if (style === "full") return (fullMap && fullMap[label]) || label;
+  return label;
+}
+
 function escapeHtml(s) {
   return String(s ?? "").replace(/[&<>"']/g, (c) => ({
     "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
   }[c]));
 }
 
+// Clamps a cell-option slider value, defaulting on missing/non-numeric
+// input. Same shape as the other calendar_* widgets' clampScale.
+export function clampScale(raw, def, lo, hi) {
+  const v = raw === null || raw === undefined || raw === "" ? def : Number(raw);
+  return Number.isFinite(v) ? Math.max(lo, Math.min(hi, v)) : def;
+}
+
 // Parse the ISO timestamp through Date so the resulting hour is in
 // the renderer's LOCAL timezone, not whatever offset is baked into
-// the ISO string. calendar_core's server normalises everything to
-// UTC ISO; the previous string-slicing path was treating "14:00
-// Melbourne → 04:00 UTC" as "render at hour 4", landing every event
-// 10 hours from its true local time.
+// the ISO string.
 function parseTime(iso) {
   if (typeof iso !== "string") return null;
   const d = new Date(iso);
@@ -38,7 +59,10 @@ function fmtHm(iso) {
   return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 }
 
-function computeRange(days) {
+// day_start_hour / day_end_hour cell options override either edge
+// (-1 = keep auto-fitting that edge); set both to 0/24 to always show
+// the whole day regardless of events.
+export function computeRange(days, startOverride = -1, endOverride = -1) {
   let lo = 24, hi = 0, has = false;
   for (const d of days) {
     for (const ev of d.events || []) {
@@ -49,11 +73,13 @@ function computeRange(days) {
       if (e != null) { hi = Math.max(hi, e); has = true; }
     }
   }
-  if (!has) return { start: 8, end: 18 };
-  return {
-    start: Math.max(0, Math.floor(lo) - 1),
-    end: Math.min(24, Math.ceil(hi) + 1),
-  };
+  const range = has
+    ? { start: Math.max(0, Math.floor(lo) - 1), end: Math.min(24, Math.ceil(hi) + 1) }
+    : { start: 8, end: 18 };
+  if (startOverride >= 0) range.start = Math.min(24, startOverride);
+  if (endOverride >= 0) range.end = Math.min(24, endOverride);
+  if (range.end <= range.start) range.end = Math.min(24, range.start + 1);
+  return range;
 }
 
 function hourLabels(range) {
@@ -65,22 +91,19 @@ function hourLabels(range) {
   return out.join("");
 }
 
-function fmtRange(startIso, endIso) {
+function fmtRange(startIso, endIso, labelStyle) {
   if (!startIso || !endIso) return "";
   const [sy, sm, sd] = startIso.split("-").map(Number);
   const [ey, em, ed] = endIso.split("-").map(Number);
-  const startBit = `${MONTH_SHORT[sm - 1] || ""} ${sd}`;
-  const endBit = (sm === em)
-    ? `${ed}`
-    : `${MONTH_SHORT[em - 1] || ""} ${ed}`;
+  const startMonth = styleShortLabel(MONTH_SHORT[sm - 1] || "", labelStyle, MONTH_MINIMAL, MONTH_FULL);
+  const endMonth = styleShortLabel(MONTH_SHORT[em - 1] || "", labelStyle, MONTH_MINIMAL, MONTH_FULL);
+  const startBit = `${startMonth} ${sd}`;
+  const endBit = (sm === em) ? `${ed}` : `${endMonth} ${ed}`;
   const year = sy === ey ? `${sy}` : `${sy}/${ey}`;
   return `${startBit} → ${endBit} · ${year}`;
 }
 
 // Which column indices are weekend days, given the chosen week start.
-// Server passes week_start as "monday" (default) or "sunday".
-// Monday-first weeks: Saturday is idx 5, Sunday idx 6.
-// Sunday-first weeks: Sunday is idx 0, Saturday idx 6.
 function weekendIndices(weekStart) {
   return weekStart === "sunday" ? new Set([0, 6]) : new Set([5, 6]);
 }
@@ -89,6 +112,17 @@ export default function render(shadow, ctx) {
   const data = ctx?.data ?? {};
   const opts = ctx?.cell?.options || {};
   const hideLabels = opts.hide_labels === true;
+  const titleScale = clampScale(opts.event_title_scale, 1.0, 0.01, 10.0);
+  const locScale = clampScale(opts.event_location_scale, 1.0, 0.01, 10.0);
+  const rowPad = clampScale(opts.event_row_padding_em, 0.0, 0.0, 3.0);
+  const headerScale = clampScale(opts.header_scale, 1.0, 0.01, 10.0);
+  const axisScale = clampScale(opts.axis_label_scale, 1.0, 0.01, 10.0);
+  const dashTitleScale = clampScale(opts.title_scale, 1.0, 0.01, 10.0);
+  const showLocations = opts.show_location === true;
+  const labelStyle = ["short", "minimal", "full"].includes(opts.date_label_style) ? opts.date_label_style : "short";
+  const startHour = clampScale(opts.day_start_hour, -1, -1, 24);
+  const endHour = clampScale(opts.day_end_hour, -1, -1, 24);
+  const styleAttr = `--tt-title-scale:${titleScale};--tt-loc-scale:${locScale};--tt-row-pad:${rowPad}em;--tt-header-scale:${headerScale};--tt-axis-scale:${axisScale};--tt-dash-title-scale:${dashTitleScale};`;
   const css = `<link rel="stylesheet" href="/static/style/spectra-widgets.css">`;
 
   if (data.error) {
@@ -101,14 +135,14 @@ export default function render(shadow, ctx) {
   }
 
   const days = Array.isArray(data.days) ? data.days.slice(0, 7) : [];
-  const range = computeRange(days);
+  const range = computeRange(days, startHour, endHour);
   const span = Math.max(1, range.end - range.start);
   const dowNames = (data.week_start === "sunday") ? DOW_SUN : DOW;
-  const rangeMeta = fmtRange(data.start, data.end);
+  const rangeMeta = fmtRange(data.start, data.end, labelStyle);
   const weekendCols = weekendIndices(data.week_start || "monday");
 
   const heads = days.map((d, i) => {
-    const name = dowNames[i] || "";
+    const name = styleShortLabel(dowNames[i] || "", labelStyle, DOW_MINIMAL, DOW_FULL);
     const isToday = !!d.is_today;
     const isWeekend = weekendCols.has(i);
     const count = Array.isArray(d.events) ? d.events.length : 0;
@@ -138,24 +172,18 @@ export default function render(shadow, ctx) {
       const e = parseTime(ev.end) ?? s + 1;
       const rawTop = ((s - range.start) / span) * 100;
       const rawHeight = Math.max(2, ((e - s) / span) * 100);
-      // Clamp the event's top so a row sitting at the very end of the
-      // range (e.g. an event at 24:00) doesn't overflow below the
-      // lane. Cap at (100 - height) so the block always ends inside
-      // the lane's bottom edge.
       const top = Math.max(0, Math.min(rawTop, 100 - rawHeight));
       const height = rawHeight;
       const colour = ev.colour || "var(--accent-4)";
       const tint = `color-mix(in oklab, ${colour} 28%, var(--surface))`;
       const time = `${fmtHm(ev.start)}${ev.end ? `–${fmtHm(ev.end)}` : ""}`;
-      // Mark very short blocks so the CSS can hide the text entirely
-      // (an illegible string of letter-tops is worse than a clean bar
-      //, the title attr still carries the summary for any browser
-      // that surfaces tooltips). Threshold is generous because the
-      // lane's height varies; 4% of a typical 12-hour span ~= 24-30 px.
       const isTiny = height < 4;
+      const location = ev.location || "";
+      const showLocation = showLocations && location && height > 8;
       return `
-        <div class="tt-event ${isTiny ? "is-tiny" : ""}" style="top:${top.toFixed(2)}%;height:${height.toFixed(2)}%;border-left-color:${colour};--tt-bg:${tint}" title="${escapeHtml(time)} ${escapeHtml(ev.summary || "")}">
+        <div class="tt-event ${isTiny ? "is-tiny" : ""}" style="top:${top.toFixed(2)}%;height:${height.toFixed(2)}%;border-left-color:${colour};--tt-bg:${tint}" title="${escapeHtml(time)} ${escapeHtml(ev.summary || "")}${location ? ` · ${escapeHtml(location)}` : ""}">
           <span class="tt-name">${escapeHtml(ev.summary || "")}</span>
+          ${showLocation ? `<span class="tt-loc"><i class="ph-bold ph-map-pin"></i>${escapeHtml(location)}</span>` : ""}
         </div>`;
     }).join("");
     const nowLine = (showNow && d.is_today)
@@ -168,13 +196,7 @@ export default function render(shadow, ctx) {
   }).join("");
 
   const layout = `
-    /* Today marker, inverse-coloured chip instead of just an accent
-       shift on the day number, so a quick scan locks on the current
-       day. The DOW label drops to on-accent over a tinted backdrop,
-       the day number becomes a filled circle. */
-    .tt-col-head.is-today {
-      color: var(--accent-1);
-    }
+    .tt-col-head.is-today { color: var(--accent-1); }
     .tt-col-head.is-today .tt-col-day {
       background: var(--accent-1);
       color: var(--on-accent);
@@ -185,11 +207,6 @@ export default function render(shadow, ctx) {
       border-radius: 999px;
       font-weight: var(--fw-black);
     }
-
-    /* Weekend tint, soft sunken background on column heads + lanes
-       to set Sat/Sun off from weekdays without yelling. Inset
-       background instead of border so the existing grid gutters
-       stay clean. */
     .tt-col-head.is-weekend {
       background: color-mix(in oklab, var(--text-primary) 4%, transparent);
     }
@@ -206,10 +223,6 @@ export default function render(shadow, ctx) {
       ),
       color-mix(in oklab, var(--text-primary) 3%, transparent);
     }
-
-    /* Per-column event-count chip, small numeric badge under the
-       day number. Hidden when count = 0 (handled in JS so the badge
-       only renders when there are events). */
     .tt-col-head {
       display: flex;
       flex-direction: column;
@@ -218,7 +231,7 @@ export default function render(shadow, ctx) {
       padding-bottom: var(--space-1);
     }
     .tt-col-dow {
-      font-size: var(--fs-caption);
+      font-size: calc(var(--fs-caption) * var(--tt-header-scale, 1));
       font-weight: var(--fw-black);
       letter-spacing: var(--ls-label);
       text-transform: var(--label-transform, uppercase);
@@ -226,7 +239,7 @@ export default function render(shadow, ctx) {
     }
     .tt-col-head.is-today .tt-col-dow { color: var(--accent-1); }
     .tt-col-day {
-      font-size: var(--fs-body);
+      font-size: calc(var(--fs-body) * var(--tt-header-scale, 1));
       font-weight: var(--fw-bold);
       color: var(--text-primary);
       line-height: 1.1;
@@ -247,39 +260,20 @@ export default function render(shadow, ctx) {
       background: color-mix(in oklab, var(--accent-1) 20%, var(--surface));
       color: var(--accent-1);
     }
-
-    /* xs / sm: drop the count chips to free space for the day-num
-       circles. */
     @container (max-width: 360px) {
       .tt-col-count { display: none; }
     }
-
-    /* Event blocks, week view squeezes events into narrow columns,
-       so the title needs a tighter line-height + minimal top
-       padding to keep all the letters visible inside the block.
-       The base .tt-event styles in spectra-widgets.css set
-       line-height: 1.1 plus var(--space-1) vertical padding, which
-       combined with the small font-size we want here pushed the
-       descender row past the overflow boundary, letters were
-       clipping at the bottom.
-
-       Title wraps for taller events via line-clamp (up to 3 lines),
-       so a 90-min meeting can spell out "Architecture review" rather
-       than truncating to "Archit...". Short events still single-line
-       ellipsis since they don't have the height to wrap. */
+    /* event_row_padding_em adds on top of the fixed 2px base, so 0
+       (default) reproduces the previous fixed spacing. */
     .tt-event {
-      padding-top: 2px;
-      padding-bottom: 2px;
+      padding-top: calc(2px + var(--tt-row-pad, 0em));
+      padding-bottom: calc(2px + var(--tt-row-pad, 0em));
       gap: 0;
     }
     .tt-event .tt-name {
-      font-size: calc(var(--fs-caption) * 0.88);
+      font-size: calc(var(--fs-caption) * 0.88 * var(--tt-title-scale, 1));
       line-height: 1.05;
       font-weight: var(--fw-black);
-      /* Multi-line wrap with line-clamp so taller events use their
-         vertical room. White-space: normal lets the browser break on
-         word boundaries; -webkit-line-clamp caps at 3 lines and the
-         remaining lines truncate with ellipsis. */
       display: -webkit-box;
       -webkit-line-clamp: 3;
       line-clamp: 3;
@@ -289,30 +283,47 @@ export default function render(shadow, ctx) {
       word-break: break-word;
       hyphens: auto;
     }
-    /* Tiny event blocks (under ~4% of lane height) drop the text
-       and just paint as a coloured bar. An illegible string of
-       letter-tops reads worse than a clean coloured strip; the
-       title attribute still carries the summary for any browser
-       that surfaces tooltips. */
     .tt-event.is-tiny .tt-name { display: none; }
     .tt-event.is-tiny { padding-top: 0; padding-bottom: 0; }
 
-    /* hide_labels cell option, when on, every event block paints as
-       its colour bar only (same treatment as is-tiny). Reads as a
-       glance-friendly heatmap of feed colours when the dashboard
-       cares about "what kind of day is this" more than "what's the
-       title of each meeting". */
+    /* Location row, off by default (show_location cell option). */
+    .tt-event .tt-loc {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.2em;
+      font-size: calc(var(--fs-caption) * 0.75 * var(--tt-loc-scale, 1));
+      font-weight: var(--fw-bold);
+      color: var(--text-muted);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 100%;
+    }
+    .tt-event .tt-loc .ph-bold { font-size: 0.9em; flex: 0 0 auto; }
+
     [data-hide-labels="true"] .tt-event .tt-name { display: none; }
+    [data-hide-labels="true"] .tt-event .tt-loc { display: none; }
     [data-hide-labels="true"] .tt-event {
       padding-top: 0;
       padding-bottom: 0;
     }
+
+    /* spectra-widgets.css's shared .tt-allday-pill has a fixed
+       font-size; scope the title-scale override here. */
+    .tt-allday-pill { font-size: calc(var(--fs-caption) * var(--tt-title-scale, 1)); }
+
+    /* header_scale: the day column headers.
+       axis_label_scale: the hour gutter labels.
+       title_scale: the "THIS WEEK" dashboard title. */
+    .tt-hours { font-size: calc(var(--fs-caption) * var(--tt-axis-scale, 1)); }
+    .cal-head-title { font-size: calc(1em * var(--tt-dash-title-scale, 1)); }
+    .cal-head-meta { font-size: calc(1em * var(--tt-dash-title-scale, 1)); }
   `;
 
   shadow.innerHTML = `
     ${css}
     <style>${layout}</style>
-    <div class="w" data-widget="calendar_week" data-hide-labels="${hideLabels}">
+    <div class="w" data-widget="calendar_week" data-hide-labels="${hideLabels}" style="${styleAttr}">
       <div class="w-body" style="gap:var(--space-3)">
         <div class="cal-head">
           <div class="cal-head-row">

--- a/plugins/calendar_week/client.js
+++ b/plugins/calendar_week/client.js
@@ -67,6 +67,95 @@ function fmtHm(iso) {
   return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
 }
 
+// A timed (non-all-day) event's end can land on a different local
+// calendar day than its start (an overnight event, or a genuinely
+// multi-day timed block like a trip). Subtracting raw hour-of-day
+// across two different dates is meaningless — it previously produced
+// negative/near-zero heights and corrupted computeRange's auto-fit
+// window for the whole visible week. Treat "ends on a later day" as
+// "runs to the bottom of this day" instead. Used for the week-wide
+// auto-fit range only, where a coarse "runs to midnight" is enough —
+// see clampToDay for the per-day-copy rendering split.
+function eventEndHour(ev, s) {
+  const e = parseTime(ev.end);
+  if (e == null) return s != null ? s + 1 : null;
+  if (s == null) return e;
+  const sameDay = new Date(ev.start).toDateString() === new Date(ev.end).toDateString();
+  return sameDay ? e : 24;
+}
+
+function localDateKey(d) {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+// The server repeats a multi-day timed event's original start/end on
+// every covered day's bucket (so each day's own copy carries the true
+// event times for the tooltip). Rendering a middle/end-day copy at the
+// *original* start hour is wrong — e.g. a Sun 16:00 → Fri 10:00 trip
+// would redraw a 16:00-start block on Wednesday too. Clamp per day:
+// only the actual start day keeps the real start hour (else 00:00),
+// and only the actual end day keeps the real end hour (else 24:00).
+export function clampToDay(ev, dayDate) {
+  const s = parseTime(ev.start);
+  if (s == null) return null;
+  const startKey = localDateKey(new Date(ev.start));
+  const endDate = ev.end ? new Date(ev.end) : null;
+  const endKey = endDate ? localDateKey(endDate) : startKey;
+  const isStartDay = !dayDate || dayDate === startKey;
+  const isEndDay = !dayDate || dayDate === endKey;
+  const top = isStartDay ? s : 0;
+  let bottom = isEndDay ? (endDate ? parseTime(ev.end) : top + 1) : 24;
+  if (bottom == null || bottom <= top) bottom = Math.min(24, top + 1);
+  return { s: top, e: bottom };
+}
+
+// Converts an [s, e) hour-space block into a top/height percentage pair
+// against the visible [rangeStart, rangeStart + spanHours] lane, clamping
+// each edge independently into [0,100] *before* deriving height. A
+// pass-through day of a multi-day event spans the full 0-24h logical day
+// (clampToDay), which routinely runs past a narrowed
+// day_start_hour/day_end_hour window — deriving height from the unclamped
+// span first would let it exceed 100% and, since nothing upstream clips
+// overflow, spill the block out past the lane's bottom edge instead of
+// stopping at it.
+export function pctSpan(s, e, rangeStart, spanHours) {
+  const rawTop = ((s - rangeStart) / spanHours) * 100;
+  const rawBottom = ((e - rangeStart) / spanHours) * 100;
+  const top = Math.max(0, Math.min(rawTop, 100));
+  const bottom = Math.max(0, Math.min(rawBottom, 100));
+  return { top, height: Math.max(2, bottom - top) };
+}
+
+// Groups an all-day event's per-day copies (identical start/end/summary
+// on each, per the server-side spread) back into a single {ev, first,
+// last} bar spanning the day-column indices it covers.
+function collectAllDayBars(days) {
+  const byKey = new Map();
+  days.forEach((d, i) => {
+    (d.events || []).filter((e) => e.all_day).forEach((ev) => {
+      const key = `${ev.start}|${ev.end}|${ev.summary}`;
+      const bar = byKey.get(key);
+      if (bar) bar.last = i;
+      else byKey.set(key, { ev, first: i, last: i });
+    });
+  });
+  return [...byKey.values()];
+}
+
+// Greedy interval-packing so overlapping bars stack into separate lanes
+// instead of colliding when two all-day events cover the same day(s).
+function packAllDayLanes(bars) {
+  const laneEnds = [];
+  return bars
+    .sort((a, b) => a.first - b.first)
+    .map((bar) => {
+      let lane = laneEnds.findIndex((end) => end < bar.first);
+      if (lane === -1) { lane = laneEnds.length; laneEnds.push(bar.last); }
+      else laneEnds[lane] = bar.last;
+      return { ...bar, lane };
+    });
+}
+
 // day_start_hour / day_end_hour cell options override either edge
 // (-1 = keep auto-fitting that edge); set both to 0/24 to always show
 // the whole day regardless of events.
@@ -77,7 +166,7 @@ export function computeRange(days, startOverride = -1, endOverride = -1) {
       if (ev.all_day) continue;
       const s = parseTime(ev.start);
       if (s != null) { lo = Math.min(lo, s); has = true; }
-      const e = parseTime(ev.end) ?? (s != null ? s + 1 : null);
+      const e = eventEndHour(ev, s);
       if (e != null) { hi = Math.max(hi, e); has = true; }
     }
   }
@@ -163,39 +252,37 @@ export default function render(shadow, ctx) {
   const showNow = nowH >= range.start && nowH <= range.end;
   const nowPct = showNow ? ((nowH - range.start) / span) * 100 : 0;
 
-  // ponytail: all-day events render as same-day pills per column; a
-  // multi-day event shows once per day it overlaps (server already
-  // expands it into every covered day's bucket) rather than as a
-  // single strip spanning columns. Add column-spanning rendering if
-  // that turns out to matter in practice.
-  const alldayRow = days.map((d) => {
-    const allDayEvents = (d.events || []).filter((e) => e.all_day);
-    if (!allDayEvents.length) return `<div class="tt-allday"></div>`;
-    const pills = allDayEvents.map((ev) => {
-      const colour = ev.colour || "var(--accent-4)";
-      const tint = `color-mix(in oklab, ${colour} 28%, var(--surface))`;
-      return `<span class="tt-allday-pill" style="border-left-color:${colour};--tt-bg:${tint}">${escapeHtml(ev.summary || "")}</span>`;
-    }).join("");
-    return `<div class="tt-allday">${pills}</div>`;
-  }).join("");
-  const hasAllDay = days.some((d) => (d.events || []).some((e) => e.all_day));
+  // The server spreads a multi-day all-day event across every covered
+  // day's bucket (same start/end/summary on each copy) so today's view
+  // always includes it. Group those copies back into one bar spanning
+  // the covered day columns instead of repeating the label per day.
+  const allDayBars = packAllDayLanes(collectAllDayBars(days));
+  // grid-column:2/-1 (day columns only, no hour-gutter track) + a plain
+  // repeat(N,1fr) here is deliberate: this wrapper is a *nested* grid,
+  // sized independently of the outer .tt.is-week grid. An "auto" gutter
+  // column here has no content to size itself against and collapses to
+  // 0, which widened every day column and shifted every pill left of
+  // its real day. Dropping the gutter track and starting at the outer
+  // grid's day-column 2 makes this grid's tracks land on the exact same
+  // pixels as the header/lane day columns above and below it.
+  const alldayRow = allDayBars.length
+    ? `<div class="tt-allday-row" style="grid-column:2/-1;display:grid;grid-template-columns:repeat(${days.length}, 1fr);gap:var(--space-1)">${allDayBars.map((bar) => {
+        const colour = bar.ev.colour || "var(--accent-4)";
+        const tint = `color-mix(in oklab, ${colour} 28%, var(--surface))`;
+        return `<span class="tt-allday-pill" style="grid-column:${bar.first + 1} / span ${bar.last - bar.first + 1};grid-row:${bar.lane + 1};border-left-color:${colour};--tt-bg:${tint}">${escapeHtml(bar.ev.summary || "")}</span>`;
+      }).join("")}</div>`
+    : "";
+  const hasAllDay = allDayBars.length > 0;
 
   const lanes = days.map((d) => {
     const isWeekend = d.weekday === 5 || d.weekday === 6;
     const isToday = !!d.is_today;
     const events = (d.events || []).filter((e) => !e.all_day);
     const blocks = events.map((ev) => {
-      const s = parseTime(ev.start);
-      if (s == null) return "";
-      const e = parseTime(ev.end) ?? s + 1;
-      const rawTop = ((s - range.start) / span) * 100;
-      const rawHeight = Math.max(2, ((e - s) / span) * 100);
-      // Clamp the event's top so a row sitting at the very end of the
-      // range (e.g. an event at 24:00) doesn't overflow below the
-      // lane. Cap at (100 - height) so the block always ends inside
-      // the lane's bottom edge.
-      const top = Math.max(0, Math.min(rawTop, 100 - rawHeight));
-      const height = rawHeight;
+      const clamped = clampToDay(ev, d.date);
+      if (clamped == null) return "";
+      const { s, e } = clamped;
+      const { top, height } = pctSpan(s, e, range.start, span);
       const colour = ev.colour || "var(--accent-4)";
       const tint = `color-mix(in oklab, ${colour} 28%, var(--surface))`;
       const time = `${fmtHm(ev.start)}${ev.end ? `–${fmtHm(ev.end)}` : ""}`;
@@ -363,7 +450,7 @@ export default function render(shadow, ctx) {
           <div class="tt is-week" style="flex:1 1 auto;min-height:0;grid-template-rows:${hasAllDay ? "auto auto 1fr" : "auto 1fr"}">
             <div></div>
             ${heads}
-            ${hasAllDay ? `<div></div>${alldayRow}` : ""}
+            ${alldayRow}
             <div class="tt-hours">${hourLabels(range)}</div>
             ${lanes}
           </div>

--- a/plugins/calendar_week/client.js
+++ b/plugins/calendar_week/client.js
@@ -1,18 +1,23 @@
-// calendar_week, Spectra timetable, seven columns. Same per-text-type
-// sizing/spacing/label controls as calendar_day / calendar_three /
-// calendar_schedule:
-// event title/location scale, event row spacing, header/axis label
-// scale, dashboard title scale, configurable day_start_hour/day_end_hour
-// (or "always show the whole day"), a show_location toggle + rendering
-// (absent from the bundled widget), and date_label_style (short/minimal
-// weekday+month abbreviations).
+// calendar_week, Spectra timetable, seven columns. Display header
+// shows the date range ("JUN 1 → 7 · 2026"), columns show DOW + day
+// number with today picked out via an inverse accent-1 chip and
+// weekend columns tinted to read distinct from weekdays. Each
+// column head also carries a small event-count chip so a glance
+// answers "which day is the busiest?" without scrolling the lane.
+//
+// Same per-text-type sizing/spacing/label controls as calendar_day /
+// calendar_three / calendar_schedule: event title/location scale,
+// event row spacing, header/axis label scale, dashboard title scale,
+// configurable day_start_hour/day_end_hour (or "always show the whole
+// day"), a show_location toggle + rendering (absent from the bundled
+// widget), and date_label_style (short/minimal weekday+month
+// abbreviations).
 
 const MONTH_SHORT = [
   "JAN", "FEB", "MAR", "APR", "MAY", "JUN",
   "JUL", "AUG", "SEP", "OCT", "NOV", "DEC",
 ];
 const DOW = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"];
-const DOW_SUN = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
 
 // date_label_style cell option: "short" (default, current 3-letter
 // behaviour), "minimal" (1-2 chars, just enough to stay unambiguous), or
@@ -44,7 +49,10 @@ export function clampScale(raw, def, lo, hi) {
 
 // Parse the ISO timestamp through Date so the resulting hour is in
 // the renderer's LOCAL timezone, not whatever offset is baked into
-// the ISO string.
+// the ISO string. calendar_core's server normalises everything to
+// UTC ISO; the previous string-slicing path was treating "14:00
+// Melbourne → 04:00 UTC" as "render at hour 4", landing every event
+// 10 hours from its true local time.
 function parseTime(iso) {
   if (typeof iso !== "string") return null;
   const d = new Date(iso);
@@ -103,11 +111,6 @@ function fmtRange(startIso, endIso, labelStyle) {
   return `${startBit} → ${endBit} · ${year}`;
 }
 
-// Which column indices are weekend days, given the chosen week start.
-function weekendIndices(weekStart) {
-  return weekStart === "sunday" ? new Set([0, 6]) : new Set([5, 6]);
-}
-
 export default function render(shadow, ctx) {
   const data = ctx?.data ?? {};
   const opts = ctx?.cell?.options || {};
@@ -137,14 +140,12 @@ export default function render(shadow, ctx) {
   const days = Array.isArray(data.days) ? data.days.slice(0, 7) : [];
   const range = computeRange(days, startHour, endHour);
   const span = Math.max(1, range.end - range.start);
-  const dowNames = (data.week_start === "sunday") ? DOW_SUN : DOW;
   const rangeMeta = fmtRange(data.start, data.end, labelStyle);
-  const weekendCols = weekendIndices(data.week_start || "monday");
 
-  const heads = days.map((d, i) => {
-    const name = styleShortLabel(dowNames[i] || "", labelStyle, DOW_MINIMAL, DOW_FULL);
+  const heads = days.map((d) => {
+    const name = styleShortLabel(DOW[d.weekday] || "", labelStyle, DOW_MINIMAL, DOW_FULL);
     const isToday = !!d.is_today;
-    const isWeekend = weekendCols.has(i);
+    const isWeekend = d.weekday === 5 || d.weekday === 6;
     const count = Array.isArray(d.events) ? d.events.length : 0;
     const classes = ["tt-col-head"];
     if (isToday) classes.push("is-today");
@@ -162,8 +163,25 @@ export default function render(shadow, ctx) {
   const showNow = nowH >= range.start && nowH <= range.end;
   const nowPct = showNow ? ((nowH - range.start) / span) * 100 : 0;
 
-  const lanes = days.map((d, i) => {
-    const isWeekend = weekendCols.has(i);
+  // ponytail: all-day events render as same-day pills per column; a
+  // multi-day event shows once per day it overlaps (server already
+  // expands it into every covered day's bucket) rather than as a
+  // single strip spanning columns. Add column-spanning rendering if
+  // that turns out to matter in practice.
+  const alldayRow = days.map((d) => {
+    const allDayEvents = (d.events || []).filter((e) => e.all_day);
+    if (!allDayEvents.length) return `<div class="tt-allday"></div>`;
+    const pills = allDayEvents.map((ev) => {
+      const colour = ev.colour || "var(--accent-4)";
+      const tint = `color-mix(in oklab, ${colour} 28%, var(--surface))`;
+      return `<span class="tt-allday-pill" style="border-left-color:${colour};--tt-bg:${tint}">${escapeHtml(ev.summary || "")}</span>`;
+    }).join("");
+    return `<div class="tt-allday">${pills}</div>`;
+  }).join("");
+  const hasAllDay = days.some((d) => (d.events || []).some((e) => e.all_day));
+
+  const lanes = days.map((d) => {
+    const isWeekend = d.weekday === 5 || d.weekday === 6;
     const isToday = !!d.is_today;
     const events = (d.events || []).filter((e) => !e.all_day);
     const blocks = events.map((ev) => {
@@ -172,11 +190,20 @@ export default function render(shadow, ctx) {
       const e = parseTime(ev.end) ?? s + 1;
       const rawTop = ((s - range.start) / span) * 100;
       const rawHeight = Math.max(2, ((e - s) / span) * 100);
+      // Clamp the event's top so a row sitting at the very end of the
+      // range (e.g. an event at 24:00) doesn't overflow below the
+      // lane. Cap at (100 - height) so the block always ends inside
+      // the lane's bottom edge.
       const top = Math.max(0, Math.min(rawTop, 100 - rawHeight));
       const height = rawHeight;
       const colour = ev.colour || "var(--accent-4)";
       const tint = `color-mix(in oklab, ${colour} 28%, var(--surface))`;
       const time = `${fmtHm(ev.start)}${ev.end ? `–${fmtHm(ev.end)}` : ""}`;
+      // Mark very short blocks so the CSS can hide the text entirely
+      // (an illegible string of letter-tops is worse than a clean bar
+      //, the title attr still carries the summary for any browser
+      // that surfaces tooltips). Threshold is generous because the
+      // lane's height varies; 4% of a typical 12-hour span ~= 24-30 px.
       const isTiny = height < 4;
       const location = ev.location || "";
       const showLocation = showLocations && location && height > 8;
@@ -333,9 +360,10 @@ export default function render(shadow, ctx) {
           <div class="cal-head-rule"></div>
         </div>
         <div class="tt-body" style="--tt-hours:${span};flex:1 1 auto;min-height:0;display:flex;flex-direction:column">
-          <div class="tt is-week" style="flex:1 1 auto;min-height:0;grid-template-rows:auto 1fr">
+          <div class="tt is-week" style="flex:1 1 auto;min-height:0;grid-template-rows:${hasAllDay ? "auto auto 1fr" : "auto 1fr"}">
             <div></div>
             ${heads}
+            ${hasAllDay ? `<div></div>${alldayRow}` : ""}
             <div class="tt-hours">${hourLabels(range)}</div>
             ${lanes}
           </div>

--- a/plugins/calendar_week/plugin.json
+++ b/plugins/calendar_week/plugin.json
@@ -14,6 +14,23 @@
   },
   "cell_options": [
     {
+      "name": "feeds_filter",
+      "type": "string",
+      "label": "Feed IDs (comma-separated; blank = all enabled)",
+      "default": ""
+    },
+    {
+      "name": "range_mode",
+      "type": "select",
+      "label": "7-day window",
+      "default": "calendar_week",
+      "choices": [
+        {"value": "calendar_week", "label": "Current calendar week (fixed start day)"},
+        {"value": "rolling_7", "label": "Next 7 days (rolling from today)"}
+      ],
+      "help": "Calendar week always starts on 'Week starts on' below, so it jumps back once today isn't that day. Rolling always starts today."
+    },
+    {
       "name": "week_start",
       "type": "select",
       "label": "Week starts on",
@@ -21,13 +38,8 @@
       "choices": [
         {"value": "sunday", "label": "Sunday"},
         {"value": "monday", "label": "Monday"}
-      ]
-    },
-    {
-      "name": "feeds_filter",
-      "type": "string",
-      "label": "Feed IDs (comma-separated; blank = all enabled)",
-      "default": ""
+      ],
+      "help": "Only used when '7-day window' above is set to Current calendar week."
     },
     {
       "name": "day_start_hour",

--- a/plugins/calendar_week/plugin.json
+++ b/plugins/calendar_week/plugin.json
@@ -1,9 +1,9 @@
 {
   "tesserae_compat": "1.x",
   "name": "Calendar, Week",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "kind": "widget",
-  "description": "Seven-day strip Each event's colour comes from its feed (Widgets \u2192 Calendar Feeds).",
+  "description": "Seven-day strip timetable with tunable event text sizing/spacing, configurable visible hour range, and a location toggle. Each event's colour comes from its feed (Widgets → Calendar Feeds).",
   "icon": "ph-calendar",
   "supports": {
     "sizes": [
@@ -19,15 +19,37 @@
       "label": "Week starts on",
       "default": "monday",
       "choices": [
-        {
-          "value": "sunday",
-          "label": "Sunday"
-        },
-        {
-          "value": "monday",
-          "label": "Monday"
-        }
+        {"value": "sunday", "label": "Sunday"},
+        {"value": "monday", "label": "Monday"}
       ]
+    },
+    {
+      "name": "feeds_filter",
+      "type": "string",
+      "label": "Feed IDs (comma-separated; blank = all enabled)",
+      "default": ""
+    },
+    {
+      "name": "day_start_hour",
+      "type": "slider",
+      "label": "Day starts at",
+      "default": -1,
+      "min": -1,
+      "max": 24,
+      "step": 1,
+      "unit": "h",
+      "help": "Hour the visible timetable starts (0-24). -1 = auto-fit to events. Set to 0 (with Day ends at = 24) to always show the whole day."
+    },
+    {
+      "name": "day_end_hour",
+      "type": "slider",
+      "label": "Day ends at",
+      "default": -1,
+      "min": -1,
+      "max": 24,
+      "step": 1,
+      "unit": "h",
+      "help": "Hour the visible timetable ends (0-24). -1 = auto-fit to events. Set to 24 (with Day starts at = 0) to always show the whole day."
     },
     {
       "name": "hide_labels",
@@ -36,10 +58,88 @@
       "default": false
     },
     {
-      "name": "feeds_filter",
-      "type": "string",
-      "label": "Feed IDs (comma-separated; blank = all enabled)",
-      "default": ""
+      "name": "show_location",
+      "type": "boolean",
+      "label": "Show event locations",
+      "default": false,
+      "help": "Off by default: seven narrow columns rarely have room for a location line."
+    },
+    {
+      "name": "date_label_style",
+      "type": "select",
+      "label": "Weekday / month label style",
+      "default": "short",
+      "choices": [
+        {"value": "full", "label": "Full word (Monday, January)"},
+        {"value": "short", "label": "Short (MON, JAN)"},
+        {"value": "minimal", "label": "Minimal (M, JA)"}
+      ]
+    },
+    {
+      "name": "title_scale",
+      "type": "slider",
+      "label": "Dashboard title size",
+      "default": 1.0,
+      "min": 0.01,
+      "max": 10.0,
+      "step": 0.05,
+      "unit": "×",
+      "help": "Multiplier on the 'THIS WEEK' header row at the top of the widget."
+    },
+    {
+      "name": "header_scale",
+      "type": "slider",
+      "label": "Day header size",
+      "default": 1.0,
+      "min": 0.01,
+      "max": 10.0,
+      "step": 0.05,
+      "unit": "×",
+      "help": "Multiplier on each column's weekday/day-number header text."
+    },
+    {
+      "name": "axis_label_scale",
+      "type": "slider",
+      "label": "Time axis label size",
+      "default": 1.0,
+      "min": 0.01,
+      "max": 10.0,
+      "step": 0.05,
+      "unit": "×",
+      "help": "Multiplier on the hour-gutter time labels (08:00, 10:00, ...)."
+    },
+    {
+      "name": "event_title_scale",
+      "type": "slider",
+      "label": "Event title size",
+      "default": 1.0,
+      "min": 0.01,
+      "max": 10.0,
+      "step": 0.05,
+      "unit": "×",
+      "help": "Multiplier on the event title font size. 1.0 = default."
+    },
+    {
+      "name": "event_location_scale",
+      "type": "slider",
+      "label": "Event location size",
+      "default": 1.0,
+      "min": 0.01,
+      "max": 10.0,
+      "step": 0.05,
+      "unit": "×",
+      "help": "Multiplier on the location text font size (when shown)."
+    },
+    {
+      "name": "event_row_padding_em",
+      "type": "slider",
+      "label": "Event block spacing",
+      "default": 0.0,
+      "min": 0.0,
+      "max": 3.0,
+      "step": 0.05,
+      "unit": "em",
+      "help": "Extra padding added inside each event block, on top of the default. 0 = default."
     }
   ],
   "render": {
@@ -49,41 +149,21 @@
   "data_schema": {
     "color": "#4F6F36",
     "fields": [
-      {
-        "name": "start",
-        "type": "str",
-        "label": "Week start"
-      },
-      {
-        "name": "end",
-        "type": "str",
-        "label": "Week end"
-      },
-      {
-        "name": "days",
-        "type": "arr",
-        "label": "Days"
-      }
+      {"name": "start", "type": "str", "label": "Week start"},
+      {"name": "end", "type": "str", "label": "Week end"},
+      {"name": "days", "type": "arr", "label": "Days"}
     ],
     "sample": {
       "start": "2026-07-06",
       "end": "2026-07-12",
       "days": [
-        {
-          "date": "2026-07-06",
-          "day": 6,
-          "is_today": false,
-          "events": []
-        },
+        {"date": "2026-07-06", "day": 6, "is_today": false, "events": []},
         {
           "date": "2026-07-10",
           "day": 10,
           "is_today": true,
           "events": [
-            {
-              "summary": "Standup",
-              "start": "2026-07-10T09:30:00"
-            }
+            {"summary": "Standup", "start": "2026-07-10T09:30:00", "location": "Zoom"}
           ]
         },
         {
@@ -91,10 +171,7 @@
           "day": 12,
           "is_today": false,
           "events": [
-            {
-              "summary": "Market",
-              "start": "2026-07-12T08:00:00"
-            }
+            {"summary": "Market", "start": "2026-07-12T08:00:00"}
           ]
         }
       ]

--- a/plugins/calendar_week/server.py
+++ b/plugins/calendar_week/server.py
@@ -8,7 +8,11 @@ from typing import Any
 
 from flask import current_app
 
-from app.calendar_time import event_local_date_key, local_midnight_utc
+from app.calendar_time import (
+    all_day_event_date_keys,
+    event_local_date_key,
+    local_midnight_utc,
+)
 from app.tz_resolve import app_timezone
 
 
@@ -31,10 +35,19 @@ def fetch(
     zone = app_timezone()
     today = datetime.now(zone).date()
     week_start = options.get("week_start", "monday")
-    first_weekday = 6 if week_start == "sunday" else 0
-    # Start the week on the chosen weekday at-or-before today.
-    offset = (today.weekday() - first_weekday) % 7
-    start_date = today - timedelta(days=offset)
+    # range_mode: "calendar_week" (default) anchors the 7-day window to the
+    # chosen week_start, same as before; "rolling_7" ignores week_start and
+    # always starts today, so the widget shows "today + the next 6 days"
+    # instead of jumping back to Sunday/Monday once today isn't the first
+    # day of the calendar week.
+    range_mode = options.get("range_mode", "calendar_week")
+    if range_mode == "rolling_7":
+        start_date = today
+    else:
+        first_weekday = 6 if week_start == "sunday" else 0
+        # Start the week on the chosen weekday at-or-before today.
+        offset = (today.weekday() - first_weekday) % 7
+        start_date = today - timedelta(days=offset)
     end_date = start_date + timedelta(days=7)
 
     start_dt = local_midnight_utc(start_date, zone)
@@ -51,10 +64,17 @@ def fetch(
     except Exception as err:
         return {"error": f"{type(err).__name__}: {err}", "days": []}
 
+    # Bucket timed events by their local start date. All-day event DTEND
+    # values are exclusive, so expand them across each covered visible date
+    # (same split as calendar_month) rather than only their start day.
     buckets: dict[str, list[dict[str, Any]]] = {}
     for ev in events:
-        day_key = event_local_date_key(ev, zone)
-        buckets.setdefault(day_key, []).append(ev)
+        if ev.get("all_day"):
+            day_keys = all_day_event_date_keys(ev, start_date, end_date)
+        else:
+            day_keys = [event_local_date_key(ev, zone)]
+        for day_key in day_keys:
+            buckets.setdefault(day_key, []).append(ev)
 
     days = []
     cur = start_date

--- a/plugins/calendar_week/server.py
+++ b/plugins/calendar_week/server.py
@@ -78,6 +78,7 @@ def fetch(
                         "end": e.get("end"),
                         "all_day": e.get("all_day", False),
                         "colour": e.get("feed_colour"),
+                        "location": e.get("location") or "",
                     }
                     for e in all_evs
                 ],

--- a/plugins/calendar_week/server.py
+++ b/plugins/calendar_week/server.py
@@ -10,8 +10,8 @@ from flask import current_app
 
 from app.calendar_time import (
     all_day_event_date_keys,
-    event_local_date_key,
     local_midnight_utc,
+    timed_event_date_keys,
 )
 from app.tz_resolve import app_timezone
 
@@ -64,15 +64,18 @@ def fetch(
     except Exception as err:
         return {"error": f"{type(err).__name__}: {err}", "days": []}
 
-    # Bucket timed events by their local start date. All-day event DTEND
-    # values are exclusive, so expand them across each covered visible date
-    # (same split as calendar_month) rather than only their start day.
+    # Expand every event across each visible day it covers: all-day DTEND
+    # values are exclusive so they're spread across each covered date (same
+    # split as calendar_month), and a timed event's [start, end) span can
+    # itself cross midnight or run several days (an overnight block, a
+    # multi-day trip) — bucketing it only on its start day would make it
+    # vanish from every day after that.
     buckets: dict[str, list[dict[str, Any]]] = {}
     for ev in events:
         if ev.get("all_day"):
             day_keys = all_day_event_date_keys(ev, start_date, end_date)
         else:
-            day_keys = [event_local_date_key(ev, zone)]
+            day_keys = timed_event_date_keys(ev, zone, start_date, end_date)
         for day_key in day_keys:
             buckets.setdefault(day_key, []).append(ev)
 

--- a/plugins/calendar_week/tests/clamp_check.mjs
+++ b/plugins/calendar_week/tests/clamp_check.mjs
@@ -1,7 +1,7 @@
 // Plain-node self-check (no test framework in this repo).
 // Run: node tests/clamp_check.mjs
 import assert from "node:assert/strict";
-import { clampScale, computeRange, styleShortLabel } from "../client.js";
+import { clampScale, clampToDay, computeRange, pctSpan, styleShortLabel } from "../client.js";
 
 assert.equal(clampScale(undefined, 1.0, 0.7, 1.5), 1.0, "missing falls back to default");
 assert.equal(clampScale(null, 1.0, 0.7, 1.5), 1.0, "null falls back to default");
@@ -19,6 +19,29 @@ assert.deepEqual(
 );
 assert.deepEqual(computeRange([], 0, 24), { start: 0, end: 24 }, "explicit 0/24 shows the whole day");
 assert.deepEqual(computeRange([], 20, 20), { start: 20, end: 21 }, "equal start/end widened by 1h to stay renderable");
+
+// clampToDay: the server repeats a multi-day timed event's original
+// start/end on every covered day's bucket, so each day-copy must clamp
+// to *that* day, not redraw at the trip's original start hour.
+const trip = { start: "2026-08-09T16:00:00", end: "2026-08-14T10:00:00" };
+assert.deepEqual(clampToDay(trip, "2026-08-09"), { s: 16, e: 24 }, "start day keeps the real start hour, runs to midnight");
+assert.deepEqual(clampToDay(trip, "2026-08-11"), { s: 0, e: 24 }, "a pass-through day runs the full 24h, not the start hour");
+assert.deepEqual(clampToDay(trip, "2026-08-14"), { s: 0, e: 10 }, "end day starts at midnight, keeps the real end hour");
+assert.deepEqual(
+  clampToDay({ start: "2026-08-09T16:00:00", end: "2026-08-09T17:00:00" }, "2026-08-09"),
+  { s: 16, e: 17 },
+  "single-day event is unaffected"
+);
+
+// pctSpan: a block's [s,e) hour span must clamp to the visible lane
+// without ever exceeding 100% height, even when day_start_hour/
+// day_end_hour narrows the range well below a pass-through day's full
+// 0-24h span (regression: height used to be derived from the *unclamped*
+// span, so it could exceed 100% and spill past the lane's bottom edge).
+assert.deepEqual(pctSpan(9, 17, 8, 10), { top: 10, height: 80 }, "fully inside the range renders normally");
+assert.deepEqual(pctSpan(0, 24, 8, 4), { top: 0, height: 100 }, "a full 0-24h pass-through day clamps to exactly the lane, not beyond");
+assert.deepEqual(pctSpan(0, 24, 8, 10), { top: 0, height: 100 }, "still clamps to 100% with a wider (but still partial) range");
+assert.deepEqual(pctSpan(20, 24, 8, 4), { top: 100, height: 2 }, "a span entirely after the visible range clamps to the bottom edge, not off it");
 
 // date_label_style: short (current) / minimal (1-2 chars) / full (whole word).
 const DOW_MINIMAL = { TUE: "TU", THU: "TH" };

--- a/plugins/calendar_week/tests/clamp_check.mjs
+++ b/plugins/calendar_week/tests/clamp_check.mjs
@@ -1,0 +1,32 @@
+// Plain-node self-check (no test framework in this repo).
+// Run: node tests/clamp_check.mjs
+import assert from "node:assert/strict";
+import { clampScale, computeRange, styleShortLabel } from "../client.js";
+
+assert.equal(clampScale(undefined, 1.0, 0.7, 1.5), 1.0, "missing falls back to default");
+assert.equal(clampScale(null, 1.0, 0.7, 1.5), 1.0, "null falls back to default");
+assert.equal(clampScale("not-a-number", 1.0, 0.7, 1.5), 1.0, "unparsable falls back to default");
+assert.equal(clampScale(1.3, 1.0, 0.7, 1.5), 1.3, "in-range value passes through");
+assert.equal(clampScale(9, 1.0, 0.7, 1.5), 1.5, "above max clamps down");
+assert.equal(clampScale(0.01, 1.0, 0.7, 1.5), 0.7, "below min clamps up");
+
+// computeRange: day_start_hour/day_end_hour overrides (-1 = auto-fit).
+assert.deepEqual(computeRange([]), { start: 8, end: 18 }, "no events falls back to 8-18");
+assert.deepEqual(
+  computeRange([{ events: [{ start: "2026-01-01T10:00:00", end: "2026-01-01T11:00:00" }] }]),
+  { start: 9, end: 12 },
+  "auto-fits with 1h padding around events"
+);
+assert.deepEqual(computeRange([], 0, 24), { start: 0, end: 24 }, "explicit 0/24 shows the whole day");
+assert.deepEqual(computeRange([], 20, 20), { start: 20, end: 21 }, "equal start/end widened by 1h to stay renderable");
+
+// date_label_style: short (current) / minimal (1-2 chars) / full (whole word).
+const DOW_MINIMAL = { TUE: "TU", THU: "TH" };
+const DOW_FULL = { TUE: "Tuesday" };
+assert.equal(styleShortLabel("TUE", "short", DOW_MINIMAL), "TUE", "short passes the existing label through unchanged");
+assert.equal(styleShortLabel("TUE", "minimal", DOW_MINIMAL), "TU", "minimal uses the disambiguation map");
+assert.equal(styleShortLabel("ZZZ", "minimal", {}), "ZZ", "unmapped label falls back to first 2 chars");
+assert.equal(styleShortLabel("TUE", "full", DOW_MINIMAL, DOW_FULL), "Tuesday", "full looks up the whole word");
+assert.equal(styleShortLabel("ZZZ", "full", {}, {}), "ZZZ", "unmapped full falls back to the short label as-is");
+
+console.log("clamp_check.mjs: all assertions passed");

--- a/plugins/calendar_week/tests/test_smoke.py
+++ b/plugins/calendar_week/tests/test_smoke.py
@@ -1,0 +1,80 @@
+"""Smoke test for calendar_week's range_mode cell option.
+
+Same stub-current_app setup as the other calendar_* widgets: patch
+calendar_core's load_events so the test exercises the date-window logic
+without reaching real ICS feeds.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, UTC
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import server
+
+
+def _stub_app(events: list[dict[str, Any]] | None = None) -> MagicMock:
+    core = MagicMock()
+    core.server_module.load_events.return_value = events or []
+    core.data_dir = "/tmp/calendar_core_unused"
+    registry = MagicMock()
+    registry.get.return_value = core
+    app = MagicMock()
+    app.config = {"PLUGIN_REGISTRY": registry}
+    return app
+
+
+def test_rolling_7_always_starts_today() -> None:
+    app = _stub_app()
+    with patch.object(server, "current_app", app):
+        out = server.fetch(options={"range_mode": "rolling_7"}, settings={}, ctx={})
+    today = datetime.now(UTC).date()
+    assert out["start"] == today.isoformat()
+    assert out["end"] == (today + timedelta(days=6)).isoformat()
+    assert out["days"][0]["is_today"] is True
+
+
+def test_calendar_week_default_unchanged() -> None:
+    app = _stub_app()
+    with patch.object(server, "current_app", app):
+        out = server.fetch(options={}, settings={}, ctx={})
+    today = datetime.now(UTC).date()
+    start = datetime.strptime(out["start"], "%Y-%m-%d").date()
+    assert start <= today <= start + timedelta(days=6)
+    assert any(d["is_today"] for d in out["days"])
+
+
+def test_multi_day_all_day_event_appears_on_every_covered_day() -> None:
+    app = _stub_app()
+    with patch.object(server, "current_app", app):
+        first = server.fetch(options={"range_mode": "rolling_7"}, settings={}, ctx={})
+    start = datetime.strptime(first["start"], "%Y-%m-%d").date()
+    # 3-day conference starting on the window's first day.
+    events = [
+        {
+            "summary": "Conference",
+            "start": start.isoformat(),
+            "end": (start + timedelta(days=3)).isoformat(),
+            "all_day": True,
+            "feed_colour": "#3366CC",
+        }
+    ]
+    app = _stub_app(events)
+    with patch.object(server, "current_app", app):
+        out = server.fetch(options={"range_mode": "rolling_7"}, settings={}, ctx={})
+    covered = out["days"][:3]
+    for day in covered:
+        summaries = [e["summary"] for e in day["events"]]
+        assert summaries == ["Conference"], day["date"]
+    assert out["days"][3]["events"] == []
+
+
+if __name__ == "__main__":
+    test_rolling_7_always_starts_today()
+    test_calendar_week_default_unchanged()
+    test_multi_day_all_day_event_appears_on_every_covered_day()
+    print("test_smoke.py: all assertions passed")

--- a/plugins/calendar_week/tests/test_smoke.py
+++ b/plugins/calendar_week/tests/test_smoke.py
@@ -7,14 +7,24 @@ without reaching real ICS feeds.
 
 from __future__ import annotations
 
+import importlib.util
 import sys
-from datetime import datetime, timedelta, UTC
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-import server
+# Load under a plugin-specific module name rather than a bare ``import
+# server``. Every calendar_* widget has a server.py, so the plain name
+# resolves to whichever plugin's test imported first and the rest silently
+# assert against a sibling widget's fetch().
+_spec = importlib.util.spec_from_file_location(
+    "calendar_week_server", Path(__file__).resolve().parent.parent / "server.py"
+)
+assert _spec is not None and _spec.loader is not None
+server = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = server
+_spec.loader.exec_module(server)
 
 
 def _stub_app(events: list[dict[str, Any]] | None = None) -> MagicMock:
@@ -28,9 +38,19 @@ def _stub_app(events: list[dict[str, Any]] | None = None) -> MagicMock:
     return app
 
 
+def _utc_zone() -> Any:
+    """Pin the widget's timezone for the duration of a test.
+
+    ``app_timezone()`` falls back to the host's zone, so a test that
+    writes event times and window offsets in the same breath only agrees
+    with itself where that zone is UTC. Pinning keeps these deterministic
+    on a developer's machine and on CI alike."""
+    return patch.object(server, "app_timezone", lambda: UTC)
+
+
 def test_rolling_7_always_starts_today() -> None:
     app = _stub_app()
-    with patch.object(server, "current_app", app):
+    with patch.object(server, "current_app", app), _utc_zone():
         out = server.fetch(options={"range_mode": "rolling_7"}, settings={}, ctx={})
     today = datetime.now(UTC).date()
     assert out["start"] == today.isoformat()
@@ -40,7 +60,7 @@ def test_rolling_7_always_starts_today() -> None:
 
 def test_calendar_week_default_unchanged() -> None:
     app = _stub_app()
-    with patch.object(server, "current_app", app):
+    with patch.object(server, "current_app", app), _utc_zone():
         out = server.fetch(options={}, settings={}, ctx={})
     today = datetime.now(UTC).date()
     start = datetime.strptime(out["start"], "%Y-%m-%d").date()
@@ -50,7 +70,7 @@ def test_calendar_week_default_unchanged() -> None:
 
 def test_multi_day_all_day_event_appears_on_every_covered_day() -> None:
     app = _stub_app()
-    with patch.object(server, "current_app", app):
+    with patch.object(server, "current_app", app), _utc_zone():
         first = server.fetch(options={"range_mode": "rolling_7"}, settings={}, ctx={})
     start = datetime.strptime(first["start"], "%Y-%m-%d").date()
     # 3-day conference starting on the window's first day.
@@ -64,7 +84,7 @@ def test_multi_day_all_day_event_appears_on_every_covered_day() -> None:
         }
     ]
     app = _stub_app(events)
-    with patch.object(server, "current_app", app):
+    with patch.object(server, "current_app", app), _utc_zone():
         out = server.fetch(options={"range_mode": "rolling_7"}, settings={}, ctx={})
     covered = out["days"][:3]
     for day in covered:
@@ -78,21 +98,21 @@ def test_multi_day_timed_event_appears_on_every_covered_day() -> None:
     # to be bucketed only on its start day and silently vanish from every
     # day after that, unlike all-day events.
     app = _stub_app()
-    with patch.object(server, "current_app", app):
+    with patch.object(server, "current_app", app), _utc_zone():
         first = server.fetch(options={"range_mode": "rolling_7"}, settings={}, ctx={})
     start = datetime.strptime(first["start"], "%Y-%m-%d").date()
     # A 4-calendar-day trip: starts 16:00 on day 0, ends 10:00 on day 3.
     events = [
         {
             "summary": "Trip",
-            "start": f"{start.isoformat()}T16:00:00",
-            "end": f"{(start + timedelta(days=3)).isoformat()}T10:00:00",
+            "start": f"{start.isoformat()}T16:00:00+00:00",
+            "end": f"{(start + timedelta(days=3)).isoformat()}T10:00:00+00:00",
             "all_day": False,
             "feed_colour": "#3366CC",
         }
     ]
     app = _stub_app(events)
-    with patch.object(server, "current_app", app):
+    with patch.object(server, "current_app", app), _utc_zone():
         out = server.fetch(options={"range_mode": "rolling_7"}, settings={}, ctx={})
     covered = out["days"][:4]
     for day in covered:

--- a/plugins/calendar_week/tests/test_smoke.py
+++ b/plugins/calendar_week/tests/test_smoke.py
@@ -73,8 +73,37 @@ def test_multi_day_all_day_event_appears_on_every_covered_day() -> None:
     assert out["days"][3]["events"] == []
 
 
+def test_multi_day_timed_event_appears_on_every_covered_day() -> None:
+    # Regression: a *timed* (non-all-day) event spanning several days used
+    # to be bucketed only on its start day and silently vanish from every
+    # day after that, unlike all-day events.
+    app = _stub_app()
+    with patch.object(server, "current_app", app):
+        first = server.fetch(options={"range_mode": "rolling_7"}, settings={}, ctx={})
+    start = datetime.strptime(first["start"], "%Y-%m-%d").date()
+    # A 4-calendar-day trip: starts 16:00 on day 0, ends 10:00 on day 3.
+    events = [
+        {
+            "summary": "Trip",
+            "start": f"{start.isoformat()}T16:00:00",
+            "end": f"{(start + timedelta(days=3)).isoformat()}T10:00:00",
+            "all_day": False,
+            "feed_colour": "#3366CC",
+        }
+    ]
+    app = _stub_app(events)
+    with patch.object(server, "current_app", app):
+        out = server.fetch(options={"range_mode": "rolling_7"}, settings={}, ctx={})
+    covered = out["days"][:4]
+    for day in covered:
+        summaries = [e["summary"] for e in day["events"]]
+        assert summaries == ["Trip"], day["date"]
+    assert out["days"][4]["events"] == []
+
+
 if __name__ == "__main__":
     test_rolling_7_always_starts_today()
     test_calendar_week_default_unchanged()
     test_multi_day_all_day_event_appears_on_every_covered_day()
+    test_multi_day_timed_event_appears_on_every_covered_day()
     print("test_smoke.py: all assertions passed")

--- a/static/components.js
+++ b/static/components.js
@@ -6,13 +6,11 @@
 (function () {
   function attachSliders(root) {
     root.querySelectorAll('input[type="range"]:not([data-bound])').forEach((slider) => {
-      const output = root.querySelector(`output[for="${slider.id}"]`);
-      const suffix = slider.dataset.outputSuffix || "";
-      const sync = () => {
-        if (output) output.value = slider.value + suffix;
-        // Paint the filled portion of the track in the accent colour
-        // (WebKit can't draw progress natively; Firefox uses
-        // ::-moz-range-progress for the same effect.)
+      const number = root.querySelector(`input[data-slider-number-for="${slider.id}"]`);
+      // Paint the filled portion of the track in the accent colour
+      // (WebKit can't draw progress natively; Firefox uses
+      // ::-moz-range-progress for the same effect.)
+      const paintFill = () => {
         const min = parseFloat(slider.min || "0");
         const max = parseFloat(slider.max || "100");
         const val = parseFloat(slider.value || "0");
@@ -20,9 +18,22 @@
         const pct = span > 0 ? ((val - min) / span) * 100 : 0;
         slider.style.setProperty("--slider-fill", pct + "%");
       };
-      slider.addEventListener("input", sync);
-      slider.addEventListener("change", sync);
-      sync();
+      const syncFromSlider = () => {
+        if (number) number.value = slider.value;
+        paintFill();
+      };
+      const syncFromNumber = () => {
+        if (!number || number.value === "") return;
+        slider.value = number.value;
+        paintFill();
+      };
+      slider.addEventListener("input", syncFromSlider);
+      slider.addEventListener("change", syncFromSlider);
+      if (number) {
+        number.addEventListener("input", syncFromNumber);
+        number.addEventListener("change", syncFromNumber);
+      }
+      syncFromSlider();
       slider.dataset.bound = "1";
     });
   }

--- a/static/components.js
+++ b/static/components.js
@@ -27,11 +27,21 @@
         slider.value = number.value;
         paintFill();
       };
+      // The range input is the one that carries the field's name, and it
+      // silently clamps anything outside min/max. Typing 9 into a 0.7-1.5
+      // box would leave 9 on screen while 1.5 got submitted, so on commit
+      // the box is rewritten with the value that will actually be saved.
+      const clampNumber = () => {
+        if (!number || number.value === "") return;
+        syncFromNumber();
+        number.value = slider.value;
+      };
       slider.addEventListener("input", syncFromSlider);
       slider.addEventListener("change", syncFromSlider);
       if (number) {
         number.addEventListener("input", syncFromNumber);
-        number.addEventListener("change", syncFromNumber);
+        number.addEventListener("change", clampNumber);
+        number.addEventListener("blur", clampNumber);
       }
       syncFromSlider();
       slider.dataset.bound = "1";

--- a/static/style/forms.css
+++ b/static/style/forms.css
@@ -1454,14 +1454,28 @@ code {
   gap: var(--t-space-2);
 }
 
-.slider-value {
+.slider-value-wrap {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--t-space-1);
+}
+
+input.slider-value {
   font-variant-numeric: tabular-nums;
   font-size: var(--t-size-sm);
   font-weight: 600;
   color: var(--t-fg-soft);
   background: var(--t-surface-soft);
   padding: 2px var(--t-space-2);
+  border: 1px solid var(--t-border);
   border-radius: var(--t-radius-pill);
+  width: 4.5em;
+  text-align: right;
+}
+
+.slider-unit {
+  font-size: var(--t-size-sm);
+  color: var(--t-fg-soft);
 }
 
 input[type="range"].slider {

--- a/templates/_components.html
+++ b/templates/_components.html
@@ -105,8 +105,12 @@ macro here instead.
   <div class="slider-header">
     <label for="{{ field_id }}">{{ label }}{{ info_pop(help) }}</label>
     <span class="slider-value-wrap">
+      {# Display + direct entry only; the range input below carries the
+         field's name, so this one is deliberately unnamed and never
+         reaches the form data. aria-label because the visible <label>
+         points at the range. #}
       <input type="number" class="slider-value" id="{{ field_id }}-number"
-             data-slider-number-for="{{ field_id }}"
+             data-slider-number-for="{{ field_id }}" aria-label="{{ label }}"
              value="{{ value }}" min="{{ min }}" max="{{ max }}" step="{{ step }}">
       {%- if unit %}<span class="slider-unit">{{ unit }}</span>{% endif %}
     </span>

--- a/templates/_components.html
+++ b/templates/_components.html
@@ -104,12 +104,16 @@ macro here instead.
 <div class="field field--slider">
   <div class="slider-header">
     <label for="{{ field_id }}">{{ label }}{{ info_pop(help) }}</label>
-    <output for="{{ field_id }}" class="slider-value">{{ value }}{{ unit }}</output>
+    <span class="slider-value-wrap">
+      <input type="number" class="slider-value" id="{{ field_id }}-number"
+             data-slider-number-for="{{ field_id }}"
+             value="{{ value }}" min="{{ min }}" max="{{ max }}" step="{{ step }}">
+      {%- if unit %}<span class="slider-unit">{{ unit }}</span>{% endif %}
+    </span>
   </div>
   <input type="range" class="slider" id="{{ field_id }}" name="{{ name }}"
          value="{{ value }}" min="{{ min }}" max="{{ max }}" step="{{ step }}"
-         {% if form %}form="{{ form }}"{% endif %}
-         data-output-suffix="{{ unit }}">
+         {% if form %}form="{{ form }}"{% endif %}>
 </div>
 {%- endmacro -%}
 

--- a/tests/test_calendar_core_caldav.py
+++ b/tests/test_calendar_core_caldav.py
@@ -113,6 +113,27 @@ def test_parse_todos_tolerates_garbage(cc: Any) -> None:
     assert cc._parse_todos(b"not a calendar") == []
 
 
+# -- _expand_events_cached window slicing --------------------------------
+
+
+def test_expand_events_cached_keeps_all_day_event_past_utc_midnight(cc: Any) -> None:
+    """A negative-UTC-offset evening (e.g. ~7pm US Eastern) pushes the UTC
+    calendar day one ahead of the local one. The warm-cache window slice
+    used to compare an all-day event's bare "YYYY-MM-DD" date string
+    against the query window's full UTC datetime string, which silently
+    dropped today's all-day event once that UTC rollover happened."""
+    from datetime import UTC, datetime, timedelta
+
+    cc._EXPANSION_CACHE["feed1"] = (
+        1.0,
+        [{"summary": "Conference", "start": "2026-08-10", "end": "2026-08-11", "all_day": True}],
+    )
+    start = datetime(2026, 8, 11, 1, 0, tzinfo=UTC)  # 8/10 20:00 America/New_York
+    end = start + timedelta(hours=24)
+    out = cc._expand_events_cached("feed1", 1.0, b"", start, end)
+    assert [e["summary"] for e in out] == ["Conference"]
+
+
 # -- load_todos (feeds.json + auth-aware fetch) --------------------------
 
 


### PR DESCRIPTION
Repo: tesserae
Branch: widget/calendar-native-refresh

Title: Calendar widgets: configurable text sizing, rolling 7-day week option, multi-day all-day fix

## Summary
Numerous fixes to allow more configuration to calendar widgets. Authored with Claude

Adds a `range_mode` option to calendar_week for a rolling 7-day window
("today + next 6" instead of the fixed calendar week), with per-day
weekday now driving labels/shading so it's correct in both modes. Fixes a
bug where calendar_week bucketed multi-day all-day events (e.g. a 3-day
conference) only under their start date instead of every day they span —
calendar_month already had the correct pattern, applied here — and adds
the missing all-day pill row to calendar_week's client, which had the CSS
support but never rendered it. Also folds in general cleanup: reordered
cell_options groupings, removed stale ImportError fallbacks in
calendar_day, widened calendar_month's padding slider bounds to match its
client clamp. 

Audited but unchanged: calendar_day already handled multi-day all-day
events correctly.

**Follow-up (7d7fd441, 4d43d736):** the day-bucketing fix above only
solved half the multi-day problem — client.js rendered a *separate* pill
in every covered day's column with the label repeated, instead of one
bar spanning them. `4d43d736` groups the per-day copies back by (start,
end, summary) and renders a single pill positioned with
`grid-column: start / span N`, lane-packed so overlapping all-day events
stack instead of colliding.  Also `7d7fd441`: the shared `slider` cell-option macro
(`_components.html`/`components.js`/`forms.css`) gets an editable number
input alongside the range input — one change point that covers every
`type: slider` option app-wide, including the calendar text-size scales.

## Files touched
CHANGELOG.md, plugins/calendar_day/{client.js,server.py,tests/{test_smoke.py,clamp_check.mjs}},
plugins/calendar_month/{client.js,plugin.json},
plugins/calendar_week/{client.js,plugin.json,server.py,tests/{test_smoke.py,clamp_check.mjs}},
plugins/calendar_core/server.py, tests/test_calendar_core_caldav.py,
app/calendar_time.py,
templates/_components.html, static/components.js, static/style/forms.css

**Follow-up (2eb2c8d5, 2418a135, c4d9c6a3, 7acd7419, 460d3860):** a second
round of multi-day-event bugs, found via a device-preview screenshot
after the fixes above landed:

- A timed event whose end lands on a later local day than its start (an
  overnight block, a multi-day trip) subtracted raw hour-of-day across
  two different dates, producing a negative/near-zero height and
  corrupting `computeRange`'s auto-fit window for the whole visible
  day/week (`2eb2c8d5`, calendar_day + calendar_week).
- `calendar_time.event_local_date_key` only ever returned an event's
  *start* day, so calendar_week bucketed a multi-day *timed* event on its
  first day only — unlike all-day events, it never appeared on any day
  after that. Added `timed_event_date_keys` mirroring the existing
  all-day spread (`2418a135`).
- Client-side, every per-day copy of a multi-day timed event redrew at
  the event's original absolute start hour instead of clamping to the
  day actually being rendered, and always ran to midnight even on the
  real end day. Added `clampToDay` in calendar_week (`2418a135`) and
  calendar_day (`7acd7419`) to clamp each day-copy against that day.
- The clamp above could still push a block's height past 100% and spill
  past the lane's bottom edge when `day_start_hour`/`day_end_hour`
  narrowed the visible range below a pass-through day's full 0-24h span.
  Added `pctSpan` to clamp top/bottom independently in calendar_week
  (`c4d9c6a3`) and calendar_day (`7acd7419`).
- All-day pills were shifted off their true day/lane column: in
  calendar_week the nested per-week grid declared an unsized `auto`
  gutter column that collapsed to 0 (`2418a135`); in calendar_day the
  pill row was a full-width sibling of the hour-gutter+lane grid
  entirely, offset by the gutter's width (`460d3860`). Both now share
  the real grid's column tracks instead of guessing at a matching width.

**Follow-up (99ef72d2):** a third bug family, reported directly ("the day
view now skips all-day events") rather than found by audit. Root cause was
in `calendar_core.load_events`'s shared warm-cache slicing
(`_expand_events_cached`), not any individual widget: it compared an
all-day event's bare `"YYYY-MM-DD"` date string against the query
window's full UTC datetime string. A bare date string sorts as "less
than" any same-day timestamp string, so once the UTC calendar day rolled
past local midnight — any evening in a negative-UTC-offset timezone, e.g.
~7pm US Eastern — today's all-day event silently dropped out before ever
reaching each widget's own correct local-date filtering
(`all_day_event_overlaps_date`/`all_day_event_date_keys`). Widened the
window by a day on each side for all-day events instead of tightening the
string comparison; every widget already re-filters by real local date
downstream, so over-inclusion here is harmless. One fix in `calendar_core`
covers every widget that calls `load_events` — bundled and standalone
alike, including `tesserae-widget-calendar-three-day` and
`tesserae-widget-calendar-schedule`, with no separate per-widget fix
needed.

**Follow-up (5ee12e75):** a fourth bug, same symptom report as the third
("day view all-day events") but a different root cause the string-comparison
fix above didn't touch: once events *were* in the response, calendar_day's
all-day pills rendered only as wide as their own titles, stopping short of
the event column's right edge — an all-day event read as a small tag rather
than a bar covering the day it applies to. The shared `.tt-allday` in
spectra-widgets.css is a wrapping flex *row*, and its pills are flex items,
so they size to content. calendar_week and calendar_three_day never hit
this because they don't use `.tt-allday` at all — they build their own
`.tt-allday-row` grid and span each pill with an explicit
`grid-column: N / span M`. Day view has exactly one lane, so the fix is one
declaration: stack the pills vertically (`flex-direction: column`) and let
them stretch the lane end to end.

## Test plan
- `uv run pytest plugins/calendar_day plugins/calendar_week
  plugins/calendar_month` — all passing, including new regression tests
  `test_multi_day_all_day_event_appears_on_every_covered_day` and
  `test_multi_day_timed_event_appears_on_every_covered_day` in
  calendar_week.
- `uv run pytest tests/test_calendar_core_caldav.py` — passing, including
  new regression test
  `test_expand_events_cached_keeps_all_day_event_past_utc_midnight`,
  which seeds the warm cache directly and slices it with a window that
  reproduces the UTC-rollover drop.
- `node plugins/calendar_day/tests/clamp_check.mjs`,
  `node plugins/calendar_week/tests/clamp_check.mjs` — `clampToDay`/
  `pctSpan` self-checks (start/pass-through/end day, full-range and
  narrowed-range overflow clamping).
- **Not covered by any automated check:** the all-day pill full-width fix
  (`5ee12e75`) is a single CSS declaration whose effect only exists once a
  layout engine resolves it. 
- Note: a pre-existing test-isolation bug (non-namespaced `import server`
  colliding across plugin test dirs when the *entire* suite runs in one
  pytest session) predates this branch and is out of scope.
