### PR TITLE
Optimize Docker layers for app-only upgrades

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -115,6 +115,9 @@ jobs:
           # + v* tag push firing together on a release) don't race on layer
           # blob writes. Without a scope, both runs write to the same cache
           # namespace and one gets "not_found" on layer blobs the other
-          # just cleaned up. Cache reuse within a ref stays intact.
-          cache-from: type=gha,scope=${{ github.ref_name }}
+          # just cleaned up. Tags also read main's cache so stable releases can
+          # reuse dependency layers from the edge build when GHA retains them.
+          cache-from: |
+            type=gha,scope=${{ github.ref_name }}
+            type=gha,scope=main
           cache-to: type=gha,mode=max,scope=${{ github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are
 [SemVer](https://semver.org/) (pre-1.0, so minors can carry breaking changes).
 
+## [0.311.1], 2026-08-17
+
+### Changed
+
+- **App-only Docker upgrades download much smaller changed layers.** System
+  packages and Python runtime dependencies are installed before the frequently
+  changing Tesserae source, and tagged builds can fall back to the `main` build
+  cache, so unchanged large layers can be reused when the cache is available.
+
 ## [0.311.0], 2026-08-17
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,16 @@
 # for 1.60) is what the matching Python wheel goes looking for at
 # launch. A mismatch boots the container fine but errors at first
 # render with "Executable doesn't exist at /ms-playwright/...".
+
+# Generate the Docker dependency manifest from the project's source of truth.
+# Run this tiny stage on the build platform so multi-architecture builds do not
+# invoke Python under QEMU. BuildKit keys the following cross-stage COPY by the
+# generated file content, so a version-only pyproject change still reuses the
+# expensive dependency layer.
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/playwright/python:v1.60.0-noble AS dependency-manifest
+COPY pyproject.toml /tmp/pyproject.toml
+RUN python -c "import pathlib, tomllib; project = tomllib.loads(pathlib.Path('/tmp/pyproject.toml').read_text()); pathlib.Path('/tmp/requirements.txt').write_text('\n'.join(project['project']['dependencies']) + '\n')"
+
 FROM mcr.microsoft.com/playwright/python:v1.60.0-noble
 
 # Where Playwright looks for installed browsers. The base image puts
@@ -41,10 +51,35 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 
 WORKDIR /app
 
-# Copy the whole source tree, Tesserae's loaders resolve plugins/,
-# renderers/, devices/, hardware/, templates/, and static/ from
-# REPO_ROOT, so the install needs to leave the source tree in place
-# rather than just copying app/ into site-packages.
+# ``gosu`` is what the entrypoint uses to drop privileges after fixing
+# the bind-mount ownership. It's a single ~2 MB static binary; the
+# obvious alternative ``su-exec`` only ships on Alpine. The base
+# image's ``setpriv`` works too but lacks gosu's standard semantics.
+#
+# ``fonts-noto-color-emoji`` is the de-facto Linux colour-emoji font.
+# Widgets that paint country flags (f1_next, sky_*) and any other
+# Unicode emoji need this to render properly inside the headless
+# Chromium that drives the composer, without it, flag emojis fall
+# back to regional-indicator letter pairs in boxes. ~12 MB on top
+# of the existing image, paid once for every emoji widget.
+#
+# Keep this stable system layer ahead of dependency and source copies:
+# an app-only release should not make operators pull it again.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gosu fonts-noto-color-emoji \
+    && rm -rf /var/lib/apt/lists/* \
+    && gosu nobody true
+
+# Install runtime dependencies before copying pyproject.toml or source. The
+# generated manifest keeps this expensive layer reusable when only the app or
+# its version changes.
+COPY --from=dependency-manifest /tmp/requirements.txt /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
+
+# Copy the whole source tree after the stable layers. Tesserae's loaders
+# resolve plugins/, renderers/, devices/, hardware/, templates/, and
+# static/ from REPO_ROOT, so the install needs to leave the source tree
+# in place rather than just copying app/ into site-packages.
 COPY pyproject.toml /app/
 COPY app/        /app/app/
 COPY plugins/    /app/plugins/
@@ -66,23 +101,7 @@ COPY static/     /app/static/
 # REPO_ROOT (resolved from app_factory.__file__) would point at
 # site-packages where none of those folders live. Editable keeps
 # REPO_ROOT = /app so the loaders find their content.
-RUN pip install -e /app
-
-# ``gosu`` is what the entrypoint uses to drop privileges after fixing
-# the bind-mount ownership. It's a single ~2 MB static binary; the
-# obvious alternative ``su-exec`` only ships on Alpine. The base
-# image's ``setpriv`` works too but lacks gosu's standard semantics.
-#
-# ``fonts-noto-color-emoji`` is the de-facto Linux colour-emoji font.
-# Widgets that paint country flags (f1_next, sky_*) and any other
-# Unicode emoji need this to render properly inside the headless
-# Chromium that drives the composer, without it, flag emojis fall
-# back to regional-indicator letter pairs in boxes. ~12 MB on top
-# of the existing image, paid once for every emoji widget.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends gosu fonts-noto-color-emoji \
-    && rm -rf /var/lib/apt/lists/* \
-    && gosu nobody true
+RUN pip install -e /app --no-deps
 
 # Persistent state, settings.json, pages, schedules, events DB, render
 # cache, gallery photos, backups. Tesserae's default data_root is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.311.0"
+version = "0.311.1"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/uv.lock
+++ b/uv.lock
@@ -1934,7 +1934,7 @@ wheels = [
 
 [[package]]
 name = "tesserae"
-version = "0.311.0"
+version = "0.311.1"
 source = { editable = "." }
 dependencies = [
     { name = "amqtt" },


### PR DESCRIPTION
## Summary

- install stable OS packages and Python runtime dependencies before copying frequently changing Tesserae source
- generate the Docker dependency manifest directly from `project.dependencies` on the native build platform
- let tag builds fall back to the `main` GitHub Actions cache while preserving per-ref cache writes
- keep the final editable install lightweight with `--no-deps`
- align the project/lockfile version and changelog with the repository's release convention

## Why

The current Dockerfile copies the source tree before `pip install -e /app`. A one-file app change therefore invalidates the approximately 329 MB dependency installation layer and every later layer, even when dependencies are unchanged.

Keeping system packages and runtime dependencies ahead of `pyproject.toml` and the source copies lets registries and Docker hosts reuse those blobs across ordinary app releases. The native-platform extractor avoids a second checked-in dependency list, while its generated output lets BuildKit reuse the dependency layer when only the project version changes. Tag builds also read the `main` cache so stable releases can reuse the layer produced by edge builds when GitHub still retains it.

## Impact

An isolated source-only rebuild on the current Playwright base kept the full image at approximately 2.71 GB, but reduced the uncompressed changed-layer set from approximately 359 MB to 25.8 MB (about 93%). The large dependency layer remains part of the image, but is reused rather than rebuilt and transferred for app-only changes.

## Validation

- `docker buildx build --check --progress=plain -f Dockerfile .` (no warnings)
- parsed all 17 runtime dependencies from `project.dependencies` with the extractor logic
- completed an amd64 image build from an isolated v0.309.1 source context using the reordered layers, then started an isolated container: `/healthz` returned `ok`, the root route returned the expected setup redirect, UID 1001 could write data, and Waitress started normally
- rebuilt after adding one temporary Python source file; the Playwright base, system package layer, and 329 MB dependency installation layer all hit cache
- compared image history and root filesystem layers to measure the changed-layer reduction
- `git diff --check`

The updated native-platform extractor and multi-architecture image build are also covered by this PR's Docker CI. The temporary local images and container were removed after validation. No running Tesserae deployment was replaced or restarted.
