### PR TITLE
feat: add placement-level scheduled widget refresh core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are
 [SemVer](https://semver.org/) (pre-1.0, so minors can carry breaking changes).
 
+## [0.293.0], 2026-08-12
+
+### Added
+
+- **Placement-level daily widget refreshes.** Widgets may declare
+  `updates.on_schedule` so each Grid cell or Canvas element can independently
+  refresh at the server's local day boundary or an explicitly selected time.
+  Due refreshes coalesce per dashboard, respect quiet hours, update only
+  displays already showing the dashboard, and silently re-warm inactive Lineup
+  pages without selecting or advancing them. The feature is off by default.
+
 ## [0.292.3], 2026-08-12
 
 ### Fixed

--- a/app/app_factory.py
+++ b/app/app_factory.py
@@ -918,6 +918,7 @@ def create_app(
         deck_store=deck_store,
         deck_nav_store=deck_nav_store,
         page_store=page_store,
+        plugin_registry=lambda: app.config["PLUGIN_REGISTRY"],
         push_manager=lambda: app.config["PUSH_MANAGER"],
         event_log=event_log,
         timezone_provider=_resolve_timezone,
@@ -929,10 +930,13 @@ def create_app(
     app.config["SCHEDULER"] = scheduler
     from app.data_change_refresh import DataChangeRefreshCoordinator
 
+    def _refresh_data_change_pages(page_ids: set[str]) -> None:
+        scheduler.refresh_pages_for_update(page_ids, source="data_change")
+
     data_change_coordinator = DataChangeRefreshCoordinator(
         page_store=page_store,
         plugin_registry=lambda: app.config["PLUGIN_REGISTRY"],
-        refresh_pages=scheduler.refresh_pages_for_data_change,
+        refresh_pages=_refresh_data_change_pages,
     )
     app.config["DATA_CHANGE_COORDINATOR"] = data_change_coordinator
     if not testing and not is_watcher:

--- a/app/plugin_loader.py
+++ b/app/plugin_loader.py
@@ -180,6 +180,24 @@ class Plugin:
             out.append(spec)
         return out
 
+    @property
+    def on_schedule_updates(self) -> list[dict[str, str]]:
+        """Validated ``updates.on_schedule`` declarations for this widget."""
+        updates = self.manifest.get("updates")
+        raw = updates.get("on_schedule") if isinstance(updates, dict) else None
+        if not isinstance(raw, list):
+            return []
+        out: list[dict[str, str]] = []
+        for item in raw:
+            if not isinstance(item, dict) or item.get("kind") != "daily":
+                continue
+            spec = {"kind": "daily"}
+            suggested_at = item.get("suggested_at")
+            if isinstance(suggested_at, str):
+                spec["suggested_at"] = suggested_at
+            out.append(spec)
+        return out
+
     def cell_option_defaults(self) -> dict[str, Any]:
         defaults: dict[str, Any] = {}
         for opt in self.manifest.get("cell_options", []):

--- a/app/scheduled_refresh.py
+++ b/app/scheduled_refresh.py
@@ -1,0 +1,69 @@
+"""Resolve manifest-supported placement schedules independently of events."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from app.plugin_loader import PluginRegistry
+from app.state.page_store import Page
+from app.state.widget_update_schedule import WidgetUpdateSchedule
+
+
+@dataclass(frozen=True)
+class ScheduledPlacement:
+    """One enabled, currently supported placement update schedule."""
+
+    key: str
+    page_id: str
+    schedule: WidgetUpdateSchedule
+
+
+def _supported(plugin_id: str | None, kind: str, registry: PluginRegistry) -> bool:
+    if not plugin_id:
+        return False
+    plugin = registry.get(plugin_id)
+    if plugin is None:
+        return False
+    return any(spec.get("kind") == kind for spec in plugin.on_schedule_updates)
+
+
+def scheduled_placements(
+    pages: Iterable[Page], registry: PluginRegistry
+) -> list[ScheduledPlacement]:
+    """Return supported Grid and Canvas schedules with stable placement keys."""
+    out: list[ScheduledPlacement] = []
+    for page in pages:
+        for cell in page.cells:
+            schedule = cell.update_schedule
+            if schedule is not None and _supported(cell.plugin, schedule.kind, registry):
+                out.append(
+                    ScheduledPlacement(
+                        key=(
+                            f"grid:{page.id}:{cell.id}:{schedule.kind}:"
+                            f"{schedule.at or 'day-boundary'}"
+                        ),
+                        page_id=page.id,
+                        schedule=schedule,
+                    )
+                )
+        if page.canvas is None:
+            continue
+        for element in page.canvas.els:
+            schedule = element.update_schedule
+            if (
+                element.kind == "widget"
+                and schedule is not None
+                and _supported(element.widget, schedule.kind, registry)
+            ):
+                out.append(
+                    ScheduledPlacement(
+                        key=(
+                            f"canvas:{page.id}:{element.id}:{schedule.kind}:"
+                            f"{schedule.at or 'day-boundary'}"
+                        ),
+                        page_id=page.id,
+                        schedule=schedule,
+                    )
+                )
+    return out

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -36,7 +36,9 @@ from typing import Any, Protocol
 
 from pydantic import ValidationError
 
+from app.plugin_loader import PluginRegistry
 from app.push import PushManager, PushResult
+from app.scheduled_refresh import ScheduledPlacement, scheduled_placements
 from app.scheduler_conditions import ConditionEvaluator
 from app.state.deck_migration import deck_to_schedule
 from app.state.deck_model import Deck
@@ -285,6 +287,7 @@ class Scheduler:
         deck_store: DeckStore | None = None,
         deck_nav_store: Any = None,
         page_store: Any = None,
+        plugin_registry: Callable[[], PluginRegistry] | None = None,
         # Conditional schedules + rotation steps (v0.48). Optional; None
         # means every condition resolves to True (legacy behaviour) so
         # existing tests don't need updating. Production wires a real
@@ -317,9 +320,15 @@ class Scheduler:
         self._deck_store = deck_store
         self._deck_nav_store = deck_nav_store
         self._page_store = page_store
+        self._plugin_registry = plugin_registry
         # Page content-refresh bookkeeping: page_id -> POSIX timestamp of
         # the last refresh attempt that reached devices (discussion #140).
         self._page_last_refresh: dict[str, float] = {}
+        # Placement schedule key -> first observed / last satisfied timestamps.
+        # Keys include the configured time, so editing a schedule starts a new
+        # observation window and cannot inherit today's prior completion.
+        self._widget_schedule_first_seen: dict[str, float] = {}
+        self._widget_schedule_last_fired: dict[str, float] = {}
         # deck_id -> last warm POSIX timestamp, so a deck's pages are re-warmed
         # (in the background, silently) at its refresh cadence. The lock keeps
         # warm passes from stacking when one runs longer than a tick.
@@ -584,6 +593,10 @@ class Scheduler:
         # currently showing the page. Runs before the fire pass so a due
         # record's frame still lands last on the panel.
         self._maybe_refresh_pages(now)
+        # Placement-level daily refreshes are independent of page cadence and
+        # data-change events. Resolve all due widgets first so placements on the
+        # same page coalesce into one render/delivery pass.
+        self._maybe_refresh_scheduled_widgets(now)
         # Unified timed-content pass (#167 Phase 1): rotations, timer
         # decks, and schedules are collected together and fired in ONE
         # ascending sort. E-ink shows the most recent frame, so firing
@@ -847,29 +860,38 @@ class Scheduler:
                 result.status,
             )
 
-    def refresh_pages_for_data_change(
-        self, page_ids: set[str], now: datetime | None = None
-    ) -> None:
-        """Refresh changed pages without choosing or advancing active content.
+    def refresh_pages_for_update(
+        self,
+        page_ids: set[str],
+        *,
+        source: str,
+        now: datetime | None = None,
+    ) -> set[str]:
+        """Refresh invalidated pages without choosing or advancing content.
 
         Active pages reuse the normal page-refresh delivery path: resolve the
         devices already showing each page, respect quiet hours, and let
         PushManager's latest-wins/no-change handling apply. Affected inactive
         Deck pages are only re-warmed for their bound devices, never promoted.
+
+        The returned page ids completed every applicable live push and deck
+        warm. A page blocked by quiet hours is deliberately absent so a daily
+        placement schedule remains due and retries after quiet hours end.
         """
         if self._page_store is None or not page_ids:
-            return
+            return set()
         now = now or datetime.now(UTC)
         try:
             known_page_ids = {page.id for page in self._page_store.list()}
         except Exception:
-            return
+            return set()
         affected = page_ids & known_page_ids
         if not affected:
-            return
+            return set()
 
         showing = self._devices_showing_pages(now)
         pusher = self._push_factory()
+        completed = set(affected)
         for page_id in sorted(affected):
             devices = showing.get(page_id) or set()
             if not devices:
@@ -879,25 +901,30 @@ class Scheduler:
                     page_id,
                     device_ids=devices,
                     respect_quiet_hours=True,
-                    source="data_change",
+                    source=source,
                 )
             except Exception:
-                logger.exception("data-change page refresh failed page=%s", page_id)
+                completed.discard(page_id)
+                logger.exception("%s page refresh failed page=%s", source, page_id)
                 continue
-            with self._lock:
-                self._page_last_refresh[page_id] = now.timestamp()
+            if result.status in ("sent", "no_change"):
+                with self._lock:
+                    self._page_last_refresh[page_id] = now.timestamp()
+            else:
+                completed.discard(page_id)
             logger.info(
-                "data-change refresh: page=%s devices=%s (%s)",
+                "%s refresh: page=%s devices=%s (%s)",
+                source,
                 page_id,
                 ",".join(sorted(devices)),
                 result.status,
             )
 
         if self._deck_store is None:
-            return
+            return completed
         warm = getattr(pusher, "warm_deck_page", None)
         if not callable(warm):
-            return
+            return completed
         warm_targets: dict[tuple[str, str], set[str]] = {}
         for deck in self._deck_store.all():
             if not deck.enabled or not deck.device_ids:
@@ -913,18 +940,80 @@ class Scheduler:
         with self._deck_warm_lock:
             for (page_id, device_id), deck_ids in sorted(warm_targets.items()):
                 try:
-                    warm(page_id, device_id)
+                    warmed = warm(page_id, device_id)
                 except Exception:
+                    completed.discard(page_id)
                     logger.exception(
-                        "data-change deck warm failed decks=%s page=%s device=%s",
+                        "%s deck warm failed decks=%s page=%s device=%s",
+                        source,
                         ",".join(sorted(deck_ids)),
                         page_id,
                         device_id,
                     )
                     continue
+                if warmed is False:
+                    completed.discard(page_id)
+                    continue
                 for deck_id in deck_ids:
                     key = f"{deck_id}\x00{device_id}\x00{page_id}"
                     self._deck_last_warm[key] = now.timestamp()
+        return completed
+
+    def _widget_schedule_records(self) -> list[ScheduledPlacement]:
+        """Load currently supported placement schedules defensively."""
+        if self._page_store is None or self._plugin_registry is None:
+            return []
+        try:
+            return scheduled_placements(self._page_store.list(), self._plugin_registry())
+        except Exception:
+            logger.exception("widget schedule resolution failed")
+            return []
+
+    def _maybe_refresh_scheduled_widgets(self, now: datetime) -> None:
+        """Run due daily placement refreshes with Schedule-style gating."""
+        records = self._widget_schedule_records()
+        active_keys = {record.key for record in records}
+        now_ts = now.timestamp()
+        with self._lock:
+            for key in list(self._widget_schedule_first_seen):
+                if key not in active_keys:
+                    self._widget_schedule_first_seen.pop(key, None)
+                    self._widget_schedule_last_fired.pop(key, None)
+            for key in active_keys:
+                self._widget_schedule_first_seen.setdefault(key, now_ts)
+
+        tz = self._tz_provider()
+        local_now = _local(now, tz)
+        due_by_page: dict[str, list[ScheduledPlacement]] = {}
+        for record in records:
+            at = record.schedule.at
+            hour, minute = map(int, at.split(":")) if at is not None else (0, 0)
+            target_local = local_now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+            target = target_local.astimezone(UTC)
+            if now < target:
+                continue
+            with self._lock:
+                first_seen = self._widget_schedule_first_seen.get(record.key)
+                last = self._widget_schedule_last_fired.get(record.key)
+            # Match daily Schedule semantics: enabling after today's target
+            # does not immediately repaint to backfill a missed time.
+            if first_seen is None or first_seen > target.timestamp():
+                continue
+            if last is not None:
+                last_dt = datetime.fromtimestamp(last, tz=UTC)
+                if _local(last_dt, tz).date() == local_now.date():
+                    continue
+            due_by_page.setdefault(record.page_id, []).append(record)
+
+        if not due_by_page:
+            return
+        completed = self.refresh_pages_for_update(
+            set(due_by_page), source="widget_schedule", now=now
+        )
+        with self._lock:
+            for page_id in completed:
+                for record in due_by_page[page_id]:
+                    self._widget_schedule_last_fired[record.key] = now_ts
 
     def _maybe_return_decks_home(self, now: datetime) -> None:
         """Return idle deck panels to the home card (deck editor's

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -49,6 +49,8 @@ from app.state.schedule_model import Schedule
 
 logger = logging.getLogger(__name__)
 
+UPDATE_REFRESH_FAILURE_BACKOFF_SECONDS = 5 * 60
+
 
 class ScheduleSource(Protocol):
     """What the scheduler needs from a schedule store: the file-backed
@@ -106,6 +108,35 @@ def _matches_window(schedule: Schedule, now: datetime, tz: tzinfo | None) -> boo
 def _parse_hhmm(value: str) -> time:
     h, m = value.split(":")
     return time(int(h), int(m))
+
+
+def _daily_is_due(
+    now: datetime,
+    tz: tzinfo | None,
+    fires_at: time,
+    *,
+    first_seen: float | None,
+    last_fired: float | None,
+) -> bool:
+    """Shared once-per-local-day gate for Schedules and widget placements."""
+    local_now = _local(now, tz)
+    target_local = local_now.replace(
+        hour=fires_at.hour,
+        minute=fires_at.minute,
+        second=0,
+        microsecond=0,
+    )
+    target = target_local.astimezone(UTC)
+    if now < target:
+        return False
+    # Suppress backfill when a schedule was first observed only after today's
+    # target. This state is intentionally session-local, matching Schedules.
+    if first_seen is None or first_seen > target.timestamp():
+        return False
+    if last_fired is None:
+        return True
+    last_dt = datetime.fromtimestamp(last_fired, tz=UTC)
+    return _local(last_dt, tz).date() != local_now.date()
 
 
 def compute_current_step(
@@ -329,6 +360,10 @@ class Scheduler:
         # observation window and cannot inherit today's prior completion.
         self._widget_schedule_first_seen: dict[str, float] = {}
         self._widget_schedule_last_fired: dict[str, float] = {}
+        # (source, page_id) -> next retry timestamp after an actual delivery
+        # failure. Quiet pages are preflighted without creating Events rows and
+        # stay eligible every tick, so they fire immediately when quiet ends.
+        self._page_update_retry_after: dict[tuple[str, str], float] = {}
         # deck_id -> last warm POSIX timestamp, so a deck's pages are re-warmed
         # (in the background, silently) at its refresh cadence. The lock keeps
         # warm passes from stacking when one runs longer than a tick.
@@ -542,31 +577,17 @@ class Scheduler:
                     continue
                 if not _matches_dow(s, now, tz):
                     continue
-                # Target time is today (wall-clock in the configured tz) at
-                # fires_at's HH:MM.
-                local_now = _local(now, tz)
-                target_local = local_now.replace(
-                    hour=s.fires_at.hour,
-                    minute=s.fires_at.minute,
-                    second=0,
-                    microsecond=0,
-                )
-                target = target_local.astimezone(UTC)
-                if now < target:
-                    continue
                 with self._lock:
                     first_seen = self._first_seen.get(s.id)
                     last = self._last_fired.get(s.id)
-                # Backfill guard: if we weren't watching the schedule at
-                # the moment today's target would have fired, skip, the
-                # user enabled it after the time had passed.
-                if first_seen is None or first_seen > target.timestamp():
-                    continue
-                if last is not None:
-                    last_dt = datetime.fromtimestamp(last, tz=UTC)
-                    if _local(last_dt, tz).date() == local_now.date():
-                        continue  # already fired today (local terms)
-                candidates.append(s)
+                if _daily_is_due(
+                    now,
+                    tz,
+                    s.fires_at.time(),
+                    first_seen=first_seen,
+                    last_fired=last,
+                ):
+                    candidates.append(s)
         candidates.sort(key=lambda s: (-s.priority, s.id))
         return candidates
 
@@ -866,6 +887,8 @@ class Scheduler:
         *,
         source: str,
         now: datetime | None = None,
+        failure_backoff_seconds: int = 0,
+        defer_during_quiet: bool = False,
     ) -> set[str]:
         """Refresh invalidated pages without choosing or advancing content.
 
@@ -877,6 +900,8 @@ class Scheduler:
         The returned page ids completed every applicable live push and deck
         warm. A page blocked by quiet hours is deliberately absent so a daily
         placement schedule remains due and retries after quiet hours end.
+        Scheduled callers can request a failure backoff and quiet preflight;
+        one-shot data-change callers keep their established delivery behavior.
         """
         if self._page_store is None or not page_ids:
             return set()
@@ -892,9 +917,33 @@ class Scheduler:
         showing = self._devices_showing_pages(now)
         pusher = self._push_factory()
         completed = set(affected)
+        deferred: set[str] = set()
         for page_id in sorted(affected):
             devices = showing.get(page_id) or set()
             if not devices:
+                continue
+            retry_key = (source, page_id)
+            if failure_backoff_seconds > 0:
+                with self._lock:
+                    retry_after = self._page_update_retry_after.get(retry_key, 0.0)
+                if now.timestamp() < retry_after:
+                    completed.discard(page_id)
+                    deferred.add(page_id)
+                    continue
+
+            # Avoid calling PushManager while every live target is quiet. Its
+            # normal quiet path writes an Events row, so a 30-second scheduler
+            # tick would otherwise flood History all night. This cheap preflight
+            # remains eligible every tick and therefore fires immediately when
+            # the quiet window ends.
+            quiet_check = getattr(pusher, "device_in_quiet_hours", None)
+            if (
+                defer_during_quiet
+                and callable(quiet_check)
+                and all(quiet_check(device_id) for device_id in devices)
+            ):
+                completed.discard(page_id)
+                deferred.add(page_id)
                 continue
             try:
                 result = pusher.push(
@@ -905,13 +954,29 @@ class Scheduler:
                 )
             except Exception:
                 completed.discard(page_id)
+                deferred.add(page_id)
+                if failure_backoff_seconds > 0:
+                    with self._lock:
+                        self._page_update_retry_after[retry_key] = (
+                            now.timestamp() + failure_backoff_seconds
+                        )
                 logger.exception("%s page refresh failed page=%s", source, page_id)
                 continue
+            # Preserve the established data-change/page-cadence interaction:
+            # any push attempt that returned a result resets the cadence clock.
+            with self._lock:
+                self._page_last_refresh[page_id] = now.timestamp()
             if result.status in ("sent", "no_change"):
                 with self._lock:
-                    self._page_last_refresh[page_id] = now.timestamp()
+                    self._page_update_retry_after.pop(retry_key, None)
             else:
                 completed.discard(page_id)
+                deferred.add(page_id)
+                if result.status != "quiet" and failure_backoff_seconds > 0:
+                    with self._lock:
+                        self._page_update_retry_after[retry_key] = (
+                            now.timestamp() + failure_backoff_seconds
+                        )
             logger.info(
                 "%s refresh: page=%s devices=%s (%s)",
                 source,
@@ -939,10 +1004,18 @@ class Scheduler:
                         warm_targets.setdefault((page_id, device_id), set()).add(deck.id)
         with self._deck_warm_lock:
             for (page_id, device_id), deck_ids in sorted(warm_targets.items()):
+                if page_id in deferred:
+                    continue
+                retry_key = (source, page_id)
                 try:
                     warmed = warm(page_id, device_id)
                 except Exception:
                     completed.discard(page_id)
+                    if failure_backoff_seconds > 0:
+                        with self._lock:
+                            self._page_update_retry_after[retry_key] = (
+                                now.timestamp() + failure_backoff_seconds
+                            )
                     logger.exception(
                         "%s deck warm failed decks=%s page=%s device=%s",
                         source,
@@ -953,10 +1026,18 @@ class Scheduler:
                     continue
                 if warmed is False:
                     completed.discard(page_id)
+                    if failure_backoff_seconds > 0:
+                        with self._lock:
+                            self._page_update_retry_after[retry_key] = (
+                                now.timestamp() + failure_backoff_seconds
+                            )
                     continue
                 for deck_id in deck_ids:
                     key = f"{deck_id}\x00{device_id}\x00{page_id}"
                     self._deck_last_warm[key] = now.timestamp()
+        with self._lock:
+            for page_id in completed:
+                self._page_update_retry_after.pop((source, page_id), None)
         return completed
 
     def _widget_schedule_records(self) -> list[ScheduledPlacement]:
@@ -983,32 +1064,30 @@ class Scheduler:
                 self._widget_schedule_first_seen.setdefault(key, now_ts)
 
         tz = self._tz_provider()
-        local_now = _local(now, tz)
         due_by_page: dict[str, list[ScheduledPlacement]] = {}
         for record in records:
             at = record.schedule.at
-            hour, minute = map(int, at.split(":")) if at is not None else (0, 0)
-            target_local = local_now.replace(hour=hour, minute=minute, second=0, microsecond=0)
-            target = target_local.astimezone(UTC)
-            if now < target:
-                continue
+            fires_at = _parse_hhmm(at) if at is not None else time(0, 0)
             with self._lock:
                 first_seen = self._widget_schedule_first_seen.get(record.key)
                 last = self._widget_schedule_last_fired.get(record.key)
-            # Match daily Schedule semantics: enabling after today's target
-            # does not immediately repaint to backfill a missed time.
-            if first_seen is None or first_seen > target.timestamp():
-                continue
-            if last is not None:
-                last_dt = datetime.fromtimestamp(last, tz=UTC)
-                if _local(last_dt, tz).date() == local_now.date():
-                    continue
-            due_by_page.setdefault(record.page_id, []).append(record)
+            if _daily_is_due(
+                now,
+                tz,
+                fires_at,
+                first_seen=first_seen,
+                last_fired=last,
+            ):
+                due_by_page.setdefault(record.page_id, []).append(record)
 
         if not due_by_page:
             return
         completed = self.refresh_pages_for_update(
-            set(due_by_page), source="widget_schedule", now=now
+            set(due_by_page),
+            source="widget_schedule",
+            now=now,
+            failure_backoff_seconds=UPDATE_REFRESH_FAILURE_BACKOFF_SECONDS,
+            defer_during_quiet=True,
         )
         with self._lock:
             for page_id in completed:

--- a/app/state/page_store.py
+++ b/app/state/page_store.py
@@ -20,6 +20,7 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.state.panel_store import CanvasLayout, CanvasStore
+from app.state.widget_update_schedule import WidgetUpdateSchedule
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +114,10 @@ class Cell(BaseModel):
     # the event coordinator (a later stage) will also require the current
     # plugin manifest to declare a matching source before acting on this bit.
     update_on_change: bool = False
+    # Optional host-owned daily refresh for time-dependent widget output.
+    # None is the compatibility default. The current plugin manifest must
+    # declare the matching ``updates.on_schedule`` kind before it can run.
+    update_schedule: WidgetUpdateSchedule | None = None
     # Per-cell content zoom. Inverse-sized at render time: the widget
     # paints into a 1/zoom virtual container that's transform-scaled back
     # up to the cell box, so text/icons grow without breaking layout. The

--- a/app/state/panel_store.py
+++ b/app/state/panel_store.py
@@ -27,6 +27,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
 
+from app.state.widget_update_schedule import WidgetUpdateSchedule
+
 
 class PartScale(BaseModel):
     """A CSS-selector-scoped transform inside a widget fragment: scale the
@@ -130,6 +132,9 @@ class Element(BaseModel):
     # Kept on the element (not plugin settings) so two dashboards using the
     # same widget can choose independently. False is the compatibility default.
     update_on_change: bool = False
+    # Optional host-owned refresh trigger for this widget placement. Static
+    # elements cannot retain it; route-level capability guards enforce that.
+    update_schedule: WidgetUpdateSchedule | None = None
     # Decoration props (kind != "widget"; ignored for widgets). ``color`` is a
     # CSS colour or a Spectra token (e.g. "var(--accent-1)") so decorations can
     # follow the theme. ``fill`` false = outlined, ``stroke`` = outline/line

--- a/app/state/widget_update_schedule.py
+++ b/app/state/widget_update_schedule.py
@@ -1,0 +1,31 @@
+"""Host-owned update schedules for individual widget placements."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, field_validator
+
+_TIME_RE = re.compile(r"^(?:[01]\d|2[0-3]):[0-5]\d$")
+
+
+class WidgetUpdateSchedule(BaseModel):
+    """A placement-level refresh trigger.
+
+    ``at=None`` means the local day boundary.  The first contract is daily
+    only; keeping the discriminator in persisted state leaves room for future
+    schedule kinds without overloading the existing page refresh cadence.
+    """
+
+    kind: Literal["daily"] = "daily"
+    at: str | None = None
+
+    @field_validator("at")
+    @classmethod
+    def _validate_at(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not _TIME_RE.fullmatch(value):
+            raise ValueError("at must be HH:MM in 24-hour time")
+        return value

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -141,6 +141,24 @@ lowercase `[a-z0-9_]` is convention, not enforced. Name it `<family>_<role>`
     }
   }
   ```
+* **`updates.on_schedule`**, optional host-owned scheduled refresh kinds for
+  time-dependent output. The first contract supports `{"kind":"daily"}`.
+  Each Grid or Canvas placement remains off by default; when enabled without a
+  custom time it becomes due at the server's local day boundary. A manifest may
+  include `suggested_at` in `HH:MM` form, but that value only prefills the
+  progressive Custom time control and is not persisted until the user chooses
+  it. Scheduled refreshes update displays already showing the dashboard and
+  silently re-warm inactive Lineup pages; they never select or advance one.
+
+  ```json
+  {
+    "updates": {
+      "on_schedule": [
+        { "kind": "daily", "suggested_at": "07:00" }
+      ]
+    }
+  }
+  ```
 
 Full schema: [`schema/plugin.schema.json`](https://github.com/dmellok/tesserae/blob/main/schema/plugin.schema.json).
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -149,6 +149,9 @@ lowercase `[a-z0-9_]` is convention, not enforced. Name it `<family>_<role>`
   progressive Custom time control and is not persisted until the user chooses
   it. Scheduled refreshes update displays already showing the dashboard and
   silently re-warm inactive Lineup pages; they never select or advance one.
+  The due/satisfied bookkeeping is in memory, matching Tesserae Schedules: a
+  server restart after today's target can defer that placement until its next
+  local-day target rather than backfilling immediately.
 
   ```json
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.292.3"
+version = "0.293.0"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/schema/plugin.schema.json
+++ b/schema/plugin.schema.json
@@ -149,8 +149,11 @@
     },
     "updates": {
       "type": "object",
-      "description": "Declares data-change events this widget can subscribe to. The declaration only makes the per-placement opt-in available; it never refreshes a dashboard by itself.",
-      "required": ["on_change"],
+      "description": "Declares host-owned update triggers this widget supports. A declaration only makes the matching per-placement opt-in available; it never refreshes a dashboard by itself.",
+      "anyOf": [
+        { "required": ["on_change"] },
+        { "required": ["on_schedule"] }
+      ],
       "additionalProperties": false,
       "properties": {
         "on_change": {
@@ -173,6 +176,25 @@
                 "minLength": 1,
                 "maxLength": 128,
                 "description": "Optional cell_options name whose saved value narrows the dependency, for example list_id."
+              }
+            }
+          }
+        },
+        "on_schedule": {
+          "type": "array",
+          "description": "Scheduled refresh kinds supported by this widget. suggested_at only prefills the optional custom-time control; omitting a placement time means the local day boundary.",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "required": ["kind"],
+            "additionalProperties": false,
+            "properties": {
+              "kind": { "const": "daily" },
+              "suggested_at": {
+                "type": "string",
+                "pattern": "^(?:[01][0-9]|2[0-3]):[0-5][0-9]$",
+                "description": "Optional HH:MM prefill for a user-selected custom time."
               }
             }
           }
@@ -228,7 +250,7 @@
       "then": { "properties": { "supports": { "properties": { "sizes": { "minItems": 1 } } } } }
     },
     {
-      "description": "Only placeable widgets may declare data-change update capabilities.",
+      "description": "Only placeable widgets may declare update capabilities.",
       "if": { "required": ["updates"] },
       "then": { "properties": { "kind": { "const": "widget" } } }
     }

--- a/tests/test_page_refresh.py
+++ b/tests/test_page_refresh.py
@@ -8,14 +8,16 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from app.plugin_loader import Plugin, PluginRegistry
 from app.scheduler import Scheduler
 from app.state.deck_model import Deck, DeckPage
 from app.state.deck_nav_store import DeckNavStore
 from app.state.deck_store import DeckStore
-from app.state.page_store import Page, PageStore
+from app.state.page_store import Cell, Page, PageStore
 from app.state.rotation_model import Rotation, RotationStep
 from app.state.rotation_store import RotationStore
 from app.state.schedule_store import ScheduleStore
+from app.state.widget_update_schedule import WidgetUpdateSchedule
 
 T0 = datetime(2026, 6, 15, 12, 0, tzinfo=UTC)
 
@@ -26,12 +28,13 @@ class FakePush:
     warms: list[tuple[str, str]] = field(default_factory=list)
     # device_id -> latest render record (as the real PushManager stores it).
     latest: dict[str, dict] = field(default_factory=dict)
+    status: str = "sent"
 
     def push(self, page_id: str, *, device_ids=None, respect_quiet_hours=False, source="page"):
         self.pushes.append((page_id, frozenset(device_ids or ()), respect_quiet_hours, source))
 
         class R:
-            status = "sent"
+            status = self.status
             error = None
             duration_s = 0.0
             event_id = None
@@ -58,9 +61,37 @@ def _sched(tmp_path: Path, page_store: PageStore, pusher: FakePush, **kw: Any) -
         store=ScheduleStore(tmp_path / "s.json"),
         push_manager=lambda: pusher,  # type: ignore[arg-type,return-value]
         page_store=page_store,
+        plugin_registry=kw.pop("plugin_registry", None),
         timezone_provider=lambda: UTC,
         device_ids_for_page=kw.pop("device_ids_for_page", None),
         **kw,
+    )
+
+
+def _scheduled_registry(tmp_path: Path) -> PluginRegistry:
+    plugin = Plugin(
+        id="daily",
+        path=tmp_path / "daily",
+        manifest={
+            "name": "Daily",
+            "kind": "widget",
+            "supports": {"sizes": ["md"]},
+            "updates": {"on_schedule": [{"kind": "daily", "suggested_at": "07:00"}]},
+        },
+        data_dir=tmp_path / "data" / "daily",
+    )
+    return PluginRegistry(plugins={"daily": plugin})
+
+
+def _scheduled_cell(cell_id: str, *, at: str | None = None) -> Cell:
+    return Cell(
+        id=cell_id,
+        plugin="daily",
+        update_schedule=WidgetUpdateSchedule(kind="daily", at=at),
+        x=0,
+        y=0,
+        w=100,
+        h=100,
     )
 
 
@@ -191,7 +222,7 @@ def test_data_change_refreshes_active_page_and_only_warms_inactive_deck_page(
     pusher = FakePush()
     sched = _sched(tmp_path, ps, pusher, deck_store=decks, deck_nav_store=nav)
 
-    sched.refresh_pages_for_data_change({"active", "inactive"}, now=T0)
+    sched.refresh_pages_for_update({"active", "inactive"}, source="data_change", now=T0)
 
     assert pusher.pushes == [("active", frozenset({"panel"}), True, "data_change")]
     assert pusher.warms == [("inactive", "panel")]
@@ -216,10 +247,120 @@ def test_data_change_warms_shared_deck_page_once_per_device(tmp_path: Path) -> N
     pusher = FakePush()
     sched = _sched(tmp_path, ps, pusher, deck_store=decks)
 
-    sched.refresh_pages_for_data_change({"shared"}, now=T0)
+    sched.refresh_pages_for_update({"shared"}, source="data_change", now=T0)
 
     assert pusher.pushes == []
     assert pusher.warms == [("shared", "panel")]
     assert sched._deck_last_warm == {
         f"{deck_id}\x00panel\x00shared": T0.timestamp() for deck_id in ("morning", "evening")
     }
+
+
+def test_widget_daily_boundary_refreshes_once_and_coalesces_placements(
+    tmp_path: Path,
+) -> None:
+    page = Page(
+        id="reminders",
+        name="Reminders",
+        device_ids=["panel"],
+        cells=[_scheduled_cell("a"), _scheduled_cell("b")],
+    )
+    ps = _pages(tmp_path, page)
+    pusher = FakePush()
+    registry = _scheduled_registry(tmp_path)
+    sched = _sched(tmp_path, ps, pusher, plugin_registry=lambda: registry)
+
+    before = datetime(2026, 6, 15, 23, 59, tzinfo=UTC)
+    sched._maybe_refresh_scheduled_widgets(before)
+    assert pusher.pushes == []
+
+    boundary = datetime(2026, 6, 16, 0, 0, tzinfo=UTC)
+    sched._maybe_refresh_scheduled_widgets(boundary)
+    sched._maybe_refresh_scheduled_widgets(boundary + timedelta(minutes=1))
+
+    assert pusher.pushes == [("reminders", frozenset({"panel"}), True, "widget_schedule")]
+
+
+def test_widget_custom_time_does_not_backfill_when_enabled_after_target(
+    tmp_path: Path,
+) -> None:
+    page = Page(
+        id="reminders",
+        name="Reminders",
+        device_ids=["panel"],
+        cells=[_scheduled_cell("a", at="07:00")],
+    )
+    ps = _pages(tmp_path, page)
+    pusher = FakePush()
+    registry = _scheduled_registry(tmp_path)
+    sched = _sched(tmp_path, ps, pusher, plugin_registry=lambda: registry)
+
+    enabled_late = datetime(2026, 6, 15, 11, 0, tzinfo=UTC)
+    sched._maybe_refresh_scheduled_widgets(enabled_late)
+    assert pusher.pushes == []
+
+    sched._maybe_refresh_scheduled_widgets(datetime(2026, 6, 16, 7, 0, tzinfo=UTC))
+    assert len(pusher.pushes) == 1
+
+
+def test_widget_schedule_retries_after_quiet_result(tmp_path: Path) -> None:
+    page = Page(
+        id="reminders",
+        name="Reminders",
+        device_ids=["panel"],
+        cells=[_scheduled_cell("a")],
+    )
+    ps = _pages(tmp_path, page)
+    pusher = FakePush(status="quiet")
+    registry = _scheduled_registry(tmp_path)
+    sched = _sched(tmp_path, ps, pusher, plugin_registry=lambda: registry)
+
+    sched._maybe_refresh_scheduled_widgets(datetime(2026, 6, 15, 23, 59, tzinfo=UTC))
+    boundary = datetime(2026, 6, 16, 0, 0, tzinfo=UTC)
+    sched._maybe_refresh_scheduled_widgets(boundary)
+    pusher.status = "sent"
+    sched._maybe_refresh_scheduled_widgets(boundary + timedelta(hours=7))
+
+    assert [push[3] for push in pusher.pushes] == ["widget_schedule", "widget_schedule"]
+
+
+def test_widget_schedule_warms_inactive_lineup_page_without_promoting(
+    tmp_path: Path,
+) -> None:
+    ps = _pages(
+        tmp_path,
+        Page(id="active", name="Active", device_ids=["panel"]),
+        Page(
+            id="reminders",
+            name="Reminders",
+            device_ids=["panel"],
+            cells=[_scheduled_cell("a")],
+        ),
+    )
+    decks = DeckStore(tmp_path / "decks.json")
+    decks.upsert(
+        Deck(
+            id="kitchen",
+            name="Kitchen",
+            device_ids=["panel"],
+            pages=[DeckPage(page_id="active"), DeckPage(page_id="reminders")],
+        )
+    )
+    nav = DeckNavStore(tmp_path / "nav.json")
+    nav.set("panel", "kitchen", "active")
+    pusher = FakePush()
+    registry = _scheduled_registry(tmp_path)
+    sched = _sched(
+        tmp_path,
+        ps,
+        pusher,
+        plugin_registry=lambda: registry,
+        deck_store=decks,
+        deck_nav_store=nav,
+    )
+
+    sched._maybe_refresh_scheduled_widgets(datetime(2026, 6, 15, 23, 59, tzinfo=UTC))
+    sched._maybe_refresh_scheduled_widgets(datetime(2026, 6, 16, 0, 0, tzinfo=UTC))
+
+    assert pusher.pushes == []
+    assert pusher.warms == [("reminders", "panel")]

--- a/tests/test_page_refresh.py
+++ b/tests/test_page_refresh.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from app.plugin_loader import Plugin, PluginRegistry
+from app.scheduled_refresh import scheduled_placements
 from app.scheduler import Scheduler
 from app.state.deck_model import Deck, DeckPage
 from app.state.deck_nav_store import DeckNavStore
@@ -29,6 +30,7 @@ class FakePush:
     # device_id -> latest render record (as the real PushManager stores it).
     latest: dict[str, dict] = field(default_factory=dict)
     status: str = "sent"
+    quiet_devices: set[str] = field(default_factory=set)
 
     def push(self, page_id: str, *, device_ids=None, respect_quiet_hours=False, source="page"):
         self.pushes.append((page_id, frozenset(device_ids or ()), respect_quiet_hours, source))
@@ -43,6 +45,9 @@ class FakePush:
 
     def latest_render_for(self, device_id: str):
         return self.latest.get(device_id)
+
+    def device_in_quiet_hours(self, device_id: str) -> bool:
+        return device_id in self.quiet_devices
 
     def warm_deck_page(self, page_id: str, device_id: str) -> bool:
         self.warms.append((page_id, device_id))
@@ -93,6 +98,21 @@ def _scheduled_cell(cell_id: str, *, at: str | None = None) -> Cell:
         w=100,
         h=100,
     )
+
+
+def test_scheduled_resolver_ignores_stale_unsupported_placement(tmp_path: Path) -> None:
+    page = Page(
+        id="reminders",
+        name="Reminders",
+        cells=[_scheduled_cell("a")],
+    )
+    registry = _scheduled_registry(tmp_path)
+    assert [record.page_id for record in scheduled_placements([page], registry)] == ["reminders"]
+
+    plugin = registry.get("daily")
+    assert plugin is not None
+    plugin.manifest["updates"] = {"on_change": [{"source": "test.daily"}]}
+    assert scheduled_placements([page], registry) == []
 
 
 def test_lone_single_bound_page_refreshes_on_cadence(tmp_path: Path) -> None:
@@ -256,6 +276,19 @@ def test_data_change_warms_shared_deck_page_once_per_device(tmp_path: Path) -> N
     }
 
 
+def test_data_change_attempt_preserves_page_cadence_timestamp(tmp_path: Path) -> None:
+    ps = _pages(tmp_path, Page(id="active", name="Active", device_ids=["panel"]))
+    pusher = FakePush(status="failed")
+    sched = _sched(tmp_path, ps, pusher)
+
+    sched.refresh_pages_for_update({"active"}, source="data_change", now=T0)
+    assert sched._page_last_refresh["active"] == T0.timestamp()
+
+    sched.refresh_pages_for_update({"active"}, source="data_change", now=T0 + timedelta(seconds=30))
+
+    assert len(pusher.pushes) == 2
+
+
 def test_widget_daily_boundary_refreshes_once_and_coalesces_placements(
     tmp_path: Path,
 ) -> None:
@@ -322,6 +355,52 @@ def test_widget_schedule_retries_after_quiet_result(tmp_path: Path) -> None:
     sched._maybe_refresh_scheduled_widgets(boundary + timedelta(hours=7))
 
     assert [push[3] for push in pusher.pushes] == ["widget_schedule", "widget_schedule"]
+
+
+def test_widget_schedule_waits_through_quiet_without_push_events(tmp_path: Path) -> None:
+    page = Page(
+        id="reminders",
+        name="Reminders",
+        device_ids=["panel"],
+        cells=[_scheduled_cell("a")],
+    )
+    ps = _pages(tmp_path, page)
+    pusher = FakePush(quiet_devices={"panel"})
+    registry = _scheduled_registry(tmp_path)
+    sched = _sched(tmp_path, ps, pusher, plugin_registry=lambda: registry)
+
+    sched._maybe_refresh_scheduled_widgets(datetime(2026, 6, 15, 23, 59, tzinfo=UTC))
+    boundary = datetime(2026, 6, 16, 0, 0, tzinfo=UTC)
+    sched._maybe_refresh_scheduled_widgets(boundary)
+    sched._maybe_refresh_scheduled_widgets(boundary + timedelta(seconds=30))
+    assert pusher.pushes == []
+
+    pusher.quiet_devices.clear()
+    sched._maybe_refresh_scheduled_widgets(boundary + timedelta(seconds=60))
+    assert len(pusher.pushes) == 1
+
+
+def test_widget_schedule_backs_off_after_delivery_failure(tmp_path: Path) -> None:
+    page = Page(
+        id="reminders",
+        name="Reminders",
+        device_ids=["panel"],
+        cells=[_scheduled_cell("a")],
+    )
+    ps = _pages(tmp_path, page)
+    pusher = FakePush(status="failed")
+    registry = _scheduled_registry(tmp_path)
+    sched = _sched(tmp_path, ps, pusher, plugin_registry=lambda: registry)
+
+    sched._maybe_refresh_scheduled_widgets(datetime(2026, 6, 15, 23, 59, tzinfo=UTC))
+    boundary = datetime(2026, 6, 16, 0, 0, tzinfo=UTC)
+    sched._maybe_refresh_scheduled_widgets(boundary)
+    sched._maybe_refresh_scheduled_widgets(boundary + timedelta(seconds=30))
+    assert len(pusher.pushes) == 1
+
+    pusher.status = "sent"
+    sched._maybe_refresh_scheduled_widgets(boundary + timedelta(minutes=5, seconds=1))
+    assert len(pusher.pushes) == 2
 
 
 def test_widget_schedule_warms_inactive_lineup_page_without_promoting(

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -115,6 +115,42 @@ def test_on_change_manifest_is_discovered(tmp_path: Path, schema_path: Path) -> 
     ]
 
 
+def test_on_schedule_only_manifest_is_discovered(tmp_path: Path, schema_path: Path) -> None:
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    _write_minimal_plugin(
+        plugins_dir,
+        "daily_widget",
+        {"updates": {"on_schedule": [{"kind": "daily", "suggested_at": "07:00"}]}},
+    )
+
+    registry = plugin_loader.discover(
+        plugins_dir, schema_path=schema_path, data_root=tmp_path / "data"
+    )
+
+    assert registry.errors == []
+    assert registry.plugins["daily_widget"].on_schedule_updates == [
+        {"kind": "daily", "suggested_at": "07:00"}
+    ]
+
+
+def test_on_schedule_rejects_invalid_suggested_time(tmp_path: Path, schema_path: Path) -> None:
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    _write_minimal_plugin(
+        plugins_dir,
+        "bad_daily_widget",
+        {"updates": {"on_schedule": [{"kind": "daily", "suggested_at": "7am"}]}},
+    )
+
+    registry = plugin_loader.discover(
+        plugins_dir, schema_path=schema_path, data_root=tmp_path / "data"
+    )
+
+    assert "bad_daily_widget" not in registry.plugins
+    assert any("manifest schema" in error.message for error in registry.errors)
+
+
 def test_on_change_selector_must_name_cell_option(tmp_path: Path, schema_path: Path) -> None:
     plugins_dir = tmp_path / "plugins"
     plugins_dir.mkdir()

--- a/uv.lock
+++ b/uv.lock
@@ -1934,7 +1934,7 @@ wheels = [
 
 [[package]]
 name = "tesserae"
-version = "0.292.3"
+version = "0.293.0"
 source = { editable = "." }
 dependencies = [
     { name = "amqtt" },


### PR DESCRIPTION
## Summary

- add the manifest updates.on_schedule contract, initially limited to daily triggers
- persist optional daily schedules per Grid cell and Canvas widget placement
- resolve scheduled placements independently from data-change dependencies
- share daily due-time semantics with existing Schedules
- coalesce due placements per dashboard, respect quiet hours without logging a skip every scheduler tick, and warm inactive Lineup pages without promoting them
- apply a five-minute retry backoff after actual scheduled refresh failures while preserving existing data-change cadence behavior

## Why

Time-dependent widget output can become stale even when its source payload has not changed. A relative due-day label is the motivating example: the date boundary changes what should render, but there is no new Reminders snapshot to produce an on-change event. Lineups decide which dashboard is visible; this contract complements them by invalidating time-dependent widget output without selecting or advancing content.

Discussion: https://github.com/dmellok/tesserae/discussions/216

## Scope

This is the Core slice only. It is off by default, supports daily schedules only, and deliberately does not add cron. The Configure UI follows in a stacked PR. A schedule without at uses the server local day boundary; suggested_at remains a manifest hint for the later UI.

Like the existing Schedules implementation, due/satisfied state is held in memory. Restarting after a day's target can defer that placement until the next day; persistence is intentionally left for a follow-up.

This is versioned as 0.293.0 and the lockfile was refreshed.

## Validation

- 49 scheduler, page-refresh, and plugin-loader tests passed
- broader stacked regression set: 279 tests passed
- Ruff passed
- mypy passed across 178 app modules with the local Python 3.12 target override
- git diff --check passed