### PR TITLE
Fix unmatched dynamic select values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are
 [SemVer](https://semver.org/) (pre-1.0, so minors can carry breaking changes).
 
+## [Unreleased]
+
+### Fixed
+
+- **Dynamic widget pickers no longer look configured when their saved value is
+  empty or unavailable.** Gallery folders, Home Assistant entities, Todo lists,
+  and other runtime-backed selects now show the actual unset or removed value
+  until it is deliberately replaced, instead of letting the browser display
+  and later submit the first available option.
+
 ## [0.292.0], 2026-08-11
 
 ### Added

--- a/templates/_components.html
+++ b/templates/_components.html
@@ -139,12 +139,28 @@ macro here instead.
     ``group`` are wrapped in a single <optgroup> labelled with the group
     name, so callers can keep the picker single-element while users see
     related themes / fonts / etc. clustered. -#}
+{% set selected = namespace(found=false) %}
+{% for opt in options %}
+  {% if opt is mapping %}{% set option_value = opt.value %}
+  {% else %}{% set option_value = opt[0] %}{% endif %}
+  {% if value == option_value %}{% set selected.found = true %}{% endif %}
+{% endfor %}
+{% set has_value = value is not none and value != '' %}
 <div class="field">
   <label for="{{ field_id }}">{{ label }}{{ info_pop(help) }}</label>
   <select id="{{ field_id }}" name="{{ name }}"
           {% if form %}form="{{ form }}"{% endif %}>
     {% if blank_label is not none %}
     <option value="" {% if not value %}selected{% endif %}>{{ blank_label }}</option>
+    {% endif %}
+    {#- Browsers visually select the first option when no option matches the
+        control's saved value. That makes an unset dynamic picker look
+        configured, and a later unrelated save silently submits the first
+        choice. Keep the actual value as an explicit option instead: blank
+        remains visibly unset, while a removed value stays visible until the
+        user deliberately replaces it. -#}
+    {% if not selected.found and (has_value or blank_label is none) %}
+    <option value="{{ value|default('', true) }}" selected data-unmatched-option>{% if has_value %}Unavailable: {{ value }}{% else %}(not set){% endif %}</option>
     {% endif %}
     {% set ns = namespace(group='') %}
     {% for opt in options %}

--- a/tests/test_page_routes.py
+++ b/tests/test_page_routes.py
@@ -53,6 +53,18 @@ def app(tmp_path: Path) -> Flask:
         updates={"on_change": [{"source": "test.clock", "selector_option": "format"}]},
     )
     _write_test_plugin(plugins_dir / "widget_b", cell_options=[])
+    _write_test_plugin(
+        plugins_dir / "widget_c",
+        cell_options=[
+            {
+                "name": "folder",
+                "type": "select",
+                "label": "Folder",
+                "default": "",
+                "choices": [{"value": "family", "label": "family (5)"}],
+            }
+        ],
+    )
 
     a = create_app(
         testing=False,
@@ -1135,6 +1147,50 @@ def test_multiselect_tolerates_bare_string_and_missing_value(app: Flask) -> None
     ]
     assert _multiselect_checkbox_order(app, "light.b", options) == ["light.b", "light.a"]
     assert _multiselect_checkbox_order(app, None, options) == ["light.a", "light.b"]
+
+
+def test_select_with_unmatched_value_does_not_visually_choose_first_option(
+    app: Flask, tmp_path: Path
+) -> None:
+    """An empty dynamic option must stay visibly empty instead of looking
+    like the browser's first available choice is already saved.
+
+    This is the Gallery failure mode: a newly selected widget stores
+    ``folder=""`` (root), while the editor used to display ``family`` because
+    it was the first runtime choice. The preview still rendered root, and the
+    next unrelated save silently changed the folder to family.
+    """
+    client = app.test_client()
+    _sign_in(client)
+    pid = _new(client, name="Gallery", layout="1_cell")
+    cell_id = _store(tmp_path).get(pid).cells[0].id
+    client.post(f"/pages/{pid}/cells/{cell_id}", data={"plugin": "widget_c"})
+
+    body = client.get(f"/pages/{pid}").get_data(as_text=True)
+
+    assert '<option value="" selected data-unmatched-option>(not set)</option>' in body
+    assert '<option value="family" selected' not in body
+    assert '<option value="family" >family (5)</option>' in body
+
+
+def test_select_with_removed_value_preserves_and_labels_it(app: Flask) -> None:
+    """A choice that disappeared from a dynamic source remains the selected
+    submitted value until the user deliberately picks a replacement."""
+    with app.app_context():
+        tmpl = app.jinja_env.from_string(
+            "{% from '_components.html' import select_field %}"
+            "{{ select_field('f', 'entity', 'Entity', value=value, options=options) }}"
+        )
+        html = tmpl.render(
+            value="sensor.removed",
+            options=[{"value": "sensor.current", "label": "Current"}],
+        )
+
+    assert (
+        '<option value="sensor.removed" selected data-unmatched-option>'
+        "Unavailable: sensor.removed</option>"
+    ) in html
+    assert '<option value="sensor.current" selected' not in html
 
 
 # -- _ensure_cells_fit_panel ------------------------------------------------


### PR DESCRIPTION
## What this changes

Render an explicit selected option when a saved select value is absent from
its current choices. Empty values remain visibly unset, while removed values
remain visible as unavailable until the user deliberately replaces them.

This shared component covers runtime-backed Gallery folder, Home Assistant
entity, Todo list, grid Dashboard, and Canvas configuration pickers.

## Why

Browsers visually select the first `<option>` when no option matches a
`<select>`'s saved value. A newly selected Gallery widget could therefore store
`folder=""` (root) while displaying `family (5)`. The preview correctly rendered
root and reported it empty, but the editor looked as though `family` was already
configured. An unrelated later save could also submit that browser-selected
first choice and silently change the configuration.

Keeping the real unmatched value as an explicit option makes the UI and
submitted form agree without automatically choosing a potentially destructive
first entity, folder, or list.

## Test plan

- [x] `pytest -q tests/test_page_routes.py` — 81 passed
- [x] `pytest -q tests/test_panels.py` — 42 passed
- [x] `ruff check . && ruff format --check .`
- [ ] `mypy app` — local reused Python 3.12 environment has NumPy stubs using
  Python 3.12-only `type` syntax while this repository configures mypy for
  Python 3.11; CI remains the authoritative standard-environment check
- [ ] Manually verified the patched UI in a deployed browser; the production
  instance remains unmodified

## Checklist

- [x] Tests added for the new behaviour
- [ ] `ruff` + `mypy` clean — Ruff passed; mypy was blocked by the local
  dependency/environment mismatch described above
- [x] User-facing change documented in `CHANGELOG.md`
- [x] CHANGELOG entry added under `## [Unreleased]`
- [x] Version bump not applicable; this PR does not publish a release
