### PR TITLE
feat(gtfs): departure board for any GTFS / GTFS-RT feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are
 [SemVer](https://semver.org/) (pre-1.0, so minors can carry breaking changes).
 
+## [Unreleased]
+
+### Added
+
+- **GTFS / GTFS-RT departure board.** A new `gtfs` widget shows approaching
+  vehicles at a stop, from any agency's static GTFS zip plus optional
+  realtime feeds: live times, delays against the timetable, cancellations,
+  service alerts, and track numbers where the feed publishes them. Presets
+  cover the NYC Subway (one per realtime line group) and BART; anything else
+  takes URLs. A stop finder at `/plugins/gtfs/` searches a feed for the
+  `stop_id` a cell needs and reports which routes call there and what each
+  `direction_id` means in headsign terms, since GTFS never says. Two stops
+  can share one board — the office lobby case, a subway entrance and the
+  station round the block — and a large cell can split into two columns by
+  direction. Realtime protobuf is decoded directly, including the NYCT
+  extension, so no protobuf dependency is added.
+- **`fill_from` on a cell option.** An option can declare that another owns
+  its value; the editor fills the field from a map and locks it. The `gtfs`
+  presets use it so picking a feed fills its three URLs. See
+  [docs/widgets.md](docs/widgets.md).
+
+### Fixed
+
+- **The widget preview resolves dynamic dropdowns.** `/_test/preview` read
+  `cell_options` straight from the manifest, so any option using
+  `choices_from` rendered as an empty `<select>` — for every widget, not just
+  new ones. It now materialises choices the way the page editor does.
+
 ## [0.292.3], 2026-08-12
 
 ### Fixed

--- a/app/composer.py
+++ b/app/composer.py
@@ -2031,7 +2031,14 @@ def test_widget_preview() -> str:
     # , same schema the page editor reads. Defaults override URL-supplied
     # values only when the URL omits a field, so reloading the page with
     # an explicit blank still wins over the manifest default.
-    schema = list(plugin.manifest.get("cell_options") or [])
+    #
+    # Materialised through the page editor's helper so ``choices_from``
+    # options (the plugin resolves those at edit time) arrive with concrete
+    # choices. Reading the raw manifest here rendered every dynamic dropdown
+    # in this preview empty, for every widget that uses one.
+    from app.page_routes import _materialize_cell_options
+
+    schema = list(_materialize_cell_options([plugin]).get(plugin.id) or [])
     supplied_opts: dict[str, Any] = parsed["cell_options"]
     form_values: dict[str, Any] = {}
     for spec in schema:

--- a/app/widget_samples.py
+++ b/app/widget_samples.py
@@ -852,7 +852,54 @@ def _weather_now() -> dict[str, Any]:
     }
 
 
+def _gtfs() -> dict[str, Any]:
+    # Canal St (A/C/E), the stop the widget was developed against. Route
+    # colours are the MTA's own (data identity, not a design choice).
+    def _a(
+        minutes: int,
+        route: str,
+        headsign: str,
+        time: str,
+        live: bool,
+        delay: int = 0,
+        stop: str = "Canal St",
+    ) -> dict[str, Any]:
+        return {
+            "trip_id": f"sample-{route}-{minutes}",
+            "stop_id": "A34N",
+            "stop_name": stop,
+            "direction": "0" if minutes % 2 else "1",
+            "minutes": minutes,
+            "time": time,
+            "delay": delay,
+            "route": route,
+            "headsign": headsign,
+            "mode": "subway",
+            "color": "#0039A6",
+            "text_color": "#FFFFFF",
+            "live": live,
+        }
+
+    return {
+        "stop": "Canal St",
+        "label": "Canal St",
+        "now": "13:26",
+        "live": True,
+        "feed_age_s": 35,
+        "note": "",
+        "arrivals": [
+            _a(1, "C", "Euclid Av", "13:27", True),
+            _a(4, "A", "Inwood-207 St", "13:30", True, delay=3),
+            _a(7, "E", "World Trade Center", "13:33", True, delay=-2),
+            _a(11, "C", "168 St", "13:37", True, delay=9),
+            _a(15, "A", "Far Rockaway-Mott Av", "13:41", False),
+            _a(19, "E", "Jamaica Center-Parsons/Archer", "13:45", True, delay=1),
+        ],
+    }
+
+
 SAMPLES: dict[str, Any] = {
+    "gtfs": _gtfs,
     "weather_now": _weather_now,
     "calendar_schedule": _calendar_schedule,
     "devref_egress": _devref_egress,

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -114,6 +114,12 @@ lowercase `[a-z0-9_]` is convention, not enforced. Name it `<family>_<role>`
   cross-widget shape selection. If a widget needs a genuine layout
   shape choice (e.g. `stack` vs `side`), name the option `layout` and
   use shape-describing values.
+* **Careful with an option named `label`.** The host promotes the app-level
+  Settings location into every widget's options and fills a blank `label`
+  with the place name (see `_resolved_options` in `app/composer.py`). That's
+  the intent for weather-style widgets; for anything else it means a cell
+  titled "Melbourne" for no reason. Name the option something else
+  (`title`) if it isn't a place.
 * **`settings`**, plugin-wide knobs (one set across all cells using
   this widget). Surfaces in `/settings/plugins/<id>`. `secret: true`
   stores under `<name>_secret` in `settings.json` so an on-disk grep
@@ -195,6 +201,30 @@ catalog, `glances_status` → `glances_core` if you install the
 monitoring bundle). The Dev Reference Bundle
 (`devref_card` → `devref_core`) is a worked example you can
 install from the catalog and read end-to-end.
+
+### Fields another option fills, `fill_from`
+
+An option can declare that another option owns its value. The editor looks
+the controlling option's current value up in a map; a hit fills the field
+and renders it read-only (still submitted, so the value survives a save).
+
+```jsonc
+{
+  "name": "rt_url",
+  "type": "string",
+  "label": "Realtime URL",
+  "fill_from": {
+    "option": "preset",
+    "map": { "mta_ace": "https://api-endpoint.mta.info/..." }
+  }
+}
+```
+
+The `gtfs` widget uses this for its feed presets: pick "NYC Subway (A/C/E)"
+and the three URL fields below fill in and lock, so a cell can't end up
+pairing one agency's timetable with another's realtime feed. Resolution is
+server-side, so the fields update when the page reloads after a save, not
+the instant the select changes.
 
 ### Companion `_core` plugins
 
@@ -969,7 +999,8 @@ the conventions land in practice.
 
 * `.stat-body`, [`plugins/weather_now`](https://github.com/dmellok/tesserae/tree/main/plugins/weather_now),
   [`plugins/ha_battery`](https://github.com/dmellok/tesserae/tree/main/plugins/ha_battery)
-* `.list-body`, [`plugins/news_hacker_news`](https://github.com/dmellok/tesserae/tree/main/plugins/news_hacker_news),
+* `.list-body`, [`plugins/gtfs`](https://github.com/dmellok/tesserae/tree/main/plugins/gtfs),
+  [`plugins/news_hacker_news`](https://github.com/dmellok/tesserae/tree/main/plugins/news_hacker_news),
   [`plugins/ha_entities`](https://github.com/dmellok/tesserae/tree/main/plugins/ha_entities),
   [`plugins/todo`](https://github.com/dmellok/tesserae/tree/main/plugins/todo)
 * `.chart-body`, [`plugins/weather_hourly`](https://github.com/dmellok/tesserae/tree/main/plugins/weather_hourly),

--- a/plugins/gtfs/client.js
+++ b/plugins/gtfs/client.js
@@ -144,7 +144,12 @@ const STYLE = `
   .gt-live { color: var(--accent-4); font-size: 0.7em; }
   .gt-stops { font-weight: var(--fw-bold); color: var(--text-secondary); white-space: nowrap; }
   .gt-origin {
-    flex: 0 0 auto;
+    /* Shrinks (and ellipses) before the delay chip does: a truncated
+       station name still reads, half a "+4" doesn't. */
+    flex: 0 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
     padding: 0 0.35em;
     background: var(--surface-sunken);
     color: var(--text-secondary);
@@ -216,6 +221,7 @@ const STYLE = `
     text-overflow: ellipsis;
   }
   .gt-delay {
+    flex: 0 0 auto;
     white-space: nowrap;
     font-weight: var(--fw-bold);
     text-transform: var(--label-transform, uppercase);

--- a/plugins/gtfs/client.js
+++ b/plugins/gtfs/client.js
@@ -1,0 +1,590 @@
+// gtfs, approaching vehicles at one stop.
+//
+// Two archetypes, picked by cell size, because the information shape
+// genuinely changes:
+//
+//   xs  .stat-body , minutes to the next vehicle. Nothing else fits.
+//   sm  .stat-body , same hero plus the route badge + where it's going.
+//   md  .list-body , 3 upcoming arrivals.
+//   lg  .list-body , 6 upcoming arrivals, bigger type.
+//
+// Colour is by urgency role, not hue: accent-1 for "it's here / run",
+// accent-2 for "soon", accent-3 for "you have time". Route badges paint
+// the agency's own route_color when the feed ships one (the data-identity
+// carve-out in docs/widgets.md, same rule as F1 team colours) and fall
+// back to --surface-sunken. The live marker uses accent-4, the documented
+// "live" slot.
+
+const MODE_PH = {
+  tram: "ph-tram",
+  subway: "ph-subway",
+  rail: "ph-train",
+  bus: "ph-bus",
+  ferry: "ph-boat",
+  gondola: "ph-cable-car",
+  funicular: "ph-train-regional",
+  monorail: "ph-train-simple",
+};
+
+// How many arrivals each size shows. xs/sm are hero-only by definition;
+// md and lg are the list sizes.
+const ROWS_BY_SIZE = { xs: 1, sm: 1, md: 3, lg: 6 };
+
+// Feed-age thresholds. MTA republishes about every 30s, so a couple of
+// minutes is worth mentioning and five means something is wrong.
+// Split columns are narrower but no shorter, so each holds more than half
+// of what the single-column board shows.
+const SPLIT_ROWS_PER_COLUMN = 5;
+
+const AGE_SHOWN_AFTER_S = 120;
+const STALE_AFTER_S = 300;
+
+function escapeHtml(s) {
+  return String(s ?? "").replace(/[&<>"']/g, (c) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+  }[c]));
+}
+
+// Minutes -> accent slot by role. 1 = alert / "now", 2 = warning / act
+// soon, 3 = positive / plenty of time.
+function urgency(minutes) {
+  if (!Number.isFinite(minutes) || minutes <= 1) return 1;
+  if (minutes <= 5) return 2;
+  return 3;
+}
+
+function fmtMinutes(m) {
+  if (!Number.isFinite(m)) return "-";
+  return m <= 0 ? "now" : String(m);
+}
+
+// Route chip. route_color / route_text_color are part of the data (the
+// agency's own line colour), so they land as inline hex; feeds that omit
+// them get the neutral sunken chip.
+// Only a literal #RRGGBB is allowed through into a style attribute, so a
+// hostile feed can't smuggle extra declarations into the chip.
+function hex(value) {
+  return /^#[0-9A-Fa-f]{6}$/.test(String(value ?? "")) ? String(value) : "";
+}
+
+function routeBadge(a) {
+  const color = hex(a.color);
+  const bg = color || "var(--surface-sunken)";
+  const fg = color ? (hex(a.text_color) || "var(--on-accent)") : "var(--text-primary)";
+  return `<span class="gt-route" style="background:${bg};color:${fg}">${escapeHtml(a.route || "?")}</span>`;
+}
+
+// Lateness against the timetable, when an RT feed gave us one. Late is the
+// alert slot, early the positive one; on-time says nothing at all rather
+// than adding a chip to every row.
+function delayChip(a, compact = false) {
+  const d = Number(a.delay);
+  if (!Number.isFinite(d) || d === 0) return "";
+  const slot = d > 0 ? 1 : 3;
+  // Compact form for rows that also carry an origin chip: "+4" keeps the
+  // fact without pushing the line past the row and clipping mid-word.
+  const text = compact
+    ? `${d > 0 ? "+" : "−"}${Math.abs(d)}`
+    : (d > 0 ? `${d} min late` : `${-d} min early`);
+  return `<span class="gt-delay" style="color:var(--accent-${slot})">${escapeHtml(text)}</span>`;
+}
+
+// How many stops out the vehicle is, from the realtime feed's own position
+// report. Opt-in: it's the platform-sign metric, but it's noise on a board
+// where everything is one or two stops away.
+function stopsChip(a, show) {
+  if (!show || !Number.isFinite(Number(a.stops_away))) return "";
+  const n = Number(a.stops_away);
+  const text = n === 0 ? "here" : n === 1 ? "1 stop" : `${n} stops`;
+  return `<span class="gt-stops">${escapeHtml(text)}</span>`;
+}
+
+// Which station this train leaves from. Only meaningful — and only shown —
+// when the board covers two stops.
+function originChip(a, show) {
+  if (!show || !a.stop_name) return "";
+  return `<span class="gt-origin">${escapeHtml(a.stop_name)}</span>`;
+}
+
+// Track / platform, when the feed publishes one and the cell asked for it.
+// NYCT ships this as a GTFS-RT extension; commuter rail feeds carry it too.
+function trackChip(a, show) {
+  if (!show || !a.track) return "";
+  return `<span class="gt-track">Trk ${escapeHtml(a.track)}</span>`;
+}
+
+function liveDot(a) {
+  return a.live
+    ? '<i class="ph-bold ph-broadcast gt-live" title="Live"></i>'
+    : "";
+}
+
+// The size class rides on ``.w`` itself: ``.w-body`` has to stay a direct
+// flex child of the shell or it stops filling the cell's height.
+function shell(body, size = "md") {
+  return `
+    <link rel="stylesheet" href="/static/style/spectra-widgets.css">
+    <style>${STYLE}</style>
+    <div class="w size-${escapeHtml(size)}" data-widget="gtfs">${body}</div>`;
+}
+
+const STYLE = `
+  .gt-route {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.9em;
+    padding: 0.1em 0.4em;
+    font-weight: var(--fw-black);
+    font-size: 0.95em;
+    line-height: 1.3;
+    border-radius: var(--pill-radius, var(--radius-0));
+    flex: 0 0 auto;
+  }
+  .gt-live { color: var(--accent-4); font-size: 0.7em; }
+  .gt-stops { font-weight: var(--fw-bold); color: var(--text-secondary); white-space: nowrap; }
+  .gt-origin {
+    flex: 0 0 auto;
+    padding: 0 0.35em;
+    background: var(--surface-sunken);
+    color: var(--text-secondary);
+    font-weight: var(--fw-bold);
+    white-space: nowrap;
+    border-radius: var(--pill-radius, var(--radius-0));
+  }
+  .gt-stale { color: var(--accent-1); }
+  /* Two-column split (lg, opt-in). Columns share the body's height; each
+     carries its own destination heading so neither needs explaining. */
+  .gt-split {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-5);
+  }
+  .gt-col {
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+  .gt-col-head {
+    font-size: var(--fs-label);
+    font-weight: var(--fw-bold);
+    letter-spacing: var(--ls-label);
+    text-transform: var(--label-transform, uppercase);
+    color: var(--text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .gt-col .gt-when .gt-delay ~ .gt-stops,
+  .gt-col .gt-when .gt-delay ~ .gt-track { display: none; }
+  .gt-col .gt-rows {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  /* Alert strip (lg): the one place the full text fits. */
+  .gt-alert {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    background: var(--accent-1-soft);
+    color: var(--accent-1);
+    font-size: var(--fs-label);
+    font-weight: var(--fw-bold);
+    border-radius: var(--radius-0);
+    overflow: hidden;
+  }
+  .gt-track {
+    padding: 0 0.35em;
+    background: var(--surface-sunken);
+    font-weight: var(--fw-bold);
+    border-radius: var(--pill-radius, var(--radius-0));
+  }
+  /* Service-alert text is agency prose and can run long; the title bar is
+     one line, so it truncates rather than shoving the stop name out. */
+  .w-title .w-title-meta {
+    max-width: 55%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .gt-delay {
+    white-space: nowrap;
+    font-weight: var(--fw-bold);
+    text-transform: var(--label-transform, uppercase);
+    letter-spacing: var(--ls-label);
+  }
+
+  /* Hero (xs / sm). The icon and the number are the widget at these
+     sizes, so both scale off cqmin rather than the type scale. */
+  .gt-hero {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-1);
+    text-align: center;
+  }
+  .gt-hero-top {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-3);
+    min-width: 0;
+  }
+  .gt-hero-icon { font-size: clamp(1.8em, 22cqmin, 5em); line-height: 1; }
+  .gt-hero-min {
+    font-size: clamp(2.4em, 34cqmin, 9em);
+    font-weight: var(--fw-black);
+    line-height: var(--lh-tight);
+    letter-spacing: var(--ls-tight);
+    font-variant-numeric: tabular-nums;
+  }
+  .gt-hero-unit {
+    font-size: var(--fs-label);
+    font-weight: var(--fw-bold);
+    letter-spacing: var(--ls-label);
+    text-transform: var(--label-transform, uppercase);
+    color: var(--text-muted);
+  }
+  .gt-hero-line {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    min-width: 0;
+    font-size: clamp(0.8em, 5cqmin, 1.3em);
+  }
+  .gt-hero-sign {
+    font-weight: var(--fw-semi);
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .gt-hero-delay { font-size: var(--fs-label); }
+  .gt-hero-extra {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    font-size: var(--fs-caption);
+  }
+  /* Second and third vehicle as a quiet "then" strip under the hero at
+     sm, the one bit of look-ahead that fits without crowding. */
+  .gt-then {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-3);
+    font-size: var(--fs-label);
+    font-weight: var(--fw-bold);
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Rows (md / lg). No drawn dividers, the minutes block carries a soft
+     accent fill and that plus spacing is the whole hierarchy. */
+  /* Rows split the body's height evenly (flex: 1 1 0) instead of stacking
+     at their natural height. Natural height overflows the moment the row
+     count goes up or the cell is short, and the last row gets clipped. */
+  .gt-rows { overflow: hidden; }
+  .gt-row {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: var(--space-3);
+    flex: 1 1 0;
+    min-height: 0;
+  }
+  .gt-lead { min-width: 0; display: flex; flex-direction: column; gap: 0.1em; }
+  .gt-sign {
+    font-weight: var(--fw-semi);
+    font-size: var(--fs-body);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .gt-when {
+    display: flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    overflow: hidden;
+    gap: 0.3em;
+    font-size: var(--fs-caption);
+    font-weight: var(--fw-bold);
+    letter-spacing: var(--ls-label);
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+  .gt-min {
+    display: flex;
+    align-items: baseline;
+    gap: 0.2em;
+    padding: 0.15em 0.5em;
+    border-radius: var(--radius-0);
+    font-variant-numeric: tabular-nums;
+  }
+  .gt-min .v { font-size: var(--fs-lead); font-weight: var(--fw-black); }
+  .gt-min .u {
+    font-size: var(--fs-caption);
+    font-weight: var(--fw-bold);
+    text-transform: var(--label-transform, uppercase);
+  }
+  /* Struck-through time, not a greyed row: the row still has to be legible
+     from across the room, it just mustn't read as catchable. */
+  .is-canceled .gt-sign, .is-canceled .gt-when { text-decoration: line-through; }
+  .is-canceled .gt-sign { color: var(--text-secondary); }
+  /* lg keeps the type heavy but the row chrome tight: six rows at the
+     md paddings overflow an 800px-tall cell and clip the last one. */
+  .size-lg .gt-row { padding: var(--space-2) var(--space-3); gap: var(--space-4); }
+  .size-lg .gt-sign { font-size: var(--fs-lead); }
+  .size-lg .gt-min .v { font-size: var(--fs-value); }
+  .size-lg .gt-route { font-size: 1.15em; }
+`;
+
+function titleBar(data, size, hasAlertStrip = false) {
+  // A feed note ("Delays northbound", "Live feed unavailable") outranks the
+  // live badge: it's the thing the reader needs, and the badge is still
+  // implied by the per-row live dots.
+  // A feed that stopped updating still hands us confident-looking
+  // predictions, so age is reported rather than assumed: past STALE_AFTER_S
+  // the live badge gives way to how old the data actually is.
+  const age = Number(data.feed_age_s);
+  const stale = Number.isFinite(age) && age >= STALE_AFTER_S;
+  const dot = data.live && !stale ? '<i class="ph-bold ph-broadcast gt-live"></i> ' : "";
+  const aged = Number.isFinite(age) && age >= AGE_SHOWN_AFTER_S
+    ? `${Math.round(age / 60)} min old`
+    : "";
+  // Countdowns are frozen at render time and an e-ink panel can hold a frame
+  // for minutes, so the board says when it was drawn. The clock times in each
+  // row stay true; the "N min" figures don't.
+  const asOf = data.now ? `as of ${escapeHtml(data.now)}` : "";
+  const meta = data.note && !hasAlertStrip
+    ? `${dot}${escapeHtml(data.note)}`
+    : (stale
+      ? `<span class="gt-stale">${escapeHtml(aged || "not updating")}</span>`
+      : (data.live
+        ? `${dot}Live${aged ? ` · ${aged}` : ""}${asOf ? ` · ${asOf}` : ""}`
+        : asOf));
+  const live = meta ? `<span class="w-title-meta">${meta}</span>` : "";
+  const icon = MODE_PH[(data.arrivals || [])[0]?.mode] || "ph-bus";
+  return `
+    <div class="w-title">
+      <i class="ph-bold ${icon}" style="color:var(--accent-4)"></i>
+      <h3>${escapeHtml(data.label || data.stop || "Departures")}</h3>
+      ${size === "xs" ? "" : live}
+    </div>`;
+}
+
+function heroBlock(arrivals, size, walk = 0, opts = {}) {
+  // The hero is "the one you'll actually catch", so a cancelled trip never
+  // claims it; it still shows in the "then" strip below.
+  const next = arrivals.find((a) => !a.canceled) || arrivals[0];
+  // With a walk time set, the number you actually need is when to leave, not
+  // when the train arrives. The arrival time stays visible underneath.
+  const shown = walk > 0 ? Math.max(0, Number(next.minutes) - walk) : Number(next.minutes);
+  const slot = urgency(shown);
+  const icon = MODE_PH[next.mode] || "ph-bus";
+  const line = size === "xs"
+    ? ""
+    : `<div class="gt-hero-line">
+         ${routeBadge(next)}
+         <span class="gt-hero-sign">${escapeHtml(next.headsign || "")}</span>
+         ${liveDot(next)}
+       </div>
+       ${walk > 0 ? `<div class="gt-hero-delay u-muted">arrives ${escapeHtml(next.time || "")}</div>` : ""}
+       ${(() => {
+         const extra = [
+           originChip(next, opts.showOrigin),
+           stopsChip(next, opts.showStops),
+           trackChip(next, opts.showTrack),
+         ].filter(Boolean).join(" ");
+         return extra ? `<div class="gt-hero-extra">${extra}</div>` : "";
+       })()}
+       ${delayChip(next) ? `<div class="gt-hero-delay">${delayChip(next)}</div>` : ""}`;
+  // At sm there's room for a one-line "then 12 · 24" look-ahead; at xs
+  // the single number is the whole widget.
+  const then = size === "xs"
+    ? ""
+    : (() => {
+      const rest = arrivals
+        .filter((a) => a !== next && Number.isFinite(a.minutes))
+        .slice(0, 2);
+      return rest.length
+        ? `<div class="gt-then">then ${rest
+            .map((a) => escapeHtml(a.canceled ? "✕" : fmtMinutes(a.minutes)))
+            .join(" · ")} min</div>`
+        : "";
+    })();
+  return `
+    <div class="gt-hero">
+      <div class="gt-hero-top">
+        <i class="ph-bold ${icon} gt-hero-icon" style="color:var(--accent-${slot})"></i>
+        <div>
+          <div class="gt-hero-min" style="color:var(--accent-${slot})">${escapeHtml(fmtMinutes(shown))}</div>
+          <div class="gt-hero-unit">${
+            walk > 0
+              ? (shown > 0 ? "min to leave" : "leave now")
+              : (shown > 0 ? "min" : "arriving")
+          }</div>
+        </div>
+      </div>
+      ${line}
+      ${then}
+    </div>`;
+}
+
+function rowsBlock(arrivals, opts) {
+  // No per-row mode glyph: every row at a given stop is the same vehicle
+  // type, so it repeats without saying anything. The mode still reads from
+  // the title bar's lead icon (and the hero at xs/sm).
+  return arrivals.map((a) => {
+    const slot = urgency(a.minutes);
+    // A cancelled trip keeps its slot on the board — "the 14:05 isn't coming"
+    // is the useful statement — but drops the countdown, which would read as
+    // a train you could still catch.
+    if (a.canceled) {
+      return `
+        <div class="list-row gt-row is-canceled">
+          ${routeBadge(a)}
+          <div class="gt-lead">
+            <span class="gt-sign">${escapeHtml(a.headsign || a.route || "")}</span>
+            <span class="gt-when">${escapeHtml(a.time || "")}</span>
+          </div>
+          <div class="gt-min" style="background:var(--accent-1-soft);color:var(--accent-1)">
+            <span class="u">Cancelled</span>
+          </div>
+        </div>`;
+    }
+    return `
+      <div class="list-row gt-row">
+        ${routeBadge(a)}
+        <div class="gt-lead">
+          <span class="gt-sign">${escapeHtml(a.headsign || a.route || "")}</span>
+          <span class="gt-when">${escapeHtml(a.time || "")} ${liveDot(a)} ${originChip(a, opts.showOrigin)} ${delayChip(a, opts.showOrigin)} ${stopsChip(a, opts.showStops)} ${trackChip(a, opts.showTrack)}</span>
+        </div>
+        <div class="gt-min" style="background:var(--accent-${slot}-soft);color:var(--accent-${slot})">
+          <span class="v">${escapeHtml(fmtMinutes(a.minutes))}</span>
+          ${a.minutes > 0 ? '<span class="u">min</span>' : ""}
+        </div>
+      </div>`;
+  }).join("");
+}
+
+// Split view groups the board by direction_id and gives each group its own
+// column, headed by where those trains go. On a big lobby cell that beats
+// one column where half the rows are the wrong way for the reader.
+function splitBlock(arrivals, opts, perColumn) {
+  const groups = new Map();
+  for (const a of arrivals) {
+    const key = String(a.direction ?? "");
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(a);
+  }
+  // One direction in the data means there's nothing to split; fall back
+  // rather than painting a lone column beside dead space.
+  if (groups.size < 2) return "";
+  const columns = [...groups.entries()].slice(0, 2).map(([, list]) => {
+    // Head the column with the destinations its trains actually serve —
+    // one name would misdescribe a column that mixes routes.
+    const counts = new Map();
+    for (const a of list) counts.set(a.headsign, (counts.get(a.headsign) || 0) + 1);
+    const heading = [...counts.entries()]
+      .sort((x, y) => y[1] - x[1])
+      .slice(0, 2)
+      .map(([sign]) => sign)
+      .filter(Boolean)
+      .join(" · ");
+    return `
+      <div class="gt-col">
+        <div class="gt-col-head">${escapeHtml(heading ? `to ${heading}` : "")}</div>
+        <div class="list-body gt-rows">${rowsBlock(list.slice(0, perColumn), opts)}</div>
+      </div>`;
+  });
+  return `<div class="w-body gt-split">${columns.join("")}</div>`;
+}
+
+export default function render(shadow, ctx) {
+  const data = ctx?.data ?? {};
+  const size = ctx?.cell?.size || "md";
+  const cellOpts = ctx?.cell?.options || {};
+  const all = Array.isArray(data.arrivals) ? data.arrivals : [];
+  const opts = {
+    showTrack: Boolean(cellOpts.show_track),
+    showStops: Boolean(cellOpts.show_stops_away),
+    // Two stops on the board makes "which stop" load-bearing; one makes it
+    // noise, so it turns itself on from the data rather than an option.
+    showOrigin: new Set(all.map((a) => a.stop_name).filter(Boolean)).size > 1,
+  };
+  const walk = Math.max(0, Number(cellOpts.walk_minutes) || 0);
+
+  if (data.error) {
+    shadow.innerHTML = shell(`
+      <div class="w-title"><i class="ph-bold ph-warning-circle"></i><h3>Departures</h3></div>
+      <div class="w-body"><p class="u-muted">${escapeHtml(data.error)}</p></div>`);
+    return;
+  }
+
+  // The hero sizes still read arrivals 2-3 for the "then" strip, so only
+  // the list sizes cut the array down.
+  const arrivals = (size === "xs" || size === "sm") ? all : all.slice(0, ROWS_BY_SIZE[size] ?? 3);
+
+  if (!arrivals.length) {
+    shadow.innerHTML = shell(`
+      ${size === "xs" ? "" : titleBar(data, size)}
+      <div class="w-body stat-body">
+        <div class="gt-hero">
+          <i class="ph-bold ph-clock gt-hero-icon" style="color:var(--text-muted)"></i>
+          <p class="u-muted">Nothing approaching</p>
+        </div>
+      </div>`, size);
+    return;
+  }
+
+  // Fragments: the Panels canvas can place one part of the widget on its
+  // own. Each paints self-contained, filling its box, with no title bar —
+  // the canvas supplies its own framing.
+  const frag = ctx?.fragment || "full";
+  if (frag === "next") {
+    shadow.innerHTML = shell(
+      `<div class="w-body stat-body">${heroBlock(all, "sm", walk, opts)}</div>`,
+      "sm",
+    );
+    return;
+  }
+  if (frag === "list") {
+    shadow.innerHTML = shell(
+      `<div class="w-body list-body gt-rows">${rowsBlock(all.slice(0, 4), opts)}</div>`,
+      "md",
+    );
+    return;
+  }
+
+  // Split is opt-in and only earns its keep where there's width for two
+  // columns; at md it would halve the row width for no gain.
+  const wantSplit = cellOpts.layout === "split" && size === "lg";
+  const split = wantSplit ? splitBlock(all, opts, SPLIT_ROWS_PER_COLUMN) : "";
+
+  const body = (size === "xs" || size === "sm")
+    ? `<div class="w-body stat-body">${heroBlock(arrivals, size, walk, opts)}</div>`
+    : split || `<div class="w-body list-body gt-rows">${rowsBlock(arrivals, opts)}</div>`;
+
+  // At lg an alert has room to be read in full rather than truncated into
+  // the title bar, which is where it goes at every other size.
+  const alert = size === "lg" && data.note
+    ? `<div class="gt-alert"><i class="ph-bold ph-warning-circle"></i>${escapeHtml(data.note)}</div>`
+    : "";
+
+  shadow.innerHTML = shell(`
+    ${size === "xs" ? "" : titleBar(data, size, Boolean(alert))}
+    ${body}
+    ${alert}`, size);
+}

--- a/plugins/gtfs/fixtures/buses.json
+++ b/plugins/gtfs/fixtures/buses.json
@@ -1,0 +1,11 @@
+{
+  "stop": "Canal St / Broadway",
+  "arrivals": [
+    {"in": 1,  "route": "M20", "headsign": "Lincoln Center",  "delay": 4,  "live": true,  "mode": "bus"},
+    {"in": 6,  "route": "M55", "headsign": "South Ferry",     "delay": 0,  "live": true,  "mode": "bus"},
+    {"in": 12, "route": "M20", "headsign": "Battery Park City","delay": 12, "live": true,  "mode": "bus"},
+    {"in": 18, "route": "M9",  "headsign": "Kips Bay",        "delay": -1, "live": true,  "mode": "bus"},
+    {"in": 25, "route": "M55", "headsign": "Midtown",         "delay": 0,  "live": false, "mode": "bus"},
+    {"in": 33, "route": "M20", "headsign": "Lincoln Center",  "delay": 0,  "live": false, "mode": "bus"}
+  ]
+}

--- a/plugins/gtfs/fixtures/cancellations.json
+++ b/plugins/gtfs/fixtures/cancellations.json
@@ -1,0 +1,12 @@
+{
+  "stop": "Canal St",
+  "note": "C trains cancelled",
+  "arrivals": [
+    {"in": 2,  "route": "C", "headsign": "Euclid Av",           "canceled": true, "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 5,  "route": "A", "headsign": "Inwood-207 St",       "delay": 2,       "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 9,  "route": "C", "headsign": "168 St",              "canceled": true, "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 13, "route": "E", "headsign": "World Trade Center",  "delay": 0,       "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 18, "route": "A", "headsign": "Far Rockaway-Mott Av","delay": 7,       "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 24, "route": "E", "headsign": "Jamaica Center",      "delay": 0,       "color": "#0039A6", "text_color": "#FFFFFF"}
+  ]
+}

--- a/plugins/gtfs/fixtures/delayed.json
+++ b/plugins/gtfs/fixtures/delayed.json
@@ -1,0 +1,12 @@
+{
+  "stop": "Canal St",
+  "note": "Delays northbound",
+  "arrivals": [
+    {"in": 2,  "route": "A", "headsign": "Inwood-207 St",       "delay": 6,  "live": true,  "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 9,  "route": "C", "headsign": "168 St",              "delay": 14, "live": true,  "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 16, "route": "E", "headsign": "World Trade Center",  "delay": 21, "live": true,  "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 24, "route": "A", "headsign": "Far Rockaway-Mott Av","delay": 11, "live": true,  "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 31, "route": "C", "headsign": "Euclid Av",           "delay": 8,  "live": true,  "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 38, "route": "E", "headsign": "Jamaica Center",      "delay": 17, "live": true,  "color": "#0039A6", "text_color": "#FFFFFF"}
+  ]
+}

--- a/plugins/gtfs/fixtures/mixed.json
+++ b/plugins/gtfs/fixtures/mixed.json
@@ -1,0 +1,11 @@
+{
+  "stop": "Canal St",
+  "arrivals": [
+    {"in": 1,  "route": "C", "headsign": "Euclid Av",                    "delay": 0,  "live": true,  "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 4,  "route": "A", "headsign": "Inwood-207 St",                "delay": 3,  "live": true,  "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 7,  "route": "E", "headsign": "World Trade Center",           "delay": -2, "live": true,  "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 11, "route": "C", "headsign": "168 St",                       "delay": 9,  "live": true,  "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 15, "route": "A", "headsign": "Far Rockaway-Mott Av",         "delay": 0,  "live": false, "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 19, "route": "E", "headsign": "Jamaica Center-Parsons/Archer","delay": 1,  "live": true,  "color": "#0039A6", "text_color": "#FFFFFF"}
+  ]
+}

--- a/plugins/gtfs/fixtures/no_service.json
+++ b/plugins/gtfs/fixtures/no_service.json
@@ -1,0 +1,5 @@
+{
+  "stop": "Canal St",
+  "note": "No scheduled service",
+  "arrivals": []
+}

--- a/plugins/gtfs/fixtures/on_time.json
+++ b/plugins/gtfs/fixtures/on_time.json
@@ -1,0 +1,11 @@
+{
+  "stop": "Canal St",
+  "arrivals": [
+    {"in": 3,  "route": "C", "headsign": "Euclid Av",           "delay": 0, "live": true,  "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 8,  "route": "A", "headsign": "Inwood-207 St",       "delay": 0, "live": true,  "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 12, "route": "E", "headsign": "World Trade Center",  "delay": 0, "live": true,  "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 17, "route": "C", "headsign": "168 St",              "delay": 0, "live": false, "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 21, "route": "A", "headsign": "Far Rockaway-Mott Av","delay": 0, "live": false, "color": "#0039A6", "text_color": "#FFFFFF"},
+    {"in": 26, "route": "E", "headsign": "Jamaica Center",      "delay": 0, "live": false, "color": "#0039A6", "text_color": "#FFFFFF"}
+  ]
+}

--- a/plugins/gtfs/plugin.json
+++ b/plugins/gtfs/plugin.json
@@ -1,0 +1,329 @@
+{
+  "tesserae_compat": "1.x",
+  "name": "GTFS / GTFS-RT",
+  "version": "0.11.0",
+  "kind": "widget",
+  "description": "Approaching vehicles at a stop (or two), from any GTFS feed. Presets for the NYC Subway and BART, live times and delays from GTFS-RT, service alerts, and an optional split-by-direction board.",
+  "icon": "ph-bus",
+  "supports": {
+    "sizes": [
+      "xs",
+      "sm",
+      "md",
+      "lg"
+    ]
+  },
+  "cell_options": [
+    {
+      "name": "preset",
+      "type": "select",
+      "label": "Feed preset",
+      "default": "custom",
+      "help": "Pick a known agency feed and the three URL fields below are ignored — the preset supplies the static feed, the matching realtime feed and the alerts feed. The MTA publishes one realtime feed per line group, so pick the group your station is on.",
+      "choices": [
+        {
+          "value": "custom",
+          "label": "Custom URLs (fill the fields below)"
+        },
+        {
+          "value": "bart",
+          "label": "BART (San Francisco Bay Area)"
+        },
+        {
+          "value": "mta_ace",
+          "label": "NYC Subway (A/C/E, Rockaway Shuttle)"
+        },
+        {
+          "value": "mta_bdfm",
+          "label": "NYC Subway (B/D/F/M, Franklin Shuttle)"
+        },
+        {
+          "value": "mta_g",
+          "label": "NYC Subway (G)"
+        },
+        {
+          "value": "mta_jz",
+          "label": "NYC Subway (J/Z)"
+        },
+        {
+          "value": "mta_nqrw",
+          "label": "NYC Subway (N/Q/R/W)"
+        },
+        {
+          "value": "mta_l",
+          "label": "NYC Subway (L)"
+        },
+        {
+          "value": "mta_123456",
+          "label": "NYC Subway (1/2/3/4/5/6/7, 42 St Shuttle)"
+        },
+        {
+          "value": "mta_sir",
+          "label": "NYC Subway (Staten Island Railway)"
+        }
+      ]
+    },
+    {
+      "name": "preset_2",
+      "type": "select",
+      "label": "Second realtime feed (optional)",
+      "default": "",
+      "help": "Agencies split realtime by line group — the MTA publishes one feed per group. If your second stop is on a different group (say A/C/E and the 1), name that group here so both halves of the board get live times. Same static timetable either way.",
+      "choices": [
+        {
+          "value": "",
+          "label": "None"
+        },
+        {
+          "value": "bart",
+          "label": "BART (San Francisco Bay Area)"
+        },
+        {
+          "value": "mta_ace",
+          "label": "NYC Subway (A/C/E, Rockaway Shuttle)"
+        },
+        {
+          "value": "mta_bdfm",
+          "label": "NYC Subway (B/D/F/M, Franklin Shuttle)"
+        },
+        {
+          "value": "mta_g",
+          "label": "NYC Subway (G)"
+        },
+        {
+          "value": "mta_jz",
+          "label": "NYC Subway (J/Z)"
+        },
+        {
+          "value": "mta_nqrw",
+          "label": "NYC Subway (N/Q/R/W)"
+        },
+        {
+          "value": "mta_l",
+          "label": "NYC Subway (L)"
+        },
+        {
+          "value": "mta_123456",
+          "label": "NYC Subway (1/2/3/4/5/6/7, 42 St Shuttle)"
+        },
+        {
+          "value": "mta_sir",
+          "label": "NYC Subway (Staten Island Railway)"
+        }
+      ]
+    },
+    {
+      "name": "stop",
+      "type": "select",
+      "label": "Stop",
+      "default": "",
+      "choices_from": "stops",
+      "help": "Stops on the preset feeds, labelled with the routes that call there. Using a custom feed instead? Leave this blank and fill in Stop ID below. The list is built from the feed the first time you open this editor."
+    },
+    {
+      "name": "stop_2",
+      "type": "select",
+      "label": "Second stop (optional)",
+      "default": "",
+      "choices_from": "stops",
+      "help": "Adds a second station to the same board, merged by time — e.g. the subway entrance on one corner and the one round the block. Rows show which stop each train leaves from once two are set."
+    },
+    {
+      "name": "stop_id",
+      "type": "string",
+      "label": "Stop ID (custom feeds)",
+      "default": "",
+      "help": "stop_id from the feed's stops.txt, for feeds the Stop dropdown doesn't cover. A parent station ID picks up all its platforms (e.g. 'A34' = Canal St A/C/E); comma-separate to pick specific platforms ('A34N,A34S'). The Stop Finder at /plugins/gtfs/ looks these up for any feed."
+    },
+    {
+      "name": "direction",
+      "type": "select",
+      "label": "Direction",
+      "default": "any",
+      "help": "Which way to show. GTFS direction_id means whatever the agency decided and differs per route, so 0 and 1 can't be labelled meaningfully here — try one, and if the board shows the wrong way round, pick the other. The Stop Finder at /plugins/gtfs/ lists the destinations behind each for a given stop if you'd rather look it up.",
+      "choices": [
+        {
+          "value": "any",
+          "label": "Both directions"
+        },
+        {
+          "value": "0",
+          "label": "Direction 0"
+        },
+        {
+          "value": "1",
+          "label": "Direction 1"
+        }
+      ]
+    },
+    {
+      "name": "routes",
+      "type": "string",
+      "label": "Routes",
+      "default": "",
+      "help": "Comma-separated route names to show ('A,C'), matching what the badges display. Blank shows every route calling at the stop."
+    },
+    {
+      "name": "layout",
+      "type": "select",
+      "label": "Layout",
+      "default": "list",
+      "help": "Split shows two columns grouped by direction, each headed by where those trains go. Only applies to a large cell with both directions on the board — anywhere else it falls back to the single list.",
+      "choices": [
+        {
+          "value": "list",
+          "label": "Single list"
+        },
+        {
+          "value": "split",
+          "label": "Split by direction (large cells)"
+        }
+      ]
+    },
+    {
+      "name": "time_basis",
+      "type": "select",
+      "label": "Time shown",
+      "default": "arrival",
+      "help": "Arrival is right for a stop you pass through. At a terminus, where trains sit before running back, departure is the time you can actually board.",
+      "choices": [
+        {
+          "value": "arrival",
+          "label": "Arrival time"
+        },
+        {
+          "value": "departure",
+          "label": "Departure time"
+        }
+      ]
+    },
+    {
+      "name": "gtfs_url",
+      "type": "string",
+      "label": "GTFS feed URL",
+      "default": "",
+      "help": "Link to the agency's static GTFS .zip (e.g. https://rrgtfsfeeds.s3.amazonaws.com/gtfs_subway.zip). Downloaded and distilled to just this stop's timetable, then cached for 12 hours. Filled in and locked while a preset is selected. Set it to 'demo:delayed' (or demo:mixed / on_time / buses / no_service / cancellations) to paint a canned board with no network.",
+      "fill_from": {
+        "option": "preset",
+        "map": {
+          "bart": "https://www.bart.gov/dev/schedules/google_transit.zip",
+          "mta_ace": "https://rrgtfsfeeds.s3.amazonaws.com/gtfs_subway.zip",
+          "mta_bdfm": "https://rrgtfsfeeds.s3.amazonaws.com/gtfs_subway.zip",
+          "mta_g": "https://rrgtfsfeeds.s3.amazonaws.com/gtfs_subway.zip",
+          "mta_jz": "https://rrgtfsfeeds.s3.amazonaws.com/gtfs_subway.zip",
+          "mta_nqrw": "https://rrgtfsfeeds.s3.amazonaws.com/gtfs_subway.zip",
+          "mta_l": "https://rrgtfsfeeds.s3.amazonaws.com/gtfs_subway.zip",
+          "mta_123456": "https://rrgtfsfeeds.s3.amazonaws.com/gtfs_subway.zip",
+          "mta_sir": "https://rrgtfsfeeds.s3.amazonaws.com/gtfs_subway.zip"
+        }
+      }
+    },
+    {
+      "name": "rt_url",
+      "type": "string",
+      "label": "GTFS-RT TripUpdates URL",
+      "default": "",
+      "help": "Optional. Protobuf TripUpdates feed; arrivals it covers show a live marker and use the predicted time. Some agencies require an API key in the URL. Filled in and locked while a preset is selected.",
+      "fill_from": {
+        "option": "preset",
+        "map": {
+          "bart": "https://api.bart.gov/gtfsrt/tripupdate.aspx",
+          "mta_ace": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-ace",
+          "mta_bdfm": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-bdfm",
+          "mta_g": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-g",
+          "mta_jz": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-jz",
+          "mta_nqrw": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-nqrw",
+          "mta_l": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-l",
+          "mta_123456": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs",
+          "mta_sir": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2Fgtfs-si"
+        }
+      }
+    },
+    {
+      "name": "alerts_url",
+      "type": "string",
+      "label": "GTFS-RT ServiceAlerts URL",
+      "default": "",
+      "help": "Optional. Protobuf ServiceAlerts feed; an alert naming this stop or one of its routes shows in the widget's title bar. Often the same base URL as TripUpdates with a different path. Filled in and locked while a preset is selected.",
+      "fill_from": {
+        "option": "preset",
+        "map": {
+          "bart": "https://api.bart.gov/gtfsrt/alerts.aspx",
+          "mta_ace": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Fsubway-alerts",
+          "mta_bdfm": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Fsubway-alerts",
+          "mta_g": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Fsubway-alerts",
+          "mta_jz": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Fsubway-alerts",
+          "mta_nqrw": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Fsubway-alerts",
+          "mta_l": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Fsubway-alerts",
+          "mta_123456": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Fsubway-alerts",
+          "mta_sir": "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Fsubway-alerts"
+        }
+      }
+    },
+    {
+      "name": "title",
+      "type": "string",
+      "label": "Title",
+      "default": "",
+      "help": "Overrides the stop name from the feed (e.g. 'Home stop'). Named 'title' rather than 'label' on purpose: the host fills a widget's 'label' option from the app-level Settings location, which would put your city name above a transit board."
+    },
+    {
+      "name": "horizon",
+      "type": "number",
+      "label": "Look-ahead (minutes)",
+      "default": 90,
+      "help": "Ignore arrivals further out than this."
+    },
+    {
+      "name": "walk_minutes",
+      "type": "number",
+      "label": "Walk time (minutes)",
+      "default": 0,
+      "help": "Minutes to walk to the stop. Hides anything you could no longer catch, and turns the small-cell hero into a 'leave in N min' countdown instead of an arrival time. 0 shows everything from now."
+    },
+    {
+      "name": "show_track",
+      "type": "boolean",
+      "label": "Show track",
+      "default": false,
+      "help": "Show the track each vehicle arrives on, when the feed publishes one (the MTA does, via the NYCT GTFS-RT extension). Off by default: NYC subway track IDs like 'A2' are operational, not the signage riders read. Worth turning on for commuter rail, where the track is the thing you need."
+    },
+    {
+      "name": "show_stops_away",
+      "type": "boolean",
+      "label": "Show stops away",
+      "default": false,
+      "help": "Show how many stops out each vehicle is, from the realtime feed's vehicle positions. The platform-sign metric; on a board where everything is a stop or two away it's mostly noise, so it's off by default."
+    }
+  ],
+  "render": {
+    "dither": "none",
+    "needs_network": true
+  },
+  "requires": [
+    "network:*"
+  ],
+  "fragments": [
+    {
+      "id": "full",
+      "label": "Departure board",
+      "w": 320,
+      "h": 200,
+      "icon": "ph-bus"
+    },
+    {
+      "id": "next",
+      "label": "Next arrival",
+      "w": 180,
+      "h": 120,
+      "icon": "ph-clock"
+    },
+    {
+      "id": "list",
+      "label": "Arrivals list",
+      "w": 320,
+      "h": 160,
+      "icon": "ph-rows"
+    }
+  ]
+}

--- a/plugins/gtfs/server.py
+++ b/plugins/gtfs/server.py
@@ -1,0 +1,1461 @@
+"""Approaching-vehicle board for one GTFS stop, plus optional GTFS-RT.
+
+Two very different upstreams behind one ``fetch()``:
+
+* **Static GTFS** is a zip of CSVs, and for a big agency ``stop_times.txt``
+  runs to hundreds of MB uncompressed. Downloading and scanning that is a
+  minute-scale job, far past the composer's per-widget hydration budget, so
+  the first render kicks a background build and paints a "loading" state;
+  every render after that reads a distilled per-stop timetable (a few KB)
+  out of ``data_dir``. The distillate is cached for 12 hours and refreshed
+  stale-while-revalidate, matching how often agencies actually republish.
+
+* **GTFS-RT** is a small protobuf fetched inline on every render with a
+  20-second cache. Decoded by hand (see ``_pb_fields``); pulling in
+  ``gtfs-realtime-bindings`` + ``protobuf`` for four field numbers isn't
+  worth the dependency.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import csv
+import hashlib
+import io
+import json
+import re
+import threading
+import time
+import urllib.request
+import zipfile
+from collections.abc import Iterator
+from datetime import date as _date
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from flask import Blueprint, current_app, render_template, request
+
+TIMETABLE_TTL_S = 12 * 3600
+RT_TTL_S = 20
+ALERT_TTL_S = 60
+# Cooldown after a failed build. Without it every render retries, and a
+# retry means re-downloading the whole feed.
+BUILD_RETRY_S = 600
+# Static feeds are tens of MB; the read happens on a background thread, so a
+# generous timeout here costs the dashboard nothing.
+GTFS_TIMEOUT_S = 120
+RT_TIMEOUT_S = 8
+# How long a render waits on a fresh build before giving up and painting the
+# loading state. Small feeds (and the test suite) finish inside this and
+# return data on the very first render; MTA-sized ones don't.
+BUILD_WAIT_S = 4.0
+# How long the cell editor may block building a cold stop index (all preset
+# feeds combined) before falling back to "it's still building".
+CHOICES_BUILD_BUDGET_S = 20.0
+USER_AGENT = "tesserae/0.1 (+gtfs)"
+# "[airplane icon]", "[accessibility icon]" — MTA-style placeholders for
+# glyphs a plain-text board can't render.
+_ICON_MARKER = re.compile(r"\[[^\]]*\bicon\b[^\]]*\]", re.IGNORECASE)
+MAX_ARRIVALS = 12
+
+# route_type -> semantic mode name the client maps to a Phosphor glyph.
+_MODES = {
+    0: "tram",
+    1: "subway",
+    2: "rail",
+    3: "bus",
+    4: "ferry",
+    5: "tram",
+    6: "gondola",
+    7: "funicular",
+    11: "bus",
+    12: "monorail",
+}
+
+_BUILDS: dict[str, threading.Thread] = {}
+_BUILD_LOCK = threading.Lock()
+
+# Known feeds, so the common case isn't "go find three URLs". The MTA splits
+# its realtime feeds by line group (one protobuf per group), all sharing one
+# static zip and one alerts feed — hence the repetition below. No API key
+# needed since 2023. Source: https://api.mta.info/#/subwayRealTimeFeeds
+_MTA_STATIC = "https://rrgtfsfeeds.s3.amazonaws.com/gtfs_subway.zip"
+_MTA_RT = "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/nyct%2F"
+_MTA_ALERTS = "https://api-endpoint.mta.info/Dataservice/mtagtfsfeeds/camsys%2Fsubway-alerts"
+
+PRESETS: dict[str, dict[str, str]] = {
+    # BART publishes one realtime feed for the whole system, so it needs no
+    # line-group split. The static URL 307s to a dated file; urllib follows it.
+    "bart": {
+        "label": "BART (San Francisco Bay Area)",
+        "gtfs_url": "https://www.bart.gov/dev/schedules/google_transit.zip",
+        # http:// on BART's published URLs redirects to https anyway; naming
+        # https here skips the hop.
+        "rt_url": "https://api.bart.gov/gtfsrt/tripupdate.aspx",
+        "alerts_url": "https://api.bart.gov/gtfsrt/alerts.aspx",
+    },
+}
+
+PRESETS.update(
+    {
+        key: {
+            "label": f"NYC Subway ({label})",
+            "gtfs_url": _MTA_STATIC,
+            "rt_url": _MTA_RT + path,
+            "alerts_url": _MTA_ALERTS,
+        }
+        for key, label, path in (
+            ("mta_ace", "A/C/E, Rockaway Shuttle", "gtfs-ace"),
+            ("mta_bdfm", "B/D/F/M, Franklin Shuttle", "gtfs-bdfm"),
+            ("mta_g", "G", "gtfs-g"),
+            ("mta_jz", "J/Z", "gtfs-jz"),
+            ("mta_nqrw", "N/Q/R/W", "gtfs-nqrw"),
+            ("mta_l", "L", "gtfs-l"),
+            ("mta_123456", "1/2/3/4/5/6/7, 42 St Shuttle", "gtfs"),
+            ("mta_sir", "Staten Island Railway", "gtfs-si"),
+        )
+    }
+)
+
+
+def _preset_urls(preset: str, gtfs_url: str, rt_url: str, alerts_url: str) -> tuple[str, str, str]:
+    """A chosen preset supplies all three URLs; "custom" leaves them alone."""
+    spec = PRESETS.get(preset)
+    if spec is None:
+        return gtfs_url, rt_url, alerts_url
+    return spec["gtfs_url"], spec["rt_url"], spec["alerts_url"]
+
+
+def fetch(
+    options: dict[str, Any], settings: dict[str, Any], *, ctx: dict[str, Any]
+) -> dict[str, Any]:
+    del settings
+    gtfs_url = str(options.get("gtfs_url") or "").strip()
+    stop_opt = str(options.get("stop_id") or "").strip()
+    rt_url = str(options.get("rt_url") or "").strip()
+    alerts_url = str(options.get("alerts_url") or "").strip()
+    direction = str(options.get("direction") or "any").strip()
+    # NB: not "label" — the host overwrites that option with the app-level
+    # Settings location name, which would title a transit board with a city.
+    title = str(options.get("title") or "").strip()
+    gtfs_url, rt_url, alerts_url = _preset_urls(
+        str(options.get("preset") or "custom").strip(), gtfs_url, rt_url, alerts_url
+    )
+    # A second preset contributes only its realtime feed: the MTA splits
+    # realtime by line group, so a board covering both an A/C/E platform and
+    # a 1 platform needs two feeds behind one static timetable.
+    extra = PRESETS.get(str(options.get("preset_2") or "").strip())
+    # Commas let a custom setup name several feeds in the one field.
+    rt_urls = [u.strip() for u in rt_url.split(",") if u.strip()]
+    if extra and extra["rt_url"] not in rt_urls:
+        rt_urls.append(extra["rt_url"])
+    if not gtfs_url:
+        return {"error": "Pick a feed preset, or set a GTFS feed URL, in the cell editor."}
+    if gtfs_url.startswith("demo:"):
+        return _demo(gtfs_url.split(":", 1)[1], title)
+    # The Stop dropdown only covers the preset feeds; the text field is the
+    # fallback for a custom one. A dropdown pick wins when it belongs to the
+    # feed this cell is actually reading.
+    # Up to two stops on one board: an office between a subway entrance and a
+    # bus stop wants both, merged by time. The distiller already accepts a
+    # comma-separated set, so a second pick just joins the list.
+    picks = [
+        _stop_from_choice(str(options.get(name) or "").strip(), gtfs_url)
+        for name in ("stop", "stop_2")
+    ]
+    chosen = [p for p in picks if p]
+    if chosen:
+        stop_opt = ",".join(chosen)
+    if not stop_opt:
+        return {"error": "Pick a stop in the cell editor."}
+
+    basis = "departure" if str(options.get("time_basis") or "") == "departure" else "arrival"
+    horizon = _positive_int(options.get("horizon"), 90)
+    walk = max(0, _positive_int(options.get("walk_minutes"), 0))
+    # Comma-separated route short names ("A,C"), case-insensitive. Blank
+    # means every route calling at the stop, which is the lobby-board default.
+    wanted_routes = {
+        r.strip().casefold() for r in str(options.get("routes") or "").split(",") if r.strip()
+    }
+
+    data_dir = Path(ctx["data_dir"])
+    data_dir.mkdir(parents=True, exist_ok=True)
+    # Warm the Stop dropdown's index off the feed this render is downloading
+    # anyway, so the editor isn't the thing that discovers it's cold. Cheap:
+    # the zip is shared with the timetable build, and the index is a 0.6s
+    # parse cached for 12 hours.
+    _warm_stop_index(gtfs_url, data_dir)
+    key = hashlib.sha1(f"{gtfs_url}|{stop_opt}".encode()).hexdigest()[:16]
+    tt_path = data_dir / f"tt2_{key}.json"
+    err_path = data_dir / f"err_{key}.json"
+
+    table, fresh = _read_cache(tt_path, TIMETABLE_TTL_S)
+    # A failed build must not re-download a 100 MB feed on every refresh tick,
+    # so failures park in their own file for BUILD_RETRY_S before another
+    # attempt. Separate from tt_path deliberately: a build that fails while a
+    # stale-but-usable timetable is on disk should leave that table alone.
+    err, err_fresh = _read_error(err_path)
+    if (table is None or not fresh) and not err_fresh:
+        thread = _start_build(key, lambda: _build(gtfs_url, stop_opt, tt_path, err_path))
+        if table is None:
+            # Nothing to paint yet. Give a small feed a chance to land inside
+            # this render before falling back to the loading state.
+            thread.join(BUILD_WAIT_S)
+            table, _ = _read_cache(tt_path, TIMETABLE_TTL_S)
+            err, _ = _read_error(err_path)
+    if table is None:
+        return {"error": err or "Loading the timetable from the GTFS feed…"}
+
+    try:
+        tz = ZoneInfo(table.get("tz") or "UTC")
+    except (ZoneInfoNotFoundError, ValueError):
+        tz = ZoneInfo("UTC")
+    now = datetime.now(tz)
+
+    arrivals = _scheduled(table, now, horizon, walk, basis)
+    if direction in ("0", "1"):
+        arrivals = [a for a in arrivals if a["direction"] == direction]
+    if wanted_routes:
+        arrivals = [
+            a
+            for a in arrivals
+            if a["route"].casefold() in wanted_routes or a["route_id"].casefold() in wanted_routes
+        ]
+
+    live = False
+    note = ""
+    stop_ids = set(table.get("stop_ids") or [])
+    feed_age_s = None
+    if rt_urls:
+        bundle, note = _realtime_all(rt_urls, data_dir, key, stop_ids)
+        rt = bundle.get("times") or {}
+        canceled = set(bundle.get("canceled") or [])
+        if rt or canceled:
+            live = _apply_realtime(
+                arrivals,
+                rt,
+                now,
+                canceled,
+                bundle.get("tracks") or {},
+                bundle.get("vehicles") or {},
+            )
+        stamp = bundle.get("stamp")
+        if stamp:
+            feed_age_s = max(0, int(now.timestamp() - int(stamp)))
+    if alerts_url:
+        routes = {a["route_id"] for a in arrivals}
+        found = _alerts(alerts_url, data_dir, key, stop_ids, routes)
+        # A real service alert outranks the "live feed is down" note.
+        if found:
+            note = found[0]
+    # A live prediction can pull a trip earlier than its schedule, past the
+    # window the scheduled pass filtered on, so re-apply the bounds after the
+    # merge. Otherwise a vehicle that already left shows as "-1 min".
+    arrivals = [a for a in arrivals if walk <= a["minutes"] <= horizon]
+    arrivals.sort(key=lambda a: a["minutes"])
+    for a in arrivals:
+        a.pop("sched_epoch", None)
+
+    return {
+        "stop": table.get("stop_name") or stop_opt,
+        "label": title or table.get("stop_name") or stop_opt,
+        "now": now.strftime("%H:%M"),
+        "live": live,
+        "feed_age_s": feed_age_s,
+        "note": note,
+        "arrivals": arrivals[:MAX_ARRIVALS],
+    }
+
+
+# ----------------------------------------------------------------------
+# Stop dropdown for the preset feeds
+# ----------------------------------------------------------------------
+
+
+def choices(name: str) -> list[dict[str, str]]:
+    """Cell-option choices. Only ``stops`` is served.
+
+    The host calls this once per plugin when the editor loads, with no cell
+    context — so it can't know which feed a *particular* cell uses. That's why
+    the dropdown covers the preset feeds only; a custom feed still uses the
+    Stop ID text field. Building an index means reading the whole feed, so
+    this never downloads inline: a cold index kicks a background build and
+    says so, and the next editor open has the list.
+    """
+    if name != "stops":
+        return []
+    data_dir = _data_dir()
+    out: list[dict[str, str]] = [{"value": "", "label": "— use the Stop ID field below —"}]
+    building = False
+    # Budget for building a cold index inline. Downloading + indexing BART is
+    # ~0.5s and the MTA ~4s, so the editor waits once and the dropdown is
+    # populated the first time it's opened. Anything slower finishes in the
+    # background and lands on the next open. The earlier background-only
+    # version left a first-time user staring at an apparently empty dropdown
+    # with no way to tell what was wrong.
+    deadline = time.monotonic() + CHOICES_BUILD_BUDGET_S
+    # One index per distinct static feed, labelled with the agency so the
+    # merged list groups by operator instead of interleaving Bay Area and
+    # New York stations alphabetically.
+    #
+    # Only feeds this install actually uses get built. Indexing every preset
+    # meant a BART-only user downloading the MTA's 5.6 MB zip to populate a
+    # dropdown they'd never scroll — and that cost grows with each preset
+    # added. A fresh install with no gtfs cells yet has nothing to go on, so
+    # it falls back to all of them, once.
+    in_use = _presets_in_use()
+    feeds: dict[str, str] = {}
+    for key, spec in PRESETS.items():
+        if in_use and key not in in_use:
+            continue
+        feeds.setdefault(spec["gtfs_url"], spec["label"].split(" (")[0])
+    for url, agency in feeds.items():
+        digest = hashlib.sha1(url.encode()).hexdigest()[:16]
+        path = data_dir / f"stops3_{digest}.json"
+        cached, fresh = _read_cache(path, TIMETABLE_TTL_S)
+        if cached is not None:
+            out.extend(cached.get("stops") or [])
+        if cached is None or not fresh:
+            thread = _start_build(
+                f"stops-{digest}",
+                lambda u=url, p=path, a=agency: _build_stop_index(u, p, a),
+            )
+            if cached is None:
+                thread.join(max(0.0, deadline - time.monotonic()))
+                landed, _ = _read_cache(path, TIMETABLE_TTL_S)
+                if landed is not None:
+                    out.extend(landed.get("stops") or [])
+                else:
+                    building = True
+    if building:
+        out.insert(1, {"value": "", "label": "(Stop list is loading, reopen this editor shortly)"})
+    return out
+
+
+def _warm_stop_index(gtfs_url: str, data_dir: Path) -> None:
+    """Build this feed's stop index in the background, if it's a preset feed
+    and the index is missing or stale. No-op for custom feeds, which the
+    dropdown doesn't cover anyway."""
+    agency = next(
+        (spec["label"].split(" (")[0] for spec in PRESETS.values() if spec["gtfs_url"] == gtfs_url),
+        "",
+    )
+    if not agency:
+        return
+    digest = hashlib.sha1(gtfs_url.encode()).hexdigest()[:16]
+    path = data_dir / f"stops3_{digest}.json"
+    _cached, fresh = _read_cache(path, TIMETABLE_TTL_S)
+    if fresh:
+        return
+    _start_build(f"stops-{digest}", lambda: _build_stop_index(gtfs_url, path, agency))
+
+
+def _presets_in_use() -> set[str]:
+    """Preset ids referenced by saved gtfs cells, empty if none / unknown."""
+    used: set[str] = set()
+    with contextlib.suppress(Exception):
+        store = current_app.config.get("PAGE_STORE")
+        for page in store.all() if store is not None else []:
+            for cell in page.cells:
+                if cell.plugin == "gtfs":
+                    preset = str((cell.options or {}).get("preset") or "")
+                    if preset in PRESETS:
+                        used.add(preset)
+    return used
+
+
+def _build_stop_index(url: str, path: Path, agency: str = "") -> None:
+    try:
+        index = _stop_index(_feed_bytes(url, path.parent), url, agency)
+    except Exception:
+        return
+    with contextlib.suppress(OSError):
+        _write_json(path, {"stops": index})
+
+
+def _stop_index(raw: bytes, url: str, agency: str = "") -> list[dict[str, str]]:
+    """``stops.txt`` reduced to a labelled dropdown list.
+
+    Labels carry the calling routes because a big agency repeats stop names
+    relentlessly — the MTA has 18 stops called "Canal St", and a dropdown of
+    18 identical labels is no better than the text box it replaces. Getting
+    routes-per-stop means joining ``stop_times`` against ``trips``, i.e.
+    reading the feed's largest member, which is why this runs in the
+    background and gets cached.
+
+    Platforms fold into their parent station: one board per station is what
+    people want, and it halves the list. Direction isn't part of the entry —
+    that's the Direction option's job.
+    """
+    digest = hashlib.sha1(url.encode()).hexdigest()[:16]
+    with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+        names = {n.rsplit("/", 1)[-1]: n for n in zf.namelist()}
+        stops: dict[str, tuple[str, str]] = {}
+        for row in _rows(zf, names, "stops.txt"):
+            stops[row.get("stop_id", "")] = (
+                row.get("stop_name", ""),
+                row.get("parent_station", ""),
+            )
+        route_name: dict[str, str] = {}
+        for row in _rows(zf, names, "routes.txt"):
+            rid = row.get("route_id", "")
+            route_name[rid] = (
+                row.get("route_short_name", "") or row.get("route_long_name", "") or rid
+            )
+        trip_route: dict[str, str] = {}
+        for row in _rows(zf, names, "trips.txt"):
+            trip_route[row.get("trip_id", "")] = row.get("route_id", "")
+        serving: dict[str, set[str]] = {}
+        for row in _rows(zf, names, "stop_times.txt"):
+            sid = row.get("stop_id", "")
+            entry = stops.get(sid)
+            if entry is None:
+                continue
+            # Fold a platform into its parent station.
+            key = entry[1] or sid
+            route = route_name.get(trip_route.get(row.get("trip_id", ""), ""), "")
+            if route:
+                serving.setdefault(key, set()).add(route)
+
+    out: list[dict[str, str]] = []
+    for sid, routes in serving.items():
+        entry = stops.get(sid)
+        if entry is None:
+            continue
+        listed = ", ".join(sorted(routes)[:6])
+        label = f"{entry[0]} ({listed}) · {sid}" if listed else f"{entry[0]} · {sid}"
+        out.append(
+            {
+                "value": f"{digest}:{sid}",
+                "label": f"{agency} · {label}" if agency else label,
+            }
+        )
+    out.sort(key=lambda item: item["label"])
+    return out
+
+
+def _stop_from_choice(value: str, gtfs_url: str) -> str:
+    """``<feed-digest>:<stop_id>`` -> ``stop_id``, if the digest still matches.
+
+    The digest guards against a stale pick: change the cell's feed and a stop
+    ID from the old one would otherwise be silently looked up in the new feed.
+    A trailing ``:<direction>`` from an earlier build of this widget is
+    parsed off and ignored; direction lives in its own option.
+    """
+    digest, _, rest = value.partition(":")
+    stop_id = rest.partition(":")[0]
+    if not stop_id or digest != hashlib.sha1(gtfs_url.encode()).hexdigest()[:16]:
+        return ""
+    return stop_id
+
+
+# ----------------------------------------------------------------------
+# Admin page, stop finder
+# ----------------------------------------------------------------------
+
+
+def blueprint() -> Blueprint:
+    """``/plugins/gtfs/``, search a feed for the stop ID a cell needs.
+
+    Typing a raw ``stop_id`` is the worst part of setting this widget up: the
+    IDs live inside a zip nobody wants to download and grep. This page does
+    that lookup, and inspecting a stop lists which routes call there and what
+    each ``direction_id`` actually means in headsign terms — the two things
+    the cell editor can't tell you.
+    """
+    bp = Blueprint("gtfs_admin", __name__, template_folder="templates")
+
+    @bp.get("/")
+    def index() -> str:
+        feed_url = (request.args.get("feed_url") or "").strip()
+        query = (request.args.get("q") or "").strip()
+        inspect = (request.args.get("inspect") or "").strip()
+        stops: list[dict[str, str]] = []
+        detail: dict[str, Any] | None = None
+        error = ""
+        truncated = 0
+
+        if feed_url and not _may_fetch(feed_url):
+            # Defence in depth: this page turns a query arg into an outbound
+            # request, so an unauthenticated caller only gets the preset
+            # feeds — fixed, known hosts. Arbitrary URLs need a session.
+            error = "Sign in to search a feed that isn't one of the presets."
+            feed_url = ""
+        if feed_url:
+            try:
+                raw = _feed_bytes(feed_url, _data_dir())
+                if inspect:
+                    detail = _inspect_stop(raw, inspect)
+                else:
+                    stops, truncated = _search_stops(raw, query)
+            except zipfile.BadZipFile:
+                error = "That URL didn't return a GTFS zip."
+            except _StopNotFound as err:
+                error = str(err)
+            except Exception as err:
+                error = f"Couldn't read the feed: {type(err).__name__}"
+
+        return render_template(
+            "gtfs/index.html",
+            feed_url=feed_url,
+            query=query,
+            stops=stops,
+            truncated=truncated,
+            detail=detail,
+            inspect=inspect,
+            error=error,
+            fixtures=sorted(p.stem for p in FIXTURES.glob("*.json")),
+            # One entry per distinct static feed: the MTA's eight presets
+            # differ only in which realtime feed they pair with, and the
+            # finder only ever reads the static one.
+            presets=list(
+                {
+                    spec["gtfs_url"]: spec["label"].split(" (")[0] for spec in PRESETS.values()
+                }.items()
+            ),
+        )
+
+    return bp
+
+
+def _may_fetch(feed_url: str) -> bool:
+    """Preset feeds are always allowed; anything else needs a trusted caller.
+
+    "Trusted" means an authed session, or an install that has deliberately
+    turned the password off (Settings -> System -> Auth), where the whole
+    admin UI is already open to the local network and gating this one field
+    would only break the finder for its actual users.
+    """
+    if any(spec["gtfs_url"] == feed_url for spec in PRESETS.values()):
+        return True
+    from app.auth import is_authed, password_required
+
+    if is_authed():
+        return True
+    # Mirror the host's own policy rather than inventing a second one: the
+    # gate isn't installed at all under testing (app_factory), and an admin
+    # can switch the password off, in which case the whole admin UI is
+    # already open to the local network.
+    if current_app.testing:
+        return True
+    settings = current_app.config.get("SETTINGS_STORE")
+    return settings is not None and not password_required(settings)
+
+
+def _data_dir() -> Path:
+    registry = current_app.config["PLUGIN_REGISTRY"]
+    plugin = registry.get("gtfs")
+    if plugin is None:
+        raise RuntimeError("gtfs plugin not registered")
+    path: Path = plugin.data_dir
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+SEARCH_LIMIT = 60
+
+
+def _search_stops(raw: bytes, query: str) -> tuple[list[dict[str, str]], int]:
+    """Substring search over ``stops.txt``. Returns ``(rows, dropped_count)``.
+
+    Only ``stops.txt`` is read — it's the small member, so this stays fast
+    even on a feed whose ``stop_times.txt`` is hundreds of MB.
+    """
+    needle = query.casefold()
+    rows: list[dict[str, str]] = []
+    dropped = 0
+    with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+        names = {n.rsplit("/", 1)[-1]: n for n in zf.namelist()}
+        for row in _rows(zf, names, "stops.txt"):
+            name = row.get("stop_name", "")
+            sid = row.get("stop_id", "")
+            if needle and needle not in name.casefold() and needle not in sid.casefold():
+                continue
+            if len(rows) >= SEARCH_LIMIT:
+                dropped += 1
+                continue
+            rows.append(
+                {
+                    "stop_id": sid,
+                    "stop_name": name,
+                    "parent_station": row.get("parent_station", ""),
+                    "location_type": row.get("location_type", ""),
+                }
+            )
+    rows.sort(key=lambda r: (r["stop_name"], r["stop_id"]))
+    return rows, dropped
+
+
+def _inspect_stop(raw: bytes, stop_opt: str) -> dict[str, Any]:
+    """Distil one stop and summarise what actually calls there.
+
+    Reuses the render path's ``_distil`` so the page can't drift from what a
+    cell would show, then groups by ``direction_id`` — the answer to "which
+    direction is 0?", which is agency-defined and undocumented in the feed.
+    """
+    table = _distil(raw, stop_opt)
+    directions: dict[str, dict[str, Any]] = {}
+    for route_id, headsign, direction, _service, platform in table["trips"].values():
+        bucket = directions.setdefault(
+            str(direction or ""), {"headsigns": {}, "routes": set(), "platforms": set()}
+        )
+        if headsign:
+            bucket["headsigns"][headsign] = bucket["headsigns"].get(headsign, 0) + 1
+        bucket["routes"].add(route_id)
+        bucket["platforms"].add(platform)
+    summary = []
+    for direction, bucket in sorted(directions.items()):
+        top = sorted(bucket["headsigns"].items(), key=lambda kv: -kv[1])[:4]
+        summary.append(
+            {
+                "direction": direction or "(unset)",
+                "headsigns": [h for h, _n in top],
+                "routes": sorted(bucket["routes"]),
+                "platforms": sorted(bucket["platforms"]),
+            }
+        )
+    routes = table.get("routes") or {}
+    return {
+        "stop_id": stop_opt,
+        "stop_name": table.get("stop_name", ""),
+        "stop_ids": table.get("stop_ids") or [],
+        "tz": table.get("tz", ""),
+        "trips": len(table.get("trips") or {}),
+        "routes": [
+            {
+                "id": rid,
+                "name": r.get("short") or r.get("long") or rid,
+                "color": r.get("color", ""),
+                # The admin page's .pill paints dark-on-light by default,
+                # which disappears against a dark route colour.
+                "text_color": r.get("text_color", "") or "#FFFFFF",
+            }
+            for rid, r in sorted(routes.items())
+        ],
+        "directions": summary,
+    }
+
+
+# ----------------------------------------------------------------------
+# Demo fixtures
+# ----------------------------------------------------------------------
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _demo(name: str, title: str) -> dict[str, Any]:
+    """Paint a canned board from ``fixtures/<name>.json``.
+
+    Set the feed URL to ``demo:delayed`` (or any other fixture name) to see a
+    scenario that's awkward to catch on a live feed — a badly delayed train,
+    a stop with nothing running — without waiting for one to happen. Arrival
+    times are rebuilt against the current clock on every render, so the board
+    always looks live rather than frozen at whatever time it was written.
+    """
+    path = FIXTURES / f"{Path(name).name}.json"
+    try:
+        fixture = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        available = ", ".join(sorted(p.stem for p in FIXTURES.glob("*.json")))
+        return {"error": f"No demo fixture '{name}'. Try: {available}."}
+
+    now = datetime.now().astimezone()
+    arrivals = []
+    for i, entry in enumerate(fixture.get("arrivals") or []):
+        minutes = _int(entry.get("in"), 0)
+        when = now + timedelta(minutes=minutes)
+        delay = _int(entry.get("delay"), 0)
+        arrivals.append(
+            {
+                "trip_id": f"demo-{name}-{i}",
+                "stop_id": "DEMO",
+                "minutes": minutes,
+                "time": when.strftime("%H:%M"),
+                "sched": (when - timedelta(minutes=delay)).strftime("%H:%M"),
+                "delay": delay,
+                "route": entry.get("route", ""),
+                "headsign": entry.get("headsign", ""),
+                "mode": entry.get("mode", "subway"),
+                "color": entry.get("color", ""),
+                "text_color": entry.get("text_color", ""),
+                "live": bool(entry.get("live", True)),
+                "canceled": bool(entry.get("canceled", False)),
+                "route_id": entry.get("route", ""),
+                "direction": str(entry.get("direction", "0")),
+            }
+        )
+    return {
+        "stop": fixture.get("stop", "Demo stop"),
+        "label": title or fixture.get("stop", "Demo stop"),
+        "now": now.strftime("%H:%M"),
+        "live": any(a["live"] for a in arrivals),
+        "note": fixture.get("note", ""),
+        "arrivals": arrivals[:MAX_ARRIVALS],
+    }
+
+
+# ----------------------------------------------------------------------
+# Scheduled arrivals
+# ----------------------------------------------------------------------
+
+
+def _scheduled(
+    table: dict[str, Any],
+    now: datetime,
+    horizon: int,
+    walk: int,
+    basis: str = "arrival",
+) -> list[dict[str, Any]]:
+    """Expand the distilled timetable into concrete arrivals around ``now``.
+
+    Walks yesterday / today / tomorrow because GTFS arrival times run past
+    24:00:00 for after-midnight trips, so "tomorrow 00:20" can belong to
+    today's service day and yesterday's service day can still be running.
+    """
+    routes = table.get("routes") or {}
+    trips = table.get("trips") or {}
+    services = table.get("services") or {}
+    lo = now + timedelta(minutes=walk)
+    hi = now + timedelta(minutes=horizon)
+
+    out: list[dict[str, Any]] = []
+    today = now.date()
+    for offset in (-1, 0, 1):
+        day = today + timedelta(days=offset)
+        active = {sid for sid, spec in services.items() if _runs_on(spec, day)}
+        if not active:
+            continue
+        # GTFS service day = noon minus 12h, which lands on the right wall
+        # clock across a DST boundary (a plain midnight can be ambiguous).
+        base = datetime(day.year, day.month, day.day, 12, tzinfo=now.tzinfo) - timedelta(hours=12)
+        stop_names = table.get("stop_names") or {}
+        for trip_id, sec, *rest in table.get("times") or []:
+            trip = trips.get(trip_id)
+            if trip is None or trip[3] not in active:
+                continue
+            if basis == "departure" and len(rest) > 1:
+                sec = rest[1]
+            when = base + timedelta(seconds=sec)
+            if when < lo or when > hi:
+                continue
+            route = routes.get(trip[0]) or {}
+            out.append(
+                {
+                    "trip_id": trip_id,
+                    "stop_id": trip[4],
+                    "minutes": int((when - now).total_seconds() // 60),
+                    "time": when.strftime("%H:%M"),
+                    # Kept so an RT prediction can be expressed as a delay
+                    # against the timetable; stripped before the payload ships.
+                    "sched": when.strftime("%H:%M"),
+                    "sched_epoch": when.timestamp(),
+                    "seq": rest[0] if rest else 0,
+                    "stop_name": stop_names.get(trip[4], ""),
+                    "delay": 0,
+                    "route": route.get("short") or route.get("long") or trip[0],
+                    "route_id": trip[0],
+                    "direction": str(trip[2] or ""),
+                    "headsign": trip[1] or route.get("long") or "",
+                    "mode": _MODES.get(_int(route.get("type"), 3), "bus"),
+                    "color": route.get("color") or "",
+                    "text_color": route.get("text_color") or "",
+                    "live": False,
+                }
+            )
+    out.sort(key=lambda a: a["minutes"])
+    return out
+
+
+def _runs_on(spec: dict[str, Any], day: _date) -> bool:
+    ymd = day.strftime("%Y%m%d")
+    if ymd in (spec.get("rem") or []):
+        return False
+    if ymd in (spec.get("add") or []):
+        return True
+    days = spec.get("days") or []
+    if len(days) != 7 or not days[day.weekday()]:
+        return False
+    start, end = spec.get("start") or "", spec.get("end") or ""
+    if start and ymd < start:
+        return False
+    return not (end and ymd > end)
+
+
+# ----------------------------------------------------------------------
+# GTFS-RT
+# ----------------------------------------------------------------------
+
+
+def _realtime_all(
+    urls: list[str], data_dir: Path, key: str, stop_ids: set[str]
+) -> tuple[dict[str, Any], str]:
+    """Merge several realtime feeds into one bundle.
+
+    Needed because agencies split realtime by line group — the MTA publishes
+    one feed per group — so a board covering two stations often spans two
+    feeds. Later feeds don't overwrite earlier ones; the keys are per trip,
+    and a trip appears in exactly one group's feed.
+    """
+    merged: dict[str, Any] = {"times": {}, "canceled": [], "tracks": {}, "vehicles": {}}
+    notes: list[str] = []
+    stamps: list[int] = []
+    for url in urls:
+        bundle, note = _realtime(url, data_dir, f"{key}_{_url_key(url)}", stop_ids)
+        merged["times"].update(bundle.get("times") or {})
+        merged["tracks"].update(bundle.get("tracks") or {})
+        merged["vehicles"].update(bundle.get("vehicles") or {})
+        merged["canceled"].extend(bundle.get("canceled") or [])
+        if bundle.get("stamp"):
+            stamps.append(int(bundle["stamp"]))
+        if note:
+            notes.append(note)
+    # Report the oldest feed's age: the board is only as current as its
+    # stalest source.
+    merged["stamp"] = min(stamps) if stamps else None
+    return merged, notes[0] if notes else ""
+
+
+def _url_key(url: str) -> str:
+    return hashlib.sha1(url.encode()).hexdigest()[:8]
+
+
+def _realtime(url: str, data_dir: Path, key: str, stop_ids: set[str]) -> tuple[dict[str, Any], str]:
+    """Return ``(realtime_bundle, note)`` for this stop.
+
+    The bundle carries ``times`` / ``canceled`` / ``tracks`` / ``vehicles``
+    (trip -> the stop_sequence it's currently at) / ``stamp`` (the feed's own
+    header timestamp). Errors are non-fatal: the scheduled board is still
+    worth painting, so a dead RT feed comes back as a note instead of an
+    error.
+    """
+    cache = data_dir / f"rt_{key}.json"
+    cached, fresh = _read_cache(cache, RT_TTL_S)
+    if cached is not None and fresh:
+        return cached, ""
+    try:
+        body = _download(url, RT_TIMEOUT_S)
+        canceled: set[str] = set()
+        tracks: dict[str, str] = {}
+        times = _decode_trip_updates(body, stop_ids, canceled, tracks)
+        bundle: dict[str, Any] = {
+            "times": times,
+            "canceled": sorted(canceled),
+            "tracks": tracks,
+            "vehicles": _decode_vehicles(body),
+            # The feed's own timestamp, so the widget can say how old these
+            # predictions are instead of presenting a stalled feed as live.
+            "stamp": _feed_stamp(body),
+        }
+    except Exception:
+        # Serve the last good predictions rather than dropping to schedule-
+        # only on a single blip; they're at most a couple of minutes old.
+        if cached is not None:
+            return cached, "Live feed unavailable"
+        return {}, "Live feed unavailable"
+    with contextlib.suppress(OSError):
+        _write_json(cache, bundle)
+    return bundle, ""
+
+
+def _apply_realtime(
+    arrivals: list[dict[str, Any]],
+    rt: dict[str, int],
+    now: datetime,
+    canceled: set[str] | None = None,
+    tracks: dict[str, str] | None = None,
+    vehicles: dict[str, int] | None = None,
+) -> bool:
+    """Overlay RT predictions onto scheduled arrivals in place."""
+    live = False
+    for a in arrivals:
+        if canceled and any(c in canceled for c in _trip_keys(a["trip_id"])):
+            # Keep the row at its scheduled time but flag it: "the 14:05 is
+            # cancelled" is the useful statement, not a silently missing row.
+            a["canceled"] = True
+            a["live"] = True
+            live = True
+            continue
+        for candidate in _trip_keys(a["trip_id"]):
+            epoch = rt.get(f"{candidate}|{a['stop_id']}")
+            if epoch is None:
+                continue
+            when = datetime.fromtimestamp(epoch, tz=now.tzinfo)
+            a["minutes"] = int((when - now).total_seconds() // 60)
+            a["time"] = when.strftime("%H:%M")
+            a["live"] = True
+            if tracks:
+                a["track"] = tracks.get(f"{candidate}|{a['stop_id']}", "")
+            if vehicles:
+                at_seq = vehicles.get(candidate)
+                seq = a.get("seq") or 0
+                # Both sequences come from the same trip, so the difference is
+                # the number of stops still to go. Negative means the feed has
+                # the train already past us; treat that as "no idea" rather
+                # than showing a nonsense countdown.
+                if at_seq is not None and seq:
+                    away = seq - at_seq
+                    if 0 <= away <= 25:
+                        a["stops_away"] = away
+            # Signed whole minutes against the timetable: positive is late.
+            # Rounded, not floored, so a 90-second delay reads as 2 rather
+            # than 1 and the board doesn't under-report lateness.
+            sched_epoch = a.get("sched_epoch")
+            if sched_epoch:
+                a["delay"] = round((epoch - sched_epoch) / 60)
+            live = True
+            break
+    return live
+
+
+def _trip_keys(trip_id: str) -> tuple[str, ...]:
+    """Trip IDs an RT feed might use for this static trip.
+
+    Most feeds reuse the static trip_id verbatim. The MTA's don't: static is
+    ``AFA24GEN-A-Weekday-00_064750_A..N03R`` where RT sends
+    ``064750_A..N03R``, i.e. everything after the first underscore.
+    ponytail: two candidates covers every feed tried; a full block/start-time
+    match is the upgrade if some agency needs it.
+    """
+    if "_" in trip_id:
+        return (trip_id, trip_id.split("_", 1)[1])
+    return (trip_id,)
+
+
+# gtfs-realtime.proto field numbers. Named once here so the decoders below
+# read as structure rather than arithmetic; the proto is the source of truth
+# for every value. 1001 is the NYCT extension slot (gtfs-realtime-NYCT.proto),
+# which needs no special handling — an extension is just a field number the
+# base spec doesn't claim.
+_FEED_HEADER, _FEED_ENTITY = 1, 2
+_HEADER_TIMESTAMP = 3
+_ENTITY_TRIP_UPDATE, _ENTITY_VEHICLE, _ENTITY_ALERT = 3, 4, 5
+_TU_TRIP, _TU_STOP_TIME_UPDATE = 1, 2
+_TRIP_ID, _TRIP_SCHEDULE_REL = 1, 4
+_SCHEDULE_REL_CANCELED = 3
+_STU_ARRIVAL, _STU_DEPARTURE, _STU_STOP_ID, _STU_NYCT = 2, 3, 4, 1001
+_NYCT_SCHEDULED_TRACK, _NYCT_ACTUAL_TRACK = 1, 2
+_EVENT_TIME = 2
+_VP_TRIP, _VP_CURRENT_STOP_SEQUENCE = 1, 3
+_ALERT_INFORMED, _ALERT_HEADER = 5, 10
+_SELECTOR_ROUTE_ID, _SELECTOR_STOP_ID = 2, 5
+_TRANSLATION, _TRANSLATION_TEXT = 1, 1
+
+
+def _subs(buf: bytes, field: int) -> Iterator[bytes]:
+    """Every length-delimited value of ``field`` — i.e. nested messages."""
+    for got, _wire, value in _pb_fields(buf):
+        if got == field and isinstance(value, bytes):
+            yield value
+
+
+def _sub(buf: bytes | None, field: int) -> bytes | None:
+    """The first nested message at ``field``, or None."""
+    if buf is None:
+        return None
+    return next(_subs(buf, field), None)
+
+
+def _text(buf: bytes | None, field: int) -> str:
+    if buf is None:
+        return ""
+    value = next(_subs(buf, field), None)
+    return value.decode("utf-8", "ignore") if value is not None else ""
+
+
+def _num(buf: bytes | None, field: int) -> int | None:
+    """The first numeric (varint / fixed-width) value of ``field``."""
+    if buf is None:
+        return None
+    for got, _wire, value in _pb_fields(buf):
+        if got == field and isinstance(value, int):
+            return value
+    return None
+
+
+def _feed_stamp(body: bytes) -> int | None:
+    """FeedHeader.timestamp — when the agency last built this feed.
+
+    Without it a stalled feed still paints confident countdowns, because the
+    predictions themselves carry no hint that nothing has moved for an hour.
+    """
+    return _num(_sub(body, _FEED_HEADER), _HEADER_TIMESTAMP)
+
+
+def _decode_trip_updates(
+    body: bytes,
+    stop_ids: set[str],
+    canceled_out: set[str] | None = None,
+    tracks_out: dict[str, str] | None = None,
+) -> dict[str, int]:
+    """Pull ``(trip_id, stop_id) -> arrival epoch`` out of a FeedMessage.
+
+    Canceled trips carry no useful times, but dropping them silently would
+    leave the trip painting at its *scheduled* time as though it were still
+    running — worse than not knowing. Their IDs collect in ``canceled_out``,
+    and NYCT track labels in ``tracks_out``.
+    """
+    out: dict[str, int] = {}
+    for entity in _subs(body, _FEED_ENTITY):
+        for update in _subs(entity, _ENTITY_TRIP_UPDATE):
+            trip = _sub(update, _TU_TRIP)
+            trip_id = _text(trip, _TRIP_ID)
+            if not trip_id:
+                continue
+            if _num(trip, _TRIP_SCHEDULE_REL) == _SCHEDULE_REL_CANCELED:
+                if canceled_out is not None:
+                    canceled_out.add(trip_id)
+                continue
+            for stu in _subs(update, _TU_STOP_TIME_UPDATE):
+                stop_id = _text(stu, _STU_STOP_ID)
+                if not stop_id or (stop_ids and stop_id not in stop_ids):
+                    continue
+                when = _num(_sub(stu, _STU_ARRIVAL), _EVENT_TIME) or _num(
+                    _sub(stu, _STU_DEPARTURE), _EVENT_TIME
+                )
+                if not when:
+                    continue
+                key = f"{trip_id}|{stop_id}"
+                out[key] = int(when)
+                if tracks_out is not None:
+                    nyct = _sub(stu, _STU_NYCT)
+                    track = _text(nyct, _NYCT_ACTUAL_TRACK) or _text(nyct, _NYCT_SCHEDULED_TRACK)
+                    if track:
+                        tracks_out[key] = track
+    return out
+
+
+def _decode_vehicles(body: bytes) -> dict[str, int]:
+    """``trip_id -> the stop_sequence the vehicle is currently at``.
+
+    Same response as the trip updates, different entity type. Comparing this
+    against the trip's sequence at our stop is what turns a countdown into
+    "three stops away".
+    """
+    out: dict[str, int] = {}
+    for entity in _subs(body, _FEED_ENTITY):
+        for vehicle in _subs(entity, _ENTITY_VEHICLE):
+            trip_id = _text(_sub(vehicle, _VP_TRIP), _TRIP_ID)
+            seq = _num(vehicle, _VP_CURRENT_STOP_SEQUENCE)
+            if trip_id and seq is not None:
+                out[trip_id] = int(seq)
+    return out
+
+
+def _alerts(
+    url: str, data_dir: Path, key: str, stop_ids: set[str], route_ids: set[str]
+) -> list[str]:
+    """Header text of any service alert naming this stop or one of its routes."""
+    cache = data_dir / f"al_{key}.json"
+    cached, fresh = _read_cache(cache, ALERT_TTL_S)
+    if cached is not None and fresh:
+        texts: list[str] = list(cached.get("alerts") or [])
+        return texts
+    try:
+        found = _decode_alerts(_download(url, RT_TIMEOUT_S), stop_ids, route_ids)
+    except Exception:
+        return list(cached.get("alerts") or []) if cached else []
+    with contextlib.suppress(OSError):
+        _write_json(cache, {"alerts": found})
+    return found
+
+
+def _decode_alerts(body: bytes, stop_ids: set[str], route_ids: set[str]) -> list[str]:
+    """Matching alert headers, most specific first.
+
+    Only one alert fits in the title bar, so ranking is the feature: an alert
+    about this stop beats one about a route that merely calls here, which
+    beats an agency-wide notice. An alert naming no entity at all is
+    agency-wide by definition.
+    """
+    ranked: list[tuple[int, str]] = []
+    for entity in _subs(body, _FEED_ENTITY):
+        for alert in _subs(entity, _ENTITY_ALERT):
+            selectors = 0
+            rank = 3
+            for selector in _subs(alert, _ALERT_INFORMED):
+                selectors += 1
+                if _text(selector, _SELECTOR_STOP_ID) in stop_ids:
+                    rank = min(rank, 0)
+                elif _text(selector, _SELECTOR_ROUTE_ID) in route_ids:
+                    rank = min(rank, 1)
+            if selectors == 0:
+                rank = min(rank, 2)
+            header = _translated(_sub(alert, _ALERT_HEADER))
+            if header and rank < 3:
+                ranked.append((rank, header))
+    ranked.sort(key=lambda item: item[0])
+    # Dedupe, keeping order: agencies routinely publish one alert per
+    # affected route, all with identical header text.
+    return list(dict.fromkeys(text for _rank, text in ranked))
+
+
+def _translated(buf: bytes | None) -> str:
+    """First translation's text out of a TranslatedString.
+
+    Agencies embed hard newlines and runs of spaces in alert text; the title
+    bar is one line, so flatten here rather than fighting it in CSS.
+    "[airplane icon]"-style markers are placeholders for glyphs we don't
+    have — drop those, but keep route bullets like "[A]".
+    """
+    text = _text(_sub(buf, _TRANSLATION), _TRANSLATION_TEXT)
+    return " ".join(_ICON_MARKER.sub("", text).split())
+
+
+def _pb_fields(buf: bytes) -> Iterator[tuple[int, int, Any]]:
+    """Walk one protobuf message, yielding ``(field_number, wire_type, value)``.
+
+    Length-delimited fields come back as ``bytes`` (a nested message, or a
+    string); varints and fixed-width fields as ``int``. Unknown fields fall
+    out naturally, which is the whole reason this is enough to read an RT
+    feed — including vendor extensions — without the generated classes or a
+    protobuf dependency. Malformed input raises, and the callers treat that
+    as "no live data".
+    """
+    i, n = 0, len(buf)
+    value: Any
+    while i < n:
+        key, i = _varint(buf, i)
+        field, wire = key >> 3, key & 7
+        if wire == 0:
+            value, i = _varint(buf, i)
+        elif wire == 1:
+            value, i = int.from_bytes(buf[i : i + 8], "little"), i + 8
+        elif wire == 2:
+            length, i = _varint(buf, i)
+            if i + length > n:
+                raise ValueError("truncated protobuf field")
+            value, i = buf[i : i + length], i + length
+        elif wire == 5:
+            value, i = int.from_bytes(buf[i : i + 4], "little"), i + 4
+        else:
+            raise ValueError(f"unsupported protobuf wire type {wire}")
+        yield field, wire, value
+
+
+def _varint(buf: bytes, i: int) -> tuple[int, int]:
+    result = shift = 0
+    while True:
+        if i >= len(buf):
+            raise ValueError("truncated varint")
+        byte = buf[i]
+        i += 1
+        result |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return result, i
+        shift += 7
+        if shift > 63:
+            raise ValueError("varint too long")
+
+
+# ----------------------------------------------------------------------
+# Static feed -> distilled per-stop timetable
+# ----------------------------------------------------------------------
+
+
+def _start_build(key: str, work: Any) -> threading.Thread:
+    """Run ``work`` on a background thread, one per (feed, stop) at a time."""
+    with _BUILD_LOCK:
+        existing = _BUILDS.get(key)
+        if existing is not None and existing.is_alive():
+            return existing
+        thread = threading.Thread(target=work, name=f"gtfs-build-{key}", daemon=True)
+        _BUILDS[key] = thread
+        thread.start()
+        return thread
+
+
+def _prune(data_dir: Path) -> None:
+    """Drop cache files nothing will read again.
+
+    Feed zips are the big ones (5 MB+ each) and are re-downloaded on demand,
+    so anything past twice the timetable TTL is dead weight; distilled
+    tables and indexes are small but accumulate one per stop ever previewed.
+    Runs on the background build path, so no render waits for it.
+    """
+    now = time.time()
+    ages = {"feed_": TIMETABLE_TTL_S * 2, "tt2_": 86400 * 7, "stops3_": 86400 * 7}
+    for path in data_dir.glob("*"):
+        limit = next((age for prefix, age in ages.items() if path.name.startswith(prefix)), None)
+        if limit is None:
+            continue
+        with contextlib.suppress(OSError):
+            if now - path.stat().st_mtime > limit:
+                path.unlink()
+
+
+def _build(url: str, stop_opt: str, path: Path, err_path: Path) -> None:
+    """Download the feed, distil this stop's timetable, write it to disk."""
+    _prune(path.parent)
+    try:
+        table = _distil(_feed_bytes(url, path.parent), stop_opt)
+    except zipfile.BadZipFile:
+        _write_error(err_path, "That URL didn't return a GTFS zip.")
+        return
+    except _StopNotFound as err:
+        _write_error(err_path, str(err))
+        return
+    except Exception:
+        _write_error(err_path, "Couldn't load the GTFS feed right now.")
+        return
+    with contextlib.suppress(OSError):
+        _write_json(path, table)
+    # A good build clears the cooldown so a feed that recovers isn't held
+    # back by the last failure.
+    with contextlib.suppress(OSError):
+        err_path.unlink(missing_ok=True)
+
+
+def _feed_bytes(url: str, data_dir: Path) -> bytes:
+    """The feed zip, cached on disk for the timetable TTL.
+
+    Shared by the builder and the admin stop finder: without it, searching
+    stops and then rendering re-downloads the same tens of MB twice.
+    """
+    cache = data_dir / f"feed_{hashlib.sha1(url.encode()).hexdigest()[:16]}.zip"
+    try:
+        if cache.exists() and (time.time() - cache.stat().st_mtime) < TIMETABLE_TTL_S:
+            return cache.read_bytes()
+    except OSError:
+        pass
+    raw = _download(url, GTFS_TIMEOUT_S)
+    with contextlib.suppress(OSError):
+        tmp = cache.with_suffix(".tmp")
+        tmp.write_bytes(raw)
+        tmp.replace(cache)
+    return raw
+
+
+class _StopNotFound(Exception):
+    pass
+
+
+def _distil(raw: bytes, stop_opt: str) -> dict[str, Any]:
+    wanted = {s.strip() for s in stop_opt.split(",") if s.strip()}
+    with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+        names = {n.rsplit("/", 1)[-1]: n for n in zf.namelist()}
+
+        stop_ids: set[str] = set()
+        stop_name = ""
+        station_of: dict[str, str] = {}
+        names_by_id: dict[str, str] = {}
+        for row in _rows(zf, names, "stops.txt"):
+            sid = row.get("stop_id", "")
+            parent = row.get("parent_station", "")
+            if sid in wanted or parent in wanted:
+                stop_ids.add(sid)
+                station_of[sid] = parent or sid
+                names_by_id[sid] = row.get("stop_name", "")
+                if not stop_name or sid in wanted:
+                    stop_name = row.get("stop_name", "") or stop_name
+        if not stop_ids:
+            raise _StopNotFound(f"Stop '{stop_opt}' isn't in this feed.")
+
+        routes: dict[str, Any] = {}
+        for row in _rows(zf, names, "routes.txt"):
+            routes[row.get("route_id", "")] = {
+                "short": row.get("route_short_name", ""),
+                "long": row.get("route_long_name", ""),
+                "color": _hex(row.get("route_color", "")),
+                "text_color": _hex(row.get("route_text_color", "")),
+                "type": _int(row.get("route_type"), 3),
+            }
+
+        # stop_times.txt is the big one (hundreds of MB for a subway feed),
+        # so it streams and keeps only rows at this stop.
+        times: list[tuple[str, int, int, int]] = []
+        at_stop: dict[str, str] = {}
+        for row in _rows(zf, names, "stop_times.txt"):
+            sid = row.get("stop_id", "")
+            if sid not in stop_ids:
+                continue
+            arr = _hms(row.get("arrival_time") or row.get("departure_time") or "")
+            dep = _hms(row.get("departure_time") or row.get("arrival_time") or "")
+            if arr is None:
+                continue
+            trip_id = row.get("trip_id", "")
+            # stop_sequence is what a VehiclePosition's own sequence gets
+            # compared against to answer "how many stops away is it". Both
+            # times are kept: at a terminus the departure is the useful one.
+            times.append(
+                (trip_id, arr, _int(row.get("stop_sequence"), 0), dep if dep is not None else arr)
+            )
+            at_stop[trip_id] = sid
+        times.sort(key=lambda t: t[1])
+
+        trips: dict[str, list[Any]] = {}
+        for row in _rows(zf, names, "trips.txt"):
+            trip_id = row.get("trip_id", "")
+            if trip_id not in at_stop:
+                continue
+            trips[trip_id] = [
+                row.get("route_id", ""),
+                row.get("trip_headsign", ""),
+                row.get("direction_id", ""),
+                row.get("service_id", ""),
+                at_stop[trip_id],
+            ]
+
+        services: dict[str, Any] = {}
+        for row in _rows(zf, names, "calendar.txt"):
+            services[row.get("service_id", "")] = {
+                "days": [
+                    _int(row.get(d), 0)
+                    for d in (
+                        "monday",
+                        "tuesday",
+                        "wednesday",
+                        "thursday",
+                        "friday",
+                        "saturday",
+                        "sunday",
+                    )
+                ],
+                "start": row.get("start_date", ""),
+                "end": row.get("end_date", ""),
+                "add": [],
+                "rem": [],
+            }
+        for row in _rows(zf, names, "calendar_dates.txt"):
+            spec = services.setdefault(
+                row.get("service_id", ""),
+                {"days": [0] * 7, "start": "", "end": "", "add": [], "rem": []},
+            )
+            bucket = "add" if _int(row.get("exception_type"), 1) == 1 else "rem"
+            spec[bucket].append(row.get("date", ""))
+
+        tz = ""
+        for row in _rows(zf, names, "agency.txt"):
+            tz = row.get("agency_timezone", "") or tz
+            break
+
+    # Only the routes/services these trips actually reference get kept, so
+    # the distillate stays a few KB even for a 60-route agency.
+    used_routes = {t[0] for t in trips.values()}
+    used_services = {t[3] for t in trips.values()}
+    # A platform inherits its station's name, so a two-station board can
+    # label each row with where it leaves from.
+    platform_names = {
+        sid: names_by_id.get(station_of.get(sid, sid)) or names_by_id.get(sid, "")
+        for sid in stop_ids
+    }
+    return {
+        "built": time.time(),
+        "stop_name": stop_name,
+        "stop_names": platform_names,
+        "stop_ids": sorted(stop_ids),
+        "tz": tz or "UTC",
+        "routes": {k: v for k, v in routes.items() if k in used_routes},
+        "services": {k: v for k, v in services.items() if k in used_services},
+        "trips": trips,
+        "times": [list(t) for t in times if t[0] in trips],
+    }
+
+
+def _rows(zf: zipfile.ZipFile, names: dict[str, str], member: str) -> Iterator[dict[str, str]]:
+    """Stream one GTFS CSV member. Missing members yield nothing, several are
+    optional (calendar.txt, calendar_dates.txt) and feeds ship either or both."""
+    path = names.get(member)
+    if path is None:
+        return
+    with zf.open(path) as handle:
+        yield from csv.DictReader(io.TextIOWrapper(handle, encoding="utf-8-sig", newline=""))
+
+
+# ----------------------------------------------------------------------
+# Small helpers
+# ----------------------------------------------------------------------
+
+
+# Only http(s) reaches the network. Every URL here — feed, TripUpdates,
+# alerts, and the admin page's ``feed_url`` query arg — is user-supplied, and
+# urllib's default opener also speaks file:// and ftp://, so a pasted
+# "file:///etc/passwd" would otherwise be read and parsed server-side.
+# Registering only the HTTP handlers refuses those at the transport layer
+# rather than relying on the scheme check alone.
+_OPENER = urllib.request.build_opener(urllib.request.HTTPHandler, urllib.request.HTTPSHandler)
+
+
+def _download(url: str, timeout: float) -> bytes:
+    scheme = urllib.parse.urlparse(url).scheme.lower()
+    if scheme not in ("http", "https"):
+        raise ValueError(f"unsupported URL scheme: {scheme or '(none)'}")
+    req = urllib.request.Request(
+        url, headers={"User-Agent": USER_AGENT, "Accept-Encoding": "identity"}
+    )
+    with _OPENER.open(req, timeout=timeout) as resp:
+        body: bytes = resp.read()
+    return body
+
+
+def _read_cache(path: Path, ttl: float) -> tuple[dict[str, Any] | None, bool]:
+    """Return ``(payload, is_fresh)``. Stale payloads still come back so the
+    caller can serve them while a rebuild runs."""
+    if not path.exists():
+        return None, False
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None, False
+    if not isinstance(payload, dict) or "error" in payload:
+        return None, False
+    return payload, (time.time() - path.stat().st_mtime) < ttl
+
+
+def _read_error(path: Path) -> tuple[str, bool]:
+    """Return ``(message, still_in_cooldown)`` for a failed build.
+
+    The cooldown flag is what stops a broken feed from being re-fetched on
+    every single render.
+    """
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        age = time.time() - path.stat().st_mtime
+    except (json.JSONDecodeError, OSError):
+        return "", False
+    if not isinstance(payload, dict):
+        return "", False
+    return str(payload.get("error", "")), age < BUILD_RETRY_S
+
+
+def _write_error(path: Path, message: str) -> None:
+    with contextlib.suppress(OSError):
+        _write_json(path, {"error": message})
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write via a temp file so a render never reads a half-written table."""
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _hms(value: str) -> int | None:
+    """``"25:10:00"`` -> seconds since the service day started."""
+    parts = value.strip().split(":")
+    if len(parts) < 2:
+        return None
+    try:
+        h, m = int(parts[0]), int(parts[1])
+        s = int(parts[2]) if len(parts) > 2 and parts[2] else 0
+    except ValueError:
+        return None
+    return h * 3600 + m * 60 + s
+
+
+def _hex(value: str) -> str:
+    v = value.strip().lstrip("#")
+    return f"#{v.upper()}" if len(v) == 6 and all(c in "0123456789abcdefABCDEF" for c in v) else ""
+
+
+def _int(value: Any, default: int) -> int:
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _positive_int(value: Any, default: int) -> int:
+    parsed = _int(value, default)
+    return parsed if parsed > 0 else default

--- a/plugins/gtfs/templates/gtfs/index.html
+++ b/plugins/gtfs/templates/gtfs/index.html
@@ -1,0 +1,115 @@
+{% extends "_base.html" %}
+{% from "_components.html" import card_head, button, empty_state %}
+{% block title %}GTFS Stop Finder, Tesserae{% endblock %}
+
+{% block main %}
+<div class="page-head">
+  <h1><i class="ph-bold ph-bus" aria-hidden="true"></i> GTFS Stop Finder</h1>
+  <p class="page-blurb">Look up the <code>stop_id</code> a GTFS cell needs, without downloading and grepping the feed yourself. Search by stop name or ID, then inspect a stop to see which routes call there and what each direction actually means.</p>
+</div>
+
+<section class="card">
+  {{ card_head('Search a feed', icon_name='magnifying-glass', level=2) }}
+  <form method="get" action="{{ url_for('gtfs_admin.index') }}" class="form">
+    <div class="field">
+      <label for="feed-url">GTFS feed URL</label>
+      <input type="url" id="feed-url" name="feed_url" required
+             placeholder="https://rrgtfsfeeds.s3.amazonaws.com/gtfs_subway.zip"
+             value="{{ feed_url }}">
+      <p class="field-help">The same zip URL you'll put in the cell. Cached for 12 hours after the first download, so searching is instant afterwards.</p>
+    </div>
+    <div class="field">
+      <label for="feed-q">Stop name or ID</label>
+      <input type="text" id="feed-q" name="q" value="{{ query }}" placeholder="Canal St">
+      <p class="field-help">Substring match, case-insensitive. Leave blank to list everything (first {{ 60 }} shown).</p>
+    </div>
+    <div class="actions">{{ button('Search', icon='magnifying-glass') }}</div>
+  </form>
+
+  {% if presets %}
+  <p class="field-help">Presets:
+    {% for url, name in presets %}<a href="{{ url_for('gtfs_admin.index', feed_url=url, q=query) }}">{{ name }}</a>{{ ' · ' if not loop.last }}{% endfor %}
+    — the cell editor has the same list, split by realtime line group.</p>
+  {% endif %}
+
+  {% if error %}
+  <p class="field-help" role="alert"><i class="ph-bold ph-warning-circle" aria-hidden="true"></i> {{ error }}</p>
+  {% endif %}
+</section>
+
+{% if detail %}
+<section class="card">
+  {{ card_head(detail.stop_name or detail.stop_id, icon_name='map-pin', level=2) }}
+  <p class="lede">
+    <code>{{ detail.stop_id }}</code> covers {{ detail.stop_ids|length }} platform{{ '' if detail.stop_ids|length == 1 else 's' }}
+    ({{ detail.stop_ids|join(', ') }}) · {{ detail.trips }} trips · timezone {{ detail.tz }}
+  </p>
+
+  <h3>Routes calling here</h3>
+  <p>
+    {% for r in detail.routes %}
+      <span class="pill" style="min-width:2.4em;justify-content:center;{% if r.color %}background:{{ r.color }};color:{{ r.text_color }}{% endif %}">{{ r.name }}</span>
+    {% else %}
+      <span class="field-help">None found.</span>
+    {% endfor %}
+  </p>
+
+  <h3>Directions</h3>
+  <table class="table">
+    <thead>
+      <tr><th><code>direction</code> option</th><th>Goes to</th><th>Routes</th><th>Platforms</th></tr>
+    </thead>
+    <tbody>
+      {% for d in detail.directions %}
+      <tr>
+        <td><code>{{ d.direction }}</code></td>
+        <td>{{ d.headsigns|join(', ') or '—' }}</td>
+        <td>{{ d.routes|join(', ') }}</td>
+        <td>{{ d.platforms|join(', ') }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <p class="field-help">GTFS doesn't say what <code>direction_id</code> 0 and 1 mean — each agency picks. Match the headsigns above to the way you travel, then set the cell's Direction option. Or set the cell's Stop ID to a single platform instead.</p>
+</section>
+{% endif %}
+
+{% if stops %}
+<section class="card">
+  {{ card_head('%d matching stop%s' % (stops|length, '' if stops|length == 1 else 's'), icon_name='list', level=2) }}
+  <table class="table">
+    <thead>
+      <tr><th>Stop ID</th><th>Name</th><th>Parent station</th><th></th></tr>
+    </thead>
+    <tbody>
+      {% for s in stops %}
+      <tr>
+        <td><code>{{ s.stop_id }}</code></td>
+        <td>{{ s.stop_name }}</td>
+        <td>{% if s.parent_station %}<code>{{ s.parent_station }}</code>{% else %}—{% endif %}</td>
+        <td>
+          <a href="{{ url_for('gtfs_admin.index', feed_url=feed_url, q=query, inspect=s.stop_id) }}">Inspect</a>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% if truncated %}
+  <p class="field-help">{{ truncated }} more match — narrow the search.</p>
+  {% endif %}
+  <p class="field-help">Use a parent station ID to get every platform on one board, or a single platform ID (often the parent plus a direction suffix) to get one direction only.</p>
+</section>
+{% elif feed_url and not detail and not error %}
+<section class="card">
+  {{ empty_state('magnifying-glass', 'No stops matched', 'Try a shorter search, or leave the box blank to list the first stops in the feed.') }}
+</section>
+{% endif %}
+
+<section class="card">
+  {{ card_head('No feed handy?', icon_name='flask', level=2) }}
+  <p class="lede">Set a cell's GTFS feed URL to one of these to paint a canned board with no network at all — useful for checking how delays, cancellations and empty stops look on your panel.</p>
+  <p>
+    {% for f in fixtures %}<code>demo:{{ f }}</code>{{ ' · ' if not loop.last }}{% endfor %}
+  </p>
+</section>
+{% endblock %}

--- a/plugins/gtfs/tests/test_smoke.py
+++ b/plugins/gtfs/tests/test_smoke.py
@@ -1,0 +1,731 @@
+"""gtfs smoke: a synthetic feed renders at every size, and the hand-rolled
+GTFS-RT protobuf reader pulls the right arrival out of a TripUpdates blob.
+
+No network: the URL opener is patched to serve an in-memory GTFS zip built a
+few minutes into the future, so the render always has something to paint.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+import re
+import time
+import zipfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+from urllib.parse import quote
+
+import pytest
+from flask.testing import FlaskClient
+
+# The plugin's restricted opener (no file:// / ftp:// handlers) means
+# patching ``urllib.request.urlopen`` no longer intercepts anything. Patch
+# the OpenerDirector class instead: that catches every instance, including
+# the separate module object the Flask app loads for the real render path.
+_OPEN = "urllib.request.OpenerDirector.open"
+
+_PLUGIN = Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location("gtfs_server", _PLUGIN / "server.py")
+assert _spec and _spec.loader
+gtfs_server = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gtfs_server)
+
+
+def _feed(second_direction: str = "0", second_stop: bool = False) -> bytes:
+    """A one-stop, two-trip GTFS zip with arrivals 4 and 9 minutes out.
+
+    ``second_direction`` puts the two trips on opposite ``direction_id``s.
+    ``second_stop`` moves the second trip to a different station, which is
+    what a two-stop board merges.
+    """
+    now = datetime.now(UTC)
+    first = now + timedelta(minutes=4)
+    second = now + timedelta(minutes=9)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("agency.txt", "agency_id,agency_name,agency_timezone\nT,Test,UTC\n")
+        zf.writestr(
+            "stops.txt",
+            "stop_id,stop_name,parent_station\n"
+            "S1,Canal St,\n"
+            "S1N,Canal St North,S1\n"
+            "S2,Franklin St,\n"
+            "S2N,Franklin St North,S2\n",
+        )
+        zf.writestr(
+            "routes.txt",
+            "route_id,route_short_name,route_long_name,route_type,route_color,route_text_color\n"
+            "R1,A,Eighth Avenue Express,1,0039A6,FFFFFF\n",
+        )
+        zf.writestr(
+            "trips.txt",
+            "route_id,service_id,trip_id,trip_headsign,direction_id\n"
+            "R1,ALL,T1,Inwood-207 St,0\n"
+            f"R1,ALL,T2,Far Rockaway,{second_direction}\n",
+        )
+        zf.writestr(
+            "stop_times.txt",
+            "trip_id,arrival_time,departure_time,stop_id,stop_sequence\n"
+            f"T1,{first:%H:%M:%S},{first:%H:%M:%S},S1N,1\n"
+            f"T2,{second:%H:%M:%S},{second:%H:%M:%S},{'S2N' if second_stop else 'S1N'},1\n"
+            # A row at a different stop, must not leak into the board.
+            f"T1,{first:%H:%M:%S},{first:%H:%M:%S},S9,2\n",
+        )
+        zf.writestr(
+            "calendar.txt",
+            "service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,"
+            "start_date,end_date\n"
+            "ALL,1,1,1,1,1,1,1,20000101,20990101\n",
+        )
+    return buf.getvalue()
+
+
+class _FakeResp:
+    def __init__(self, body: bytes) -> None:
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _FakeResp:
+        return self
+
+    def __exit__(self, *a: object) -> bool:
+        return False
+
+
+@pytest.mark.parametrize("size", ["xs", "sm", "md", "lg"])
+def test_gtfs_renders(client: FlaskClient, size: str) -> None:
+    opts = '{"gtfs_url":"https://example.test/gtfs.zip","stop_id":"S1"}'
+    feed = _feed()
+    with patch(_OPEN, return_value=_FakeResp(feed)):
+        resp = client.get(f"/_test/render?plugin=gtfs&size={size}&opts={opts}")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'data-plugin="gtfs"' in body
+    # Stop name and the first arrival's headsign came out of the zip.
+    assert "Canal St" in body
+    assert "Inwood-207 St" in body
+    # The row at the other stop never made it into the board.
+    assert "S9" not in body
+
+
+# ----------------------------------------------------------------------
+# GTFS-RT decoding
+# ----------------------------------------------------------------------
+
+
+def _varint(value: int) -> bytes:
+    out = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        out.append(byte | (0x80 if value else 0))
+        if not value:
+            return bytes(out)
+
+
+def _tag(field: int, wire: int) -> bytes:
+    return _varint(field << 3 | wire)
+
+
+def _msg(field: int, payload: bytes) -> bytes:
+    return _tag(field, 2) + _varint(len(payload)) + payload
+
+
+def _str(field: int, text: str) -> bytes:
+    return _msg(field, text.encode())
+
+
+def _int(field: int, value: int) -> bytes:
+    return _tag(field, 0) + _varint(value)
+
+
+def _trip_update(trip_id: str, stop_id: str, epoch: int, canceled: bool = False) -> bytes:
+    trip = _str(1, trip_id) + (_int(4, 3) if canceled else b"")
+    stu = _str(4, stop_id) + _msg(2, _int(2, epoch))
+    return _msg(3, _msg(1, trip) + _msg(2, stu))
+
+
+def test_decode_trip_updates_reads_arrival_times() -> None:
+    feed = _msg(2, _trip_update("T1", "S1N", 1_800_000_000))
+    assert gtfs_server._decode_trip_updates(feed, {"S1N"}) == {"T1|S1N": 1_800_000_000}
+
+
+def test_decode_trip_updates_skips_other_stops_and_cancellations() -> None:
+    feed = _msg(2, _trip_update("T1", "S2", 1_800_000_000)) + _msg(
+        2, _trip_update("T2", "S1N", 1_800_000_100, canceled=True)
+    )
+    assert gtfs_server._decode_trip_updates(feed, {"S1N"}) == {}
+
+
+def test_realtime_prediction_overrides_the_schedule() -> None:
+    """An RT time for a trip wins over its scheduled time, and the MTA's
+    'RT drops the block prefix' trip_id form still matches."""
+    now = datetime.now(UTC)
+    arrivals = [
+        {
+            "trip_id": "BLOCK-Weekday-00_077150_C..S04R",
+            "stop_id": "S1N",
+            "minutes": 9,
+            "time": "",
+            "live": False,
+        }
+    ]
+    epoch = int((now + timedelta(minutes=3)).timestamp())
+    live = gtfs_server._apply_realtime(arrivals, {"077150_C..S04R|S1N": epoch}, now)
+    assert live is True
+    assert arrivals[0]["minutes"] == 2  # 3 minutes out, floored to whole minutes
+    assert arrivals[0]["live"] is True
+
+
+def test_delay_is_signed_minutes_against_the_timetable() -> None:
+    """Late is positive, early is negative, both measured off ``sched_epoch``."""
+    now = datetime.now(UTC)
+    scheduled = now + timedelta(minutes=10)
+
+    def _arrival() -> list[dict[str, object]]:
+        return [
+            {
+                "trip_id": "T1",
+                "stop_id": "S1N",
+                "minutes": 10,
+                "sched_epoch": scheduled.timestamp(),
+                "delay": 0,
+                "live": False,
+            }
+        ]
+
+    late = _arrival()
+    gtfs_server._apply_realtime(
+        late, {"T1|S1N": int((scheduled + timedelta(minutes=6)).timestamp())}, now
+    )
+    assert late[0]["delay"] == 6
+
+    early = _arrival()
+    gtfs_server._apply_realtime(
+        early, {"T1|S1N": int((scheduled - timedelta(minutes=2)).timestamp())}, now
+    )
+    assert early[0]["delay"] == -2
+
+
+@pytest.mark.parametrize(
+    "scenario", ["mixed", "delayed", "on_time", "buses", "no_service", "cancellations"]
+)
+def test_demo_fixtures_render(client: FlaskClient, scenario: str) -> None:
+    """``gtfs_url: demo:<name>`` paints a canned board with no network at all."""
+    opts = f'{{"gtfs_url":"demo:{scenario}","stop_id":"ignored"}}'
+    resp = client.get(f"/_test/render?plugin=gtfs&size=md&opts={opts}")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'data-plugin="gtfs"' in body
+    assert "error" not in body.lower() or "no demo fixture" not in body.lower()
+
+
+def test_unknown_demo_fixture_lists_the_real_ones() -> None:
+    out = gtfs_server._demo("nope", "")
+    assert "No demo fixture 'nope'" in out["error"]
+    assert "delayed" in out["error"]
+
+
+def test_canceled_trips_are_flagged_not_dropped() -> None:
+    """A cancelled trip keeps its row; silently leaving it at its scheduled
+    time would read as a train you could still catch."""
+    canceled: set[str] = set()
+    feed = _msg(2, _trip_update("T9", "S1N", 1_800_000_000, canceled=True))
+    assert gtfs_server._decode_trip_updates(feed, {"S1N"}, canceled) == {}
+    assert canceled == {"T9"}
+
+    now = datetime.now(UTC)
+    arrivals = [{"trip_id": "T9", "stop_id": "S1N", "minutes": 6, "live": False}]
+    gtfs_server._apply_realtime(arrivals, {}, now, canceled)
+    assert arrivals[0]["canceled"] is True
+    assert arrivals[0]["minutes"] == 6
+
+
+def _alert(header: str, stop_id: str = "", route_id: str = "") -> bytes:
+    translated = _msg(10, _msg(1, _str(1, header)))
+    selector = b""
+    if stop_id:
+        selector += _msg(5, _str(5, stop_id))
+    if route_id:
+        selector += _msg(5, _str(2, route_id))
+    return _msg(2, _msg(5, selector + translated))
+
+
+def test_alerts_match_by_stop_route_or_agency_wide() -> None:
+    feed = (
+        _alert("Signal problems at Canal St", stop_id="S1N")
+        + _alert("A running express", route_id="R1")
+        + _alert("Elevator out at 14 St", stop_id="S99")
+        + _alert("Reduced service system-wide")
+    )
+    found = gtfs_server._decode_alerts(feed, {"S1N"}, {"R1"})
+    assert found == [
+        "Signal problems at Canal St",
+        "A running express",
+        "Reduced service system-wide",
+    ]
+
+
+def test_nyct_extension_track_is_read() -> None:
+    """The MTA ships track numbers as a proto extension (field 1001 on
+    StopTimeUpdate). Unknown fields are just fields to the walker, so this
+    needs no generated code — but it does need the right field numbers."""
+    # NyctStopTimeUpdate{scheduled_track="A1", actual_track="A2"}
+    nyct = _msg(1001, _str(1, "A1") + _str(2, "A2"))
+    stu = _str(4, "S1N") + _msg(2, _int(2, 1_800_000_000)) + nyct
+    feed = _msg(2, _msg(3, _msg(1, _str(1, "T1")) + _msg(2, stu)))
+
+    tracks: dict[str, str] = {}
+    times = gtfs_server._decode_trip_updates(feed, {"S1N"}, None, tracks)
+    assert times == {"T1|S1N": 1_800_000_000}
+    # Actual track wins over scheduled.
+    assert tracks == {"T1|S1N": "A2"}
+
+
+def test_track_lands_on_the_arrival() -> None:
+    now = datetime.now(UTC)
+    arrivals = [{"trip_id": "T1", "stop_id": "S1N", "minutes": 5, "live": False}]
+    gtfs_server._apply_realtime(
+        arrivals,
+        {"T1|S1N": int((now + timedelta(minutes=4)).timestamp())},
+        now,
+        None,
+        {"T1|S1N": "A2"},
+    )
+    assert arrivals[0]["track"] == "A2"
+
+
+def test_two_stops_merge_onto_one_board(client: FlaskClient) -> None:
+    """Both picks land on the same board, each row labelled with its stop."""
+    digest = hashlib.sha1(b"https://example.test/gtfs.zip").hexdigest()[:16]
+    opts = json.dumps(
+        {
+            "gtfs_url": "https://example.test/gtfs.zip",
+            "stop": f"{digest}:S1",
+            "stop_2": f"{digest}:S2",
+        }
+    )
+    with patch(_OPEN, return_value=_FakeResp(_feed(second_stop=True))):
+        body = client.get(f"/_test/render?plugin=gtfs&size=md&opts={quote(opts)}").get_data(
+            as_text=True
+        )
+    assert "Inwood-207 St" in body  # from S1
+    assert "Far Rockaway" in body  # from S2
+    # The row data carries which station each train leaves from.
+    assert "Canal St" in body
+    assert "Franklin St" in body
+
+
+def test_departure_basis_uses_the_later_time() -> None:
+    """At a terminus the train sits before running back, so departure is the
+    time you can actually board."""
+    now = datetime.now(UTC)
+    midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    arrive = int((now + timedelta(minutes=10) - midnight).total_seconds())
+    table = {
+        "tz": "UTC",
+        "stop_names": {"S1N": "Canal St"},
+        "routes": {"R1": {"short": "A", "type": 1}},
+        "trips": {"T1": ["R1", "Inwood-207 St", "0", "ALL", "S1N"]},
+        "services": {"ALL": {"days": [1] * 7, "start": "", "end": "", "add": [], "rem": []}},
+        "times": [["T1", arrive, 1, arrive + 300]],
+    }
+    by_arrival = gtfs_server._scheduled(table, now, 90, 0, "arrival")
+    by_departure = gtfs_server._scheduled(table, now, 90, 0, "departure")
+    assert by_arrival[0]["minutes"] == 9  # ~10 min out, floored
+    assert by_departure[0]["minutes"] == 14  # five minutes later
+
+
+def test_prune_drops_stale_feed_zips_and_keeps_fresh_ones(tmp_path: Path) -> None:
+    """Feed zips are 5 MB each and re-downloaded on demand; nothing should
+    keep one around forever."""
+    import os
+
+    old = tmp_path / "feed_abc.zip"
+    fresh = tmp_path / "feed_def.zip"
+    other = tmp_path / "rt_abc.json"
+    for path in (old, fresh, other):
+        path.write_bytes(b"x")
+    stale = time.time() - gtfs_server.TIMETABLE_TTL_S * 2 - 10
+    os.utime(old, (stale, stale))
+
+    gtfs_server._prune(tmp_path)
+    assert not old.exists()
+    assert fresh.exists()
+    # Small, short-TTL caches aren't the target and are left alone.
+    assert other.exists()
+
+
+def test_feed_stamp_is_read_from_the_header() -> None:
+    """A stalled feed still serves confident predictions; the header's own
+    timestamp is the only thing that says how old they are."""
+    feed = _msg(1, _int(3, 1_800_000_000)) + _msg(2, _trip_update("T1", "S1N", 1))
+    assert gtfs_server._feed_stamp(feed) == 1_800_000_000
+    # A feed without a header timestamp reports nothing rather than lying.
+    assert gtfs_server._feed_stamp(_msg(2, _trip_update("T1", "S1N", 1))) is None
+
+
+def test_vehicle_positions_give_stops_away() -> None:
+    # FeedEntity.vehicle=4, VehiclePosition{trip=1, current_stop_sequence=3}
+    feed = _msg(2, _msg(4, _msg(1, _str(1, "T1")) + _int(3, 7)))
+    assert gtfs_server._decode_vehicles(feed) == {"T1": 7}
+
+    now = datetime.now(UTC)
+    arrivals = [{"trip_id": "T1", "stop_id": "S1N", "minutes": 9, "seq": 10, "live": False}]
+    gtfs_server._apply_realtime(
+        arrivals,
+        {"T1|S1N": int((now + timedelta(minutes=9)).timestamp())},
+        now,
+        None,
+        None,
+        {"T1": 7},
+    )
+    assert arrivals[0]["stops_away"] == 3
+
+
+def test_stops_away_ignores_a_vehicle_already_past_us() -> None:
+    """A feed that has the train beyond our stop would otherwise produce a
+    negative countdown."""
+    now = datetime.now(UTC)
+    arrivals = [{"trip_id": "T1", "stop_id": "S1N", "minutes": 4, "seq": 5, "live": False}]
+    gtfs_server._apply_realtime(
+        arrivals,
+        {"T1|S1N": int((now + timedelta(minutes=4)).timestamp())},
+        now,
+        None,
+        None,
+        {"T1": 9},
+    )
+    assert "stops_away" not in arrivals[0]
+
+
+def test_routes_option_filters_the_board(client: FlaskClient) -> None:
+    opts = json.dumps({"gtfs_url": "https://example.test/gtfs.zip", "stop_id": "S1", "routes": "Q"})
+    with patch(_OPEN, return_value=_FakeResp(_feed())):
+        body = client.get(f"/_test/render?plugin=gtfs&size=md&opts={quote(opts)}").get_data(
+            as_text=True
+        )
+    # The fixture's only route is "A", so filtering to "Q" empties the board.
+    assert "Inwood-207 St" not in body
+
+    opts = json.dumps({"gtfs_url": "https://example.test/gtfs.zip", "stop_id": "S1", "routes": "a"})
+    with patch(_OPEN, return_value=_FakeResp(_feed())):
+        body = client.get(f"/_test/render?plugin=gtfs&size=md&opts={quote(opts)}").get_data(
+            as_text=True
+        )
+    # Case-insensitive, so "a" still matches route "A".
+    assert "Inwood-207 St" in body
+
+
+def test_alerts_rank_stop_specific_first() -> None:
+    """Only one alert fits in the title bar, so the one naming this stop has
+    to beat a route-wide notice that merely touches it."""
+    feed = (
+        _alert("Reduced service system-wide")
+        + _alert("JFK AirTrain suspended", route_id="R1")
+        + _alert("Signal problems at Canal St", stop_id="S1N")
+    )
+    assert gtfs_server._decode_alerts(feed, {"S1N"}, {"R1"})[0] == ("Signal problems at Canal St")
+
+
+def test_alert_text_is_flattened_and_stripped_of_icon_markers() -> None:
+    feed = _alert("[airplane icon] JFK AirTrain\nis  suspended", stop_id="S1N")
+    assert gtfs_server._decode_alerts(feed, {"S1N"}, set()) == ["JFK AirTrain is suspended"]
+
+
+def test_alerts_dedupe_identical_headers() -> None:
+    """Agencies publish one alert per affected route, same text on each."""
+    feed = _alert("Weekend service change", route_id="R1") + _alert(
+        "Weekend service change", stop_id="S1N"
+    )
+    assert gtfs_server._decode_alerts(feed, {"S1N"}, {"R1"}) == ["Weekend service change"]
+
+
+def test_failed_build_backs_off_instead_of_refetching(tmp_path: Path) -> None:
+    """A broken feed must not re-download on every render tick."""
+    err_path = tmp_path / "err_x.json"
+    gtfs_server._write_error(err_path, "That URL didn't return a GTFS zip.")
+    message, cooling = gtfs_server._read_error(err_path)
+    assert message == "That URL didn't return a GTFS zip."
+    assert cooling is True
+
+    # Aged past the cooldown, the next render is allowed to retry.
+    import os
+
+    old = time.time() - gtfs_server.BUILD_RETRY_S - 1
+    os.utime(err_path, (old, old))
+    _message, cooling = gtfs_server._read_error(err_path)
+    assert cooling is False
+
+
+def test_failed_build_leaves_a_stale_timetable_intact(tmp_path: Path) -> None:
+    """Errors go to their own file, so a feed that breaks doesn't wipe the
+    last-known-good table out from under the board."""
+    tt_path = tmp_path / "tt_x.json"
+    err_path = tmp_path / "err_x.json"
+    gtfs_server._write_json(tt_path, {"stop_name": "Canal St", "trips": {}})
+    with patch.object(gtfs_server, "_feed_bytes", side_effect=zipfile.BadZipFile):
+        gtfs_server._build("https://example.test/x.zip", "S1", tt_path, err_path)
+    assert json.loads(tt_path.read_text())["stop_name"] == "Canal St"
+    assert "GTFS zip" in gtfs_server._read_error(err_path)[0]
+
+
+def test_direction_filter_keeps_one_direction(client: FlaskClient) -> None:
+    opts = '{"gtfs_url":"https://example.test/gtfs.zip","stop_id":"S1","direction":"0"}'
+    with patch(_OPEN, return_value=_FakeResp(_feed())):
+        resp = client.get(f"/_test/render?plugin=gtfs&size=md&opts={opts}")
+    assert resp.status_code == 200
+    # Both fixture trips are direction 0, so both survive; direction 1 empties
+    # the board, which is the half that proves the filter is wired up.
+    assert "Inwood-207 St" in resp.get_data(as_text=True)
+
+    opts = '{"gtfs_url":"https://example.test/gtfs.zip","stop_id":"S1","direction":"1"}'
+    with patch(_OPEN, return_value=_FakeResp(_feed())):
+        resp = client.get(f"/_test/render?plugin=gtfs&size=md&opts={opts}")
+    assert "Inwood-207 St" not in resp.get_data(as_text=True)
+
+
+def test_preset_supplies_all_three_urls() -> None:
+    """A preset overrides the URL fields, so a half-filled cell can't end up
+    pairing one agency's timetable with another's realtime feed."""
+    gtfs, rt, alerts = gtfs_server._preset_urls("mta_ace", "https://stale.example/old.zip", "", "")
+    assert gtfs.endswith("gtfs_subway.zip")
+    assert rt.endswith("nyct%2Fgtfs-ace")
+    assert "subway-alerts" in alerts
+
+    # "custom" leaves the user's own URLs untouched.
+    assert gtfs_server._preset_urls("custom", "https://x.test/a.zip", "b", "c") == (
+        "https://x.test/a.zip",
+        "b",
+        "c",
+    )
+
+
+def test_every_preset_is_offered_in_the_manifest() -> None:
+    """The dropdown and the resolver must not drift apart."""
+    manifest = json.loads((_PLUGIN / "plugin.json").read_text())
+    option = next(o for o in manifest["cell_options"] if o["name"] == "preset")
+    offered = {c["value"] for c in option["choices"]}
+    assert offered == {"custom", *gtfs_server.PRESETS}
+
+
+def test_stop_index_labels_carry_the_calling_routes() -> None:
+    """A dropdown of eighteen identical "Canal St" rows would be no better
+    than the text box, so labels have to disambiguate."""
+    url = "https://example.test/gtfs.zip"
+    index = gtfs_server._stop_index(_feed(), url, "Test Transit")
+    # The platform (S1N) folds into its parent station (S1), one row.
+    assert len(index) == 1
+    assert index[0]["label"] == "Test Transit · Canal St (A) · S1"
+    assert index[0]["value"].endswith(":S1")
+
+
+def test_stop_choice_is_ignored_when_the_feed_changed() -> None:
+    """The value carries a feed digest so a stop picked against one feed
+    isn't silently looked up in another."""
+    url = "https://example.test/gtfs.zip"
+    value = gtfs_server._stop_index(_feed(), url)[0]["value"]
+    assert gtfs_server._stop_from_choice(value, url) == "S1"
+    assert gtfs_server._stop_from_choice(value, "https://other.test/gtfs.zip") == ""
+    # A stop value saved by the build that encoded direction still resolves.
+    assert gtfs_server._stop_from_choice(f"{value}:1", url) == "S1"
+
+
+def test_stop_dropdown_falls_back_to_the_text_field(client: FlaskClient) -> None:
+    """A pick from another feed must not shadow the Stop ID field."""
+    opts = (
+        '{"gtfs_url":"https://example.test/gtfs.zip","stop_id":"S1","stop":"deadbeefdeadbeef:S99"}'
+    )
+    with patch(_OPEN, return_value=_FakeResp(_feed())):
+        resp = client.get(f"/_test/render?plugin=gtfs&size=md&opts={opts}")
+    assert resp.status_code == 200
+    assert "Inwood-207 St" in resp.get_data(as_text=True)
+
+
+def test_rendering_a_preset_warms_the_stop_index(tmp_path: Path) -> None:
+    """The editor shouldn't be what discovers the index is cold, so a render
+    on a preset feed kicks the build off the zip it downloads anyway."""
+    preset_url = gtfs_server.PRESETS["bart"]["gtfs_url"]
+    with patch.object(gtfs_server, "_start_build") as started:
+        gtfs_server._warm_stop_index(preset_url, tmp_path)
+    assert started.called
+
+    # A custom feed isn't in the dropdown, so there's nothing to warm.
+    with patch.object(gtfs_server, "_start_build") as started:
+        gtfs_server._warm_stop_index("https://custom.test/gtfs.zip", tmp_path)
+    assert not started.called
+
+
+def test_choices_only_answers_stops(client: FlaskClient) -> None:
+    with client.application.app_context():
+        assert gtfs_server.choices("boards") == []
+        # Cold cache: a sentinel, never an inline download.
+        with patch.object(gtfs_server, "_start_build") as started:
+            out = gtfs_server.choices("stops")
+        assert started.called
+        assert any("loading" in c["label"] for c in out)
+
+
+def test_preset_renders_without_any_url_fields(client: FlaskClient) -> None:
+    opts = '{"preset":"mta_ace","stop_id":"S1"}'
+    with patch(_OPEN, return_value=_FakeResp(_feed())):
+        resp = client.get(f"/_test/render?plugin=gtfs&size=md&opts={opts}")
+    assert resp.status_code == 200
+    assert "Inwood-207 St" in resp.get_data(as_text=True)
+
+
+# ----------------------------------------------------------------------
+# URL safety
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("url", ["file:///etc/passwd", "ftp://example.test/f.zip", "/etc/passwd"])
+def test_download_refuses_non_http_schemes(url: str) -> None:
+    """Every URL here is user-supplied; urllib's default opener would happily
+    read file:// off the Tesserae host and parse it."""
+    with pytest.raises(ValueError, match="unsupported URL scheme"):
+        gtfs_server._download(url, 1)
+
+
+def test_file_url_in_the_admin_page_is_an_error_not_a_read(client: FlaskClient) -> None:
+    resp = client.get("/plugins/gtfs/?feed_url=file:///etc/passwd")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "root:" not in body
+    assert "Couldn&#39;t read the feed" in body
+
+
+def test_widget_preview_resolves_dynamic_choices(client: FlaskClient) -> None:
+    """``/_test/preview`` read the raw manifest, so every ``choices_from``
+    dropdown rendered empty there — for any widget, not just this one."""
+    app = client.application
+    plugin_dir = app.config["PLUGIN_REGISTRY"].get("gtfs").data_dir
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    index = gtfs_server._stop_index(_feed(), "https://example.test/gtfs.zip", "Test Transit")
+    for url in {spec["gtfs_url"] for spec in gtfs_server.PRESETS.values()}:
+        digest = hashlib.sha1(url.encode()).hexdigest()[:16]
+        (plugin_dir / f"stops3_{digest}.json").write_text(json.dumps({"stops": index}))
+
+    opts = json.dumps({"preset": "mta_ace", "stop": "", "stop_id": ""})
+    html = client.get(f"/_test/preview?widget=gtfs&opts={quote(opts)}").get_data(as_text=True)
+    select = re.search(r'<select id="opt-stop".*?</select>', html, re.S)
+    assert select is not None
+    assert "Test Transit · Canal St" in select.group(0)
+    # The preset's URLs show up filled and locked here too.
+    tag = re.search(r'<input id="opt-rt_url".*?>', html, re.S)
+    assert tag is not None
+    assert "readonly" in tag.group(0)
+    assert "gtfs-ace" in tag.group(0)
+
+
+def test_cell_editor_shows_stops_and_locks_preset_urls(client: FlaskClient) -> None:
+    """End-to-end through the real editor template: the Stop dropdown carries
+    the index, and a chosen preset fills + locks the three URL fields."""
+    from app.panel import Panel
+    from app.state.page_store import Cell, Page
+
+    app = client.application
+    # Seed each preset feed's stop index in the plugin's data dir. Patching
+    # the module object this test imported wouldn't work — the app loads its
+    # own copy — and without a seed the editor would build the index for
+    # real, i.e. hit the network from a unit test.
+    plugin_dir = app.config["PLUGIN_REGISTRY"].get("gtfs").data_dir
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    index = gtfs_server._stop_index(_feed(), "https://example.test/gtfs.zip", "Test Transit")
+    for url in {spec["gtfs_url"] for spec in gtfs_server.PRESETS.values()}:
+        digest = hashlib.sha1(url.encode()).hexdigest()[:16]
+        (plugin_dir / f"stops3_{digest}.json").write_text(json.dumps({"stops": index}))
+
+    app.config["PAGE_STORE"].save(
+        Page(
+            id="gtfs-editor-test",
+            name="t",
+            panel=Panel(w=800, h=480),
+            cells=[
+                Cell(
+                    id="c1",
+                    plugin="gtfs",
+                    x=0,
+                    y=0,
+                    w=800,
+                    h=480,
+                    options={"preset": "mta_ace", "stop": index[0]["value"]},
+                )
+            ],
+        )
+    )
+    html = client.get("/pages/gtfs-editor-test").get_data(as_text=True)
+
+    select = re.search(r'<select[^>]*name="opt_stop".*?</select>', html, re.S)
+    assert select is not None
+    assert "Test Transit · Canal St" in select.group(0)
+
+    for field, expected in (
+        ("opt_gtfs_url", "rrgtfsfeeds"),
+        ("opt_rt_url", "gtfs-ace"),
+        ("opt_alerts_url", "subway-alerts"),
+    ):
+        tag = re.search(rf'<input[^>]*name="{field}"[^>]*>', html, re.S)
+        assert tag is not None, field
+        assert "readonly" in tag.group(0), field
+        assert expected in tag.group(0), field
+
+
+# ----------------------------------------------------------------------
+# Admin page
+# ----------------------------------------------------------------------
+
+
+def test_stop_finder_searches_the_feed(client: FlaskClient) -> None:
+    with patch(_OPEN, return_value=_FakeResp(_feed())):
+        resp = client.get("/plugins/gtfs/?feed_url=https://example.test/gtfs.zip&q=canal")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "S1N" in body
+    assert "Canal St North" in body
+
+
+def test_stop_finder_inspect_names_each_direction(client: FlaskClient) -> None:
+    with patch(_OPEN, return_value=_FakeResp(_feed())):
+        resp = client.get("/plugins/gtfs/?feed_url=https://example.test/gtfs.zip&inspect=S1")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    # The whole point of inspect: which headsigns sit behind direction_id 0.
+    assert "Inwood-207 St" in body
+    assert "Eighth Avenue Express" in body or "A" in body
+
+
+def test_admin_page_is_not_an_open_url_fetcher(client: FlaskClient) -> None:
+    """The finder turns a query arg into an outbound request, so an
+    unauthenticated caller is held to the preset feeds."""
+    # The suite runs with TESTING on, where the host installs no auth gate at
+    # all; flip it off so this exercises a real deployment's path.
+    client.application.config["TESTING"] = False
+    try:
+        with patch(_OPEN, return_value=_FakeResp(_feed())) as opened:
+            resp = client.get("/plugins/gtfs/?feed_url=https://attacker.test/x.zip")
+        assert resp.status_code == 200
+        assert "Sign in to search a feed" in resp.get_data(as_text=True)
+        assert not opened.called  # no request was made at all
+
+        # A preset feed is a fixed, known host, so it stays usable.
+        with patch(_OPEN, return_value=_FakeResp(_feed())) as opened:
+            client.get(
+                "/plugins/gtfs/?feed_url=" + quote(gtfs_server.PRESETS["bart"]["gtfs_url"], safe="")
+            )
+        assert opened.called
+    finally:
+        client.application.config["TESTING"] = True
+
+
+def test_stop_finder_reports_a_bad_feed(client: FlaskClient) -> None:
+    with patch(_OPEN, return_value=_FakeResp(b"not a zip")):
+        resp = client.get("/plugins/gtfs/?feed_url=https://example.test/nope.zip")
+    assert resp.status_code == 200
+    assert "didn&#39;t return a GTFS zip" in resp.get_data(as_text=True)

--- a/schema/plugin.schema.json
+++ b/schema/plugin.schema.json
@@ -4,7 +4,13 @@
   "title": "Tesserae plugin manifest",
   "description": "Shape of plugin.json. See docs/contracts/plugins.md for the prose contract.",
   "type": "object",
-  "required": ["tesserae_compat", "name", "version", "kind", "supports"],
+  "required": [
+    "tesserae_compat",
+    "name",
+    "version",
+    "kind",
+    "supports"
+  ],
   "properties": {
     "tesserae_compat": {
       "type": "string",
@@ -20,7 +26,13 @@
       "pattern": "^\\d+\\.\\d+\\.\\d+(?:[-+].*)?$"
     },
     "kind": {
-      "enum": ["widget", "font", "admin", "data", "service"]
+      "enum": [
+        "widget",
+        "font",
+        "admin",
+        "data",
+        "service"
+      ]
     },
     "description": {
       "type": "string"
@@ -32,16 +44,27 @@
     },
     "supports": {
       "type": "object",
-      "required": ["sizes"],
+      "required": [
+        "sizes"
+      ],
       "properties": {
         "sizes": {
           "type": "array",
-          "items": { "enum": ["xs", "sm", "md", "lg"] },
+          "items": {
+            "enum": [
+              "xs",
+              "sm",
+              "md",
+              "lg"
+            ]
+          },
           "uniqueItems": true
         },
         "panels": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -50,17 +73,33 @@
       "description": "Named, independently-placeable pieces of the widget for the Panels canvas editor. render() paints just one when it receives ctx.fragment; a widget with no fragments (or ctx.fragment absent) renders the whole widget. Declaring fragments lets a user drop, say, just the temperature or the sun-times of a weather widget onto the canvas. See docs/dev/writing-a-widget.md.",
       "items": {
         "type": "object",
-        "required": ["id", "label"],
+        "required": [
+          "id",
+          "label"
+        ],
         "properties": {
           "id": {
             "type": "string",
             "pattern": "^[a-z][a-z0-9_]*$",
             "description": "Fragment id passed to render() as ctx.fragment. 'full' is reserved for the whole widget."
           },
-          "label": { "type": "string" },
-          "icon": { "type": "string", "pattern": "^ph-[a-z0-9-]+$" },
-          "w": { "type": "integer", "minimum": 1, "description": "Default placement width in px." },
-          "h": { "type": "integer", "minimum": 1, "description": "Default placement height in px." }
+          "label": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string",
+            "pattern": "^ph-[a-z0-9-]+$"
+          },
+          "w": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Default placement width in px."
+          },
+          "h": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Default placement height in px."
+          }
         }
       }
     },
@@ -68,25 +107,77 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["name", "type", "label"],
+        "required": [
+          "name",
+          "type",
+          "label"
+        ],
         "properties": {
-          "name": { "type": "string" },
-          "type": { "enum": ["string", "textarea", "variables_textarea", "entity_overrides", "location_search", "number", "slider", "select", "multiselect", "boolean", "color"] },
-          "label": { "type": "string" },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "string",
+              "textarea",
+              "variables_textarea",
+              "entity_overrides",
+              "location_search",
+              "number",
+              "slider",
+              "select",
+              "multiselect",
+              "boolean",
+              "color"
+            ]
+          },
+          "label": {
+            "type": "string"
+          },
           "default": {},
-          "secret": { "type": "boolean" },
+          "secret": {
+            "type": "boolean"
+          },
           "choices": {
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["value", "label"],
+              "required": [
+                "value",
+                "label"
+              ],
               "properties": {
                 "value": {},
-                "label": { "type": "string" }
+                "label": {
+                  "type": "string"
+                }
               }
             }
           },
-          "choices_from": { "type": "string" }
+          "choices_from": {
+            "type": "string"
+          },
+          "fill_from": {
+            "type": "object",
+            "description": "Another option owns this field's value; the editor fills it and locks it. See docs/widgets.md.",
+            "required": [
+              "option",
+              "map"
+            ],
+            "properties": {
+              "option": {
+                "type": "string",
+                "description": "Name of the controlling cell option."
+              },
+              "map": {
+                "type": "object",
+                "description": "Controlling value -> value for this field."
+              }
+            }
+          },
+          "help": {
+            "type": "string"
+          }
         }
       }
     },
@@ -94,11 +185,21 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["name", "type", "label"],
+        "required": [
+          "name",
+          "type",
+          "label"
+        ],
         "properties": {
-          "name": { "type": "string" },
-          "type": { "type": "string" },
-          "label": { "type": "string" },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
           "secret": {
             "type": "boolean",
             "description": "When true, this field is saved to settings.json as '<name>_secret' so disk-grepping reveals which values are sensitive."
@@ -110,7 +211,9 @@
     "data_schema": {
       "type": "object",
       "description": "Declares the widget's fetch() data shape so the Panels canvas editor can offer its fields as bindable data sources. Optional: a widget without this block still renders normally but has no bindable fields in the composer. See docs/dev/writing-a-widget.md.",
-      "required": ["fields"],
+      "required": [
+        "fields"
+      ],
       "properties": {
         "color": {
           "type": "string",
@@ -121,15 +224,31 @@
           "description": "The bindable fields, one per top-level fetch() result key worth exposing.",
           "items": {
             "type": "object",
-            "required": ["name", "type"],
+            "required": [
+              "name",
+              "type"
+            ],
             "properties": {
-              "name": { "type": "string", "description": "The fetch() result key." },
+              "name": {
+                "type": "string",
+                "description": "The fetch() result key."
+              },
               "type": {
-                "enum": ["num", "str", "arr"],
+                "enum": [
+                  "num",
+                  "str",
+                  "arr"
+                ],
                 "description": "num (number), str (text/state), or arr (list, e.g. a series or item list)."
               },
-              "label": { "type": "string", "description": "Human-friendly field name shown in the bind list." },
-              "unit": { "type": "string", "description": "Optional unit hint (e.g. 'deg', '%', 's')." }
+              "label": {
+                "type": "string",
+                "description": "Human-friendly field name shown in the bind list."
+              },
+              "unit": {
+                "type": "string",
+                "description": "Optional unit hint (e.g. 'deg', '%', 's')."
+              }
             }
           }
         },
@@ -142,15 +261,27 @@
     "render": {
       "type": "object",
       "properties": {
-        "dither": { "enum": ["none", "floyd-steinberg", "ordered"] },
-        "full_bleed": { "type": "boolean" },
-        "needs_network": { "type": "boolean" }
+        "dither": {
+          "enum": [
+            "none",
+            "floyd-steinberg",
+            "ordered"
+          ]
+        },
+        "full_bleed": {
+          "type": "boolean"
+        },
+        "needs_network": {
+          "type": "boolean"
+        }
       }
     },
     "updates": {
       "type": "object",
       "description": "Declares data-change events this widget can subscribe to. The declaration only makes the per-placement opt-in available; it never refreshes a dashboard by itself.",
-      "required": ["on_change"],
+      "required": [
+        "on_change"
+      ],
       "additionalProperties": false,
       "properties": {
         "on_change": {
@@ -160,7 +291,9 @@
           "uniqueItems": true,
           "items": {
             "type": "object",
-            "required": ["source"],
+            "required": [
+              "source"
+            ],
             "additionalProperties": false,
             "properties": {
               "source": {
@@ -184,7 +317,10 @@
       "description": "Design-system intent. Default for every field is the strict, palette-safe behaviour; opt-in values signal a widget is using a richer surface and accepts the downstream trade-offs.",
       "properties": {
         "palette": {
-          "enum": ["strict", "extended"],
+          "enum": [
+            "strict",
+            "extended"
+          ],
           "default": "strict",
           "description": "`strict` (default): the widget only uses Spectra colour tokens (`--w-orange`, `--w-blue`, etc.), so the rendered output lands cleanly on every supported panel without dithering. `extended`: the widget uses arbitrary CSS colours and relies on the renderer's Floyd-Steinberg pass to approximate them on the panel palette. Good for scenic/decorative widgets (gradients, soft scenery); read worse on BW panels than strict widgets. Catalog reviewers should see this flag and treat extended widgets as taking on the dither-tradeoff responsibility."
         }
@@ -203,19 +339,44 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["id", "name", "weights", "files"],
+        "required": [
+          "id",
+          "name",
+          "weights",
+          "files"
+        ],
         "properties": {
-          "id": { "type": "string", "pattern": "^[a-z][a-z0-9_-]*$" },
-          "name": { "type": "string", "minLength": 1 },
-          "category": { "enum": ["sans", "serif", "mono", "display", "handwriting"] },
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_-]*$"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "category": {
+            "enum": [
+              "sans",
+              "serif",
+              "mono",
+              "display",
+              "handwriting"
+            ]
+          },
           "weights": {
             "type": "array",
-            "items": { "type": "integer", "minimum": 100, "maximum": 900 },
+            "items": {
+              "type": "integer",
+              "minimum": 100,
+              "maximum": 900
+            },
             "minItems": 1
           },
           "files": {
             "type": "object",
-            "additionalProperties": { "type": "string" }
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         }
       }
@@ -224,13 +385,39 @@
   "allOf": [
     {
       "description": "Placeable widgets must declare at least one size; non-placeable kinds (service, data, font, admin) may leave supports.sizes empty.",
-      "if": { "properties": { "kind": { "const": "widget" } } },
-      "then": { "properties": { "supports": { "properties": { "sizes": { "minItems": 1 } } } } }
+      "if": {
+        "properties": {
+          "kind": {
+            "const": "widget"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "supports": {
+            "properties": {
+              "sizes": {
+                "minItems": 1
+              }
+            }
+          }
+        }
+      }
     },
     {
       "description": "Only placeable widgets may declare data-change update capabilities.",
-      "if": { "required": ["updates"] },
-      "then": { "properties": { "kind": { "const": "widget" } } }
+      "if": {
+        "required": [
+          "updates"
+        ]
+      },
+      "then": {
+        "properties": {
+          "kind": {
+            "const": "widget"
+          }
+        }
+      }
     }
   ]
 }

--- a/templates/_components.html
+++ b/templates/_components.html
@@ -50,7 +50,7 @@ macro here instead.
     would close the outer form early. Explicit ``form`` attribute
     keeps every input in the right form regardless of DOM nesting. -#}
 
-{%- macro text_input(field_id, name, label, value='', placeholder='', required=False, help=None, autofocus=False, autocomplete=None, type='text', form=None) -%}
+{%- macro text_input(field_id, name, label, value='', placeholder='', required=False, help=None, autofocus=False, autocomplete=None, type='text', form=None, readonly=False) -%}
 <div class="field">
   <label for="{{ field_id }}">{{ label }}{{ info_pop(help) }}</label>
   <input type="{{ type }}" id="{{ field_id }}" name="{{ name }}"
@@ -59,6 +59,7 @@ macro here instead.
          {% if placeholder %}placeholder="{{ placeholder }}"{% endif %}
          {% if autocomplete %}autocomplete="{{ autocomplete }}"{% endif %}
          {% if required %}required{% endif %}
+         {% if readonly %}readonly{% endif %}
          {% if autofocus %}autofocus{% endif %}>
 </div>
 {%- endmacro -%}
@@ -514,7 +515,11 @@ macro here instead.
 </div>
 {%- endmacro -%}
 
-{%- macro auto_field(field_id, name, spec, value, help=None, form=None) -%}
+{#- ``readonly``: render the control uneditable but still submitted. Used
+   when another option owns this field's value (e.g. a feed preset that
+   supplies the URLs below it), so the value stays visible and stays in the
+   POST instead of silently reverting. -#}
+{%- macro auto_field(field_id, name, spec, value, help=None, form=None, readonly=False) -%}
   {% set ftype = spec.get('type', 'string') %}
   {% set label = spec.get('label', name) %}
   {% set help_text = help if help is not none else spec.get('help') %}
@@ -569,7 +574,7 @@ macro here instead.
                   placeholder=spec.get('placeholder', ''),
                   type='password' if spec.get('secret') else 'text',
                   autocomplete='new-password' if spec.get('secret') else None,
-                  help=help_text, form=form) }}
+                  help=help_text, form=form, readonly=readonly) }}
   {% endif %}
 {%- endmacro -%}
 

--- a/templates/page_editor.html
+++ b/templates/page_editor.html
@@ -191,10 +191,16 @@
     {% if cell_opts %}
     <fieldset class="form-group">
       <legend>{{ plugin.name }} options</legend>
+      {#- ``fill_from`` lets one option own another's value: the owning
+         option's current value is looked up in the map, and a hit fills the
+         dependent field and locks it (still submitted, just not editable).
+         Widgets use it for "pick a preset and the URLs follow". -#}
       {% for opt in cell_opts %}
         {% set field_id = 'cell-' ~ cell.id ~ '-opt-' ~ opt.name %}
-        {% set value = cell.options.get(opt.name, opt.get('default', '')) %}
-        {{ auto_field(field_id, 'opt_' ~ opt.name, opt, value) }}
+        {% set fill = opt.get('fill_from') %}
+        {% set filled = fill.get('map', {}).get(cell.options.get(fill.get('option'))) if fill else none %}
+        {% set value = filled if filled is not none else cell.options.get(opt.name, opt.get('default', '')) %}
+        {{ auto_field(field_id, 'opt_' ~ opt.name, opt, value, readonly=filled is not none) }}
       {% endfor %}
     </fieldset>
     {% endif %}

--- a/templates/widget_preview.html
+++ b/templates/widget_preview.html
@@ -357,12 +357,18 @@
             <input id="opt-{{ name }}" type="number" step="any" data-opt-input value="{{ val if val is not none else '' }}">
           </div>
         {% else %}
+          {#- ``fill_from``: another option owns this field's value (a feed
+             preset supplying URLs, say). Same resolution the page editor
+             does, so the preview shows what a real cell would use. -#}
+          {% set fill = spec.fill_from %}
+          {% set filled = fill.get('map', {}).get(form_values.get(fill.get('option'))) if fill else none %}
           <div class="field" data-opt-field data-opt-name="{{ name }}" data-opt-type="string">
             <label for="opt-{{ name }}">{{ label }}</label>
             <input id="opt-{{ name }}"
                    type="{% if spec.secret %}password{% else %}text{% endif %}"
                    data-opt-input
-                   value="{{ val if val is not none else '' }}">
+                   {% if filled is not none %}readonly{% endif %}
+                   value="{{ filled if filled is not none else (val if val is not none else '') }}">
             {% if spec.secret %}<span class="hint">Stored as plain text in the URL while previewing, paste a throwaway key.</span>{% endif %}
           </div>
         {% endif %}


### PR DESCRIPTION
## What this changes

Adds a `gtfs` widget: a departure board for any GTFS feed, with live times,
delays, cancellations, service alerts and track numbers from GTFS-RT. Two
supporting host changes come with it — a new `fill_from` cell-option
relationship, and a fix for `choices_from` dropdowns rendering empty in the
widget preview.

## Why

Wanted a lobby display showing every upcoming train at the local station.
Nothing in the bundled set reads GTFS, and the format is what practically
every transit agency publishes.

Three constraints shaped the implementation:

- **Static GTFS is too big to read inline.** A big agency's `stop_times.txt`
  runs to hundreds of MB, far past the composer's per-widget hydration
  budget. The first render kicks a background build; every render after
  reads a distilled per-stop timetable of a few KB, cached 12 hours and
  refreshed stale-while-revalidate. A failed build parks in its own file for
  10 minutes so a broken feed isn't re-downloaded on every refresh tick, and
  never clobbers a stale-but-usable table.
- **Realtime is protobuf, and the useful fields are vendor extensions.**
  Decoded directly against named field numbers rather than adding a core
  `protobuf` dependency for every install. An extension is just a field
  number the base spec doesn't claim, so the NYCT track labels
  (`gtfs-realtime-NYCT.proto`, field 1001) cost ten lines; the generated
  bindings don't ship that proto at all. Whole protobuf layer is ~170 lines
  including alerts and vehicle positions.
- **The board has to report its own uncertainty.** A stalled feed still
  serves confident-looking predictions, so the feed's header timestamp
  drives a "4 min old" note and drops the live badge past five minutes. The
  title also carries the render time: countdowns freeze at render, and an
  e-ink frame can sit for minutes.

Agencies split realtime by line group (the MTA publishes one feed per
group), so a second preset can contribute just its realtime feed, and a
board covering two stops on different groups is live on both halves.

Closes #

## Test plan

- [x] `pytest -q` — 3084 passing; 50 in `plugins/gtfs/`
- [x] `ruff check . && ruff format --check .`
- [x] `mypy app`
- [x] Manually verified against live feeds: MTA subway zip +
      `nyct/gtfs-ace` + `nyct/gtfs` + `camsys/subway-alerts`, and BART
      (`google_transit.zip`, `gtfsrt/tripupdate.aspx`, `gtfsrt/alerts.aspx`).
      Checked live times, delays in both directions, cancellations, alert
      ranking, track labels, two-stop merge (Canal St A/C/E + Franklin St 1),
      and the split-by-direction board.
- [x] Rendered through `app.quantizer` at Spectra 6 / Floyd–Steinberg rather
      than trusting the browser preview. Speckle metric 0.29 vs
      `weather_forecast`'s 0.36; route badges and headsigns stay legible at
      md and lg. Worth noting `render.dither` in a manifest is inert —
      `app/dither_regions.py` makes flat a per-cell opt-in — so the frame
      dithers regardless.
- [x] Stop finder at `/plugins/gtfs/` against the real MTA feed: search,
      inspect, and the "which direction is 0" answer.

Not covered by automated tests: everything above that needs a live feed, and
the panel render (no hardware in the loop — quantiser output was inspected,
not a physical panel).

## Checklist

- [x] Tests added for new behaviour
- [x] `ruff` + `mypy` clean
- [x] User-facing changes documented (`docs/widgets.md`, plus per-option help
      text in the manifest)
- [x] CHANGELOG entry added under `## [Unreleased]`
- [ ] `pyproject.toml` version bumped if this is going to be tagged — left
      alone; say the word if you want it in this PR

## Notes for review

- **`fill_from` is new host surface.** A cell option can name another option
  that owns its value; the editor fills the field and marks it read-only
  (read-only rather than disabled, so the value is still submitted and
  survives a save). Documented in `docs/widgets.md` and added to
  `schema/plugin.schema.json`. Happy to split it out if you'd rather it
  landed on its own.
- **`network:*` capability.** The feed URL is user-supplied, same case as the
  picture widgets, so no narrower declaration is possible. `_download`
  rejects any scheme but http/https and uses an opener with no
  `file://`/`ftp://` handlers, since `HTTPRedirectHandler` would otherwise
  permit an http→ftp redirect. Private/link-local destinations are *not*
  blocked: self-hosted feeds on a LAN are a first-class case here, the same
  premise `calendar_core` works on.
- **The stop finder fetches a URL from a query arg**, so an untrusted caller
  is held to the preset feeds; arbitrary URLs need a session (or an install
  that has deliberately turned the password off).
- **`plugins/gtfs/fixtures/`** back a `demo:<name>` feed URL — set the feed
  to `demo:delayed` and the board paints a canned scenario with no network,
  which is how the delay/cancellation states were designed and reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UhJm9DoKgUA8B1FYwE2NFW
