### PR TITLE
Fix prioritised multi-select reordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are
 [SemVer](https://semver.org/) (pre-1.0, so minors can carry breaking changes).
 
+## [Unreleased]
+
+### Fixed
+
+- **Prioritised multi-select lists can actually be reordered.** Checked rows
+  now expose a drag handle that works with a mouse, touch, or pen, plus arrow,
+  Home, and End keys for precise accessible movement. The new DOM order is
+  submitted immediately, so priority-based widgets such as Album Art evaluate
+  Home Assistant entities in the order shown by the editor.
+
 ## [0.313.0], 2026-08-17
 
 ### Added

--- a/static/components.js
+++ b/static/components.js
@@ -193,8 +193,88 @@
       ms.dataset.msBound = "1";
       const filter = ms.querySelector("[data-ms-filter]");
       const opts = Array.from(ms.querySelectorAll(".multiselect-opt"));
+      const list = ms.querySelector("[data-ms-list]");
       const emptyEl = ms.querySelector("[data-ms-empty]");
       const countEl = ms.querySelector("[data-ms-count]");
+      const orderStatus = ms.querySelector("[data-ms-order-status]");
+      let dragged = null;
+      let dragStartOrder = [];
+      let pointerDrag = null;
+
+      const inputFor = (row) => row && row.querySelector('input[type="checkbox"]');
+      const rows = () => list ? Array.from(list.querySelectorAll(".multiselect-opt")) : [];
+      const selectedRows = () => rows().filter((row) => inputFor(row)?.checked);
+      const selectedValues = () => selectedRows().map((row) => inputFor(row).value);
+      const sameOrder = (a, b) => a.length === b.length && a.every((v, i) => v === b[i]);
+
+      function firstUnchecked() {
+        return rows().find((row) => !inputFor(row)?.checked) || emptyEl || null;
+      }
+
+      function announce(row) {
+        if (!orderStatus || !row) return;
+        const selected = selectedRows();
+        const position = selected.indexOf(row) + 1;
+        const label = row.querySelector(".multiselect-label")?.textContent.trim() || "Item";
+        orderStatus.textContent = `${label}, priority ${position} of ${selected.length}`;
+      }
+
+      function emitOrderChange(row) {
+        if (list) list.dispatchEvent(new Event("input", { bubbles: true }));
+        announce(row);
+      }
+
+      function partitionSelection() {
+        if (!list) return;
+        const ordered = rows();
+        const checked = ordered.filter((row) => inputFor(row)?.checked);
+        const unchecked = ordered.filter((row) => !inputFor(row)?.checked);
+        [...checked, ...unchecked].forEach((row) => list.insertBefore(row, emptyEl || null));
+      }
+
+      function beginDrag(row) {
+        if (!row || !inputFor(row)?.checked || (filter && filter.value.trim())) return false;
+        dragged = row;
+        dragStartOrder = selectedValues();
+        row.classList.add("is-dragging");
+        return true;
+      }
+
+      function reorderAt(clientY) {
+        if (!dragged || !list) return;
+        const peers = selectedRows().filter((row) => row !== dragged);
+        const before = peers.find((row) => {
+          const rect = row.getBoundingClientRect();
+          return clientY < rect.top + rect.height / 2;
+        });
+        list.insertBefore(dragged, before || firstUnchecked());
+      }
+
+      function finishDrag() {
+        if (!dragged) return;
+        const row = dragged;
+        row.classList.remove("is-dragging");
+        dragged = null;
+        if (!sameOrder(dragStartOrder, selectedValues())) emitOrderChange(row);
+        dragStartOrder = [];
+      }
+
+      function moveWithKeyboard(row, key) {
+        const selected = selectedRows();
+        const current = selected.indexOf(row);
+        if (current < 0 || selected.length < 2) return;
+        let target = current;
+        if (key === "ArrowUp") target -= 1;
+        else if (key === "ArrowDown") target += 1;
+        else if (key === "Home") target = 0;
+        else if (key === "End") target = selected.length - 1;
+        target = Math.max(0, Math.min(selected.length - 1, target));
+        if (target === current) return;
+        const reordered = selected.filter((item) => item !== row);
+        reordered.splice(target, 0, row);
+        reordered.forEach((item) => list.insertBefore(item, firstUnchecked()));
+        emitOrderChange(row);
+      }
 
       function updateCount() {
         if (!countEl) return;
@@ -209,6 +289,7 @@
           o.hidden = !match;
           if (match) shown += 1;
         });
+        ms.classList.toggle("is-filtering", Boolean(q));
         if (emptyEl) emptyEl.hidden = shown > 0;
       }
       if (filter) {
@@ -219,7 +300,78 @@
         );
         filter.addEventListener("input", applyFilter);
       }
-      ms.addEventListener("change", updateCount);
+      if (list) {
+        list.addEventListener("dragover", (ev) => {
+          if (!dragged) return;
+          ev.preventDefault();
+          if (ev.dataTransfer) ev.dataTransfer.dropEffect = "move";
+          reorderAt(ev.clientY);
+        });
+        list.addEventListener("drop", (ev) => {
+          if (!dragged) return;
+          ev.preventDefault();
+          reorderAt(ev.clientY);
+          finishDrag();
+        });
+
+        opts.forEach((row) => {
+          const handle = row.querySelector("[data-ms-drag]");
+          if (!handle) return;
+          handle.addEventListener("click", (ev) => {
+            ev.preventDefault();
+            ev.stopPropagation();
+          });
+          handle.addEventListener("dragstart", (ev) => {
+            if (pointerDrag || !beginDrag(row)) {
+              ev.preventDefault();
+              return;
+            }
+            if (ev.dataTransfer) {
+              ev.dataTransfer.effectAllowed = "move";
+              ev.dataTransfer.setData("text/plain", inputFor(row).value);
+            }
+          });
+          handle.addEventListener("dragend", finishDrag);
+          handle.addEventListener("keydown", (ev) => {
+            if (!["ArrowUp", "ArrowDown", "Home", "End"].includes(ev.key)) return;
+            ev.preventDefault();
+            moveWithKeyboard(row, ev.key);
+          });
+
+          // Native HTML drag handles mouse input. Pointer events cover touch
+          // and pen input, where HTML drag-and-drop is not consistently
+          // available across mobile browsers.
+          handle.addEventListener("pointerdown", (ev) => {
+            if (ev.pointerType === "mouse" || !inputFor(row)?.checked) return;
+            if (filter && filter.value.trim()) return;
+            pointerDrag = { id: ev.pointerId, row, startY: ev.clientY, moved: false };
+            handle.setPointerCapture?.(ev.pointerId);
+          });
+          handle.addEventListener("pointermove", (ev) => {
+            if (!pointerDrag || pointerDrag.id !== ev.pointerId) return;
+            if (!pointerDrag.moved && Math.abs(ev.clientY - pointerDrag.startY) < 5) return;
+            if (!pointerDrag.moved) {
+              pointerDrag.moved = beginDrag(pointerDrag.row);
+              if (!pointerDrag.moved) return;
+            }
+            ev.preventDefault();
+            reorderAt(ev.clientY);
+          });
+          const endPointerDrag = (ev) => {
+            if (!pointerDrag || pointerDrag.id !== ev.pointerId) return;
+            if (pointerDrag.moved) finishDrag();
+            handle.releasePointerCapture?.(ev.pointerId);
+            pointerDrag = null;
+          };
+          handle.addEventListener("pointerup", endPointerDrag);
+          handle.addEventListener("pointercancel", endPointerDrag);
+        });
+      }
+
+      ms.addEventListener("change", (ev) => {
+        if (ev.target.matches?.('input[type="checkbox"]')) partitionSelection();
+        updateCount();
+      });
       updateCount();
     });
   }

--- a/static/style/forms.css
+++ b/static/style/forms.css
@@ -1738,15 +1738,23 @@ input[type="range"].slider:focus::-moz-range-thumb {
 }
 .multiselect-opt {
   display: flex;
+  align-items: stretch;
+  padding: 0;
+  font-size: var(--t-size-sm);
+  border-top: 1px solid var(--t-border);
+  position: relative;
+}
+.multiselect-choice {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
   align-items: center;
   gap: var(--t-space-2);
   padding: var(--t-space-2) var(--t-space-3);
   cursor: pointer;
-  font-size: var(--t-size-sm);
-  border-top: 1px solid var(--t-border);
   /* The hidden ``<input>`` inside uses ``position: absolute`` so the
      checkbox doesn't take up space in the row layout. Anchoring its
-     containing block to the option label means the auto-focus
+     containing block to this choice label means the auto-focus
      ``scrollIntoView`` the browser fires on click stays bounded to
      the option's own bounding rect, the click target is already in
      view, so no jump occurs. Without this the input's nearest
@@ -1768,7 +1776,7 @@ input[type="range"].slider:focus::-moz-range-thumb {
  *, so the page doesn't jump. ``pointer-events: none`` would defeat
  * this (clicks would skip the input), we WANT the click to land on
  * the input here, unlike older visually-hidden patterns. */
-.multiselect-opt input {
+.multiselect-choice input {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -1780,6 +1788,53 @@ input[type="range"].slider:focus::-moz-range-thumb {
   cursor: pointer;
 }
 .multiselect-opt:hover { background: var(--t-surface-soft); }
+.multiselect-drag {
+  position: relative;
+  z-index: 1;
+  flex: 0 0 34px;
+  display: none;
+  place-items: center;
+  width: 34px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--t-muted);
+  box-shadow: none;
+  transform: none;
+  cursor: grab;
+  touch-action: none;
+}
+.multiselect-opt:has(input:checked) .multiselect-drag { display: grid; }
+.multiselect-opt:has(input:checked) + .multiselect-opt:has(input:checked) {
+  border-top-color: transparent;
+}
+.multiselect.is-filtering .multiselect-drag { display: none; }
+.multiselect-drag:hover,
+.multiselect-drag:active,
+.multiselect-drag:focus-visible {
+  background: var(--t-surface-soft);
+  color: var(--t-fg);
+  box-shadow: none;
+  transform: none;
+}
+.multiselect-drag:focus-visible {
+  outline: 2px solid var(--t-accent);
+  outline-offset: -3px;
+}
+.multiselect-drag .ph {
+  display: block;
+  width: 12px;
+  height: 18px;
+  background: radial-gradient(circle, currentColor 1.5px, transparent 1.75px) 0 0 / 6px 6px;
+}
+.multiselect-drag .ph::before { content: none; }
+.multiselect-opt.is-dragging {
+  z-index: 1;
+  background: var(--t-accent-soft);
+  box-shadow: inset 0 0 0 2px var(--t-accent);
+}
+.multiselect-opt.is-dragging .multiselect-drag { cursor: grabbing; }
 .multiselect-tick {
   flex: 0 0 auto;
   display: grid;
@@ -1801,6 +1856,7 @@ input[type="range"].slider:focus::-moz-range-thumb {
 .multiselect-opt:has(input:checked) { background: var(--t-accent-soft); }
 .multiselect-label {
   min-width: 0;
+  flex: 1 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/templates/_components.html
+++ b/templates/_components.html
@@ -369,15 +369,25 @@ macro here instead.
     </div>
     <div class="multiselect-list" data-ms-list>
       {% for opt in real %}
-      <label class="multiselect-opt" data-ms-text="{{ opt.label | lower }}">
-        <input type="checkbox" name="{{ name }}" value="{{ opt.value }}"
-               {% if opt.value | string in sel_str %}checked{% endif %}>
-        <span class="multiselect-tick" aria-hidden="true"><i class="ph ph-check"></i></span>
-        <span class="multiselect-label">{{ opt.label }}</span>
-      </label>
+      <div class="multiselect-opt" data-ms-text="{{ opt.label | lower }}">
+        <label class="multiselect-choice" for="{{ field_id }}-{{ loop.index0 }}">
+          <input type="checkbox" id="{{ field_id }}-{{ loop.index0 }}"
+                 name="{{ name }}" value="{{ opt.value }}"
+                 {% if opt.value | string in sel_str %}checked{% endif %}>
+          <span class="multiselect-tick" aria-hidden="true"><i class="ph ph-check"></i></span>
+          <span class="multiselect-label">{{ opt.label }}</span>
+        </label>
+        <button class="multiselect-drag" type="button" draggable="true" data-ms-drag
+                aria-label="Reorder {{ opt.label }}"
+                aria-keyshortcuts="ArrowUp ArrowDown Home End"
+                title="Drag to reorder; use arrow keys for precise movement">
+          <i class="ph ph-dots-six-vertical" aria-hidden="true"></i>
+        </button>
+      </div>
       {% endfor %}
       <p class="multiselect-empty" data-ms-empty hidden>No matches.</p>
     </div>
+    <span class="sr-only" data-ms-order-status aria-live="polite"></span>
     {% else %}
     <p class="multiselect-hint">{{ (options[0].label if options else None) or 'No options available.' }}</p>
     {% endif %}

--- a/tests/test_page_routes.py
+++ b/tests/test_page_routes.py
@@ -1184,17 +1184,21 @@ def test_multiselect_cell_option_coercion() -> None:
     assert _coerce_cell_option(field, "", {"opt_entities": ""}) == []
 
 
-def _multiselect_checkbox_order(app: Flask, value: Any, options: list[dict[str, str]]) -> list[str]:
-    """Render the ``multiselect_field`` macro and pull the checkbox
-    values back out in DOM order (which is the order they'd submit in)."""
-    import re
-
+def _render_multiselect(app: Flask, value: Any, options: list[dict[str, str]]) -> str:
     with app.app_context():
         tmpl = app.jinja_env.from_string(
             "{% from '_components.html' import multiselect_field %}"
             "{{ multiselect_field('f', 'entities', 'Entities', value=value, options=options) }}"
         )
-        html = tmpl.render(value=value, options=options)
+        return tmpl.render(value=value, options=options)
+
+
+def _multiselect_checkbox_order(app: Flask, value: Any, options: list[dict[str, str]]) -> list[str]:
+    """Render the ``multiselect_field`` macro and pull the checkbox
+    values back out in DOM order (which is the order they'd submit in)."""
+    import re
+
+    html = _render_multiselect(app, value, options)
     return re.findall(r'type="checkbox"[^>]*value="([^"]*)"', html)
 
 
@@ -1226,6 +1230,42 @@ def test_multiselect_tolerates_bare_string_and_missing_value(app: Flask) -> None
     ]
     assert _multiselect_checkbox_order(app, "light.b", options) == ["light.b", "light.a"]
     assert _multiselect_checkbox_order(app, None, options) == ["light.a", "light.b"]
+
+
+def test_multiselect_renders_accessible_reorder_handles(app: Flask) -> None:
+    html = _render_multiselect(
+        app,
+        ["light.b", "light.a"],
+        [
+            {"value": "light.a", "label": "Desk"},
+            {"value": "light.b", "label": "Hallway"},
+        ],
+    )
+
+    assert html.count('class="multiselect-drag"') == 2
+    assert html.count('draggable="true"') == 2
+    assert 'aria-label="Reorder Hallway"' in html
+    assert 'aria-keyshortcuts="ArrowUp ArrowDown Home End"' in html
+    assert 'data-ms-order-status aria-live="polite"' in html
+
+
+def test_multiselect_component_wires_mouse_touch_and_keyboard_reordering() -> None:
+    source = (Path(__file__).parents[1] / "static" / "components.js").read_text()
+    styles = (Path(__file__).parents[1] / "static" / "style" / "forms.css").read_text()
+
+    assert 'handle.addEventListener("dragstart"' in source
+    assert 'list.addEventListener("drop"' in source
+    assert 'handle.addEventListener("pointermove"' in source
+    assert 'handle.addEventListener("keydown"' in source
+    assert 'new Event("input", { bubbles: true })' in source
+    assert ".multiselect-drag .ph" in styles
+    assert "radial-gradient(circle, currentColor 1.5px" in styles
+    assert ".multiselect-opt:has(input:checked) + .multiselect-opt:has(input:checked)" in styles
+    assert "border-top-color: transparent" in styles
+    drag_button = styles.split(".multiselect-drag {", 1)[1].split("}", 1)[0]
+    assert "border-left" not in drag_button
+    assert "box-shadow: none" in drag_button
+    assert "transform: none" in drag_button
 
 
 def test_select_with_unmatched_value_does_not_visually_choose_first_option(


### PR DESCRIPTION
## Summary

- add real drag handles to selected rows in prioritised multi-select fields
- support mouse, touch, pen, and keyboard reordering
- submit the reordered DOM immediately so widget priority matches the editor
- align the compact dot handles and remove dark seams between adjacent selected rows

## Why

The help text promised drag-to-reorder, and the server already round-tripped selected values in DOM order, but the shared editor component did not provide a working reorder interaction. Priority-based widgets such as Album Art therefore could not be reordered from the UI.

## User impact

Selected media players and other prioritised multi-select values can now be reordered directly in both Dashboard editors. The resulting order is saved and used by the widget immediately.

## Validation

- `ruff check tests/test_page_routes.py`
- `pytest -q tests/test_page_routes.py` — 92 passed
- `node --check static/components.js`
- `git diff --check`