### PR TITLE
Add Apple Health summary server support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are
 [SemVer](https://semver.org/) (pre-1.0, so minors can carry breaking changes).
 
+## [Unreleased]
+
+### Added
+
+- **Apple Health seven-day summaries can now be published through Companion.**
+  Servers advertise the opt-in `health.summary` source, strictly validate its
+  bounded Activity, Sleep, and Workout sections, retain only the latest
+  publisher-isolated snapshot until expiry, and emit source-wide semantic
+  refresh events without putting raw Health values in logs, API errors, or
+  backups.
+
 ## [0.313.0], 2026-08-17
 
 ### Added

--- a/app/app_factory.py
+++ b/app/app_factory.py
@@ -1035,8 +1035,9 @@ def create_app(
     from app.state.personal_data_store import PersonalDataSnapshotStore
 
     app.config["COMPANION_PAIRING_STORE"] = PairingStore()
-    # Personal-data bridge (#176): latest-only Apple-Reminders snapshot the
-    # Companion publishes, kept off any render/History path.
+    # Personal-data bridge (#176): latest-only, expiring Reminders and Health
+    # snapshots published by Companion. The store is separate from History
+    # and explicitly excluded from backups.
     app.config["PERSONAL_DATA_STORE"] = PersonalDataSnapshotStore(
         data_root / "core" / "companion_personal_data.json"
     )

--- a/app/backup.py
+++ b/app/backup.py
@@ -45,12 +45,15 @@ LABEL_PRE_UPDATE = "pre-update"
 #   composition PNGs and per-renderer ``.bin`` artifacts. These regenerate
 #   the moment any dashboard is pushed again, and the push code already
 #   handles the "PNG evicted from disk" case for old history entries.
+# - ``core/companion_personal_data.json`` contains latest-only personal values
+#   explicitly excluded from backups by the Companion privacy contract.
 #
 # Restoring a backup that excluded a subpath does NOT wipe the user's
 # current files there, the photos / render cache persist across restores.
 DEFAULT_EXCLUDED_SUBPATHS: tuple[str, ...] = (
     "plugins/picture_gallery",
     "core/renders",
+    "core/companion_personal_data.json",
 )
 
 

--- a/app/companion_api.py
+++ b/app/companion_api.py
@@ -81,6 +81,12 @@ from app.device_upcoming import (
 from app.device_upcoming import (
     MAX_LIMIT as DEVICE_TIMELINE_MAX_EVENTS,
 )
+from app.health_summary import (
+    HEALTH_SUMMARY_MAX_BYTES,
+    HEALTH_SUMMARY_SOURCE_ID,
+    InvalidHealthSummary,
+    validate_health_summary,
+)
 from app.http_headers import HeaderError, validate_header_map
 from app.image_upload import (
     IMAGE_CONTENT_TYPES,
@@ -130,7 +136,7 @@ IDEMPOTENCY_RETENTION_SECONDS = 86_400
 # the app does not hard-code them.
 PERSONAL_DATA_STALE_SECONDS = 86_400  # 24 h
 PERSONAL_DATA_MAX_TTL_SECONDS = 172_800  # 48 h
-PERSONAL_DATA_SOURCES = ("reminders", "reminders.fridge")
+PERSONAL_DATA_SOURCES = ("reminders", "reminders.fridge", HEALTH_SUMMARY_SOURCE_ID)
 PERSONAL_DATA_SNAPSHOT_VERSION = "personal_data_bridge_v1"
 PERSONAL_DATA_REMINDERS_MAX_LISTS = 20
 PERSONAL_DATA_REMINDERS_MAX_ITEMS = 200
@@ -148,6 +154,7 @@ FEATURES = (
     "history",
     "image_framing",
     "personal_data_reminders",
+    "personal_data_health",
     # Read + control for Lineups (#205). Authoring is a separate capability
     # so a client can offer the controls without implying it can edit, which
     # it can't until the write path behind #204 exists.
@@ -779,8 +786,28 @@ def put_personal_data(source_id: str) -> Any:
     timestamp is refused so delayed background work can't overwrite newer data."""
     if source_id not in PERSONAL_DATA_SOURCES:
         return _error("unsupported_personal_data_source", f"unknown source {source_id!r}", 400)
+    if source_id == HEALTH_SUMMARY_SOURCE_ID:
+        content_length = request.content_length
+        if content_length is not None and content_length > HEALTH_SUMMARY_MAX_BYTES:
+            return _error("invalid_snapshot", "health.summary exceeds the 256 KiB limit", 400)
+        if len(request.get_data(cache=True)) > HEALTH_SUMMARY_MAX_BYTES:
+            return _error("invalid_snapshot", "health.summary exceeds the 256 KiB limit", 400)
     body = request.get_json(silent=True)
-    if source_id == "reminders":
+    result: tuple[dict[str, Any], float, float] | None
+    err: tuple[Response, int] | None
+    if source_id == HEALTH_SUMMARY_SOURCE_ID:
+        try:
+            result = validate_health_summary(
+                source_id,
+                body,
+                active_timezone=_timezone(),
+                snapshot_version=PERSONAL_DATA_SNAPSHOT_VERSION,
+                maximum_ttl_seconds=PERSONAL_DATA_MAX_TTL_SECONDS,
+            )
+        except InvalidHealthSummary as exc:
+            return _error("invalid_snapshot", str(exc), 400)
+        err = None
+    elif source_id == "reminders":
         result, err = _validate_reminders(source_id, body)
     else:
         result, err = _validate_reminders_fridge(source_id, body)

--- a/app/data_change_refresh.py
+++ b/app/data_change_refresh.py
@@ -6,7 +6,7 @@ opaque selector ids. A daemon timer waits for a quiet window, resolves the
 currently opted-in widget placements, deduplicates their containing pages, and
 hands those page ids to the existing scheduler refresh machinery.
 
-No reminder titles, list names, or item bodies enter this event path.
+No reminder or Health values enter this event path.
 """
 
 from __future__ import annotations
@@ -78,8 +78,10 @@ def personal_data_update_event(
     Envelope timestamps and expiry are deliberately ignored. Reminders events
     identify only lists whose title or item set changed; list and item ordering
     alone is not meaningful. The deprecated fridge source likewise treats item
-    ordering as presentation-only. The first usable snapshot is source-wide
-    because freshness/missing-source state can affect every configured placement.
+    ordering as presentation-only. Other sources, including ``health.summary``,
+    emit only a source-wide event when their semantic ``data`` changes. The first
+    usable snapshot is source-wide because freshness/missing-source state can
+    affect every configured placement.
     """
     source = f"personal_data.{source_id}"
     previous_data = _snapshot_data(previous)

--- a/app/health_summary.py
+++ b/app/health_summary.py
@@ -1,0 +1,535 @@
+"""Strict validation for Companion ``health.summary`` snapshots.
+
+The iPhone is the authority for HealthKit selection and aggregation.  The
+server accepts only the bounded, versioned summary contract and deliberately
+does not accept raw samples, source/device identity, routes, heart rate,
+metadata, or arbitrary extension fields.
+
+Validation errors describe contract paths and rules only; they never include
+the submitted value, so sensitive Health data cannot leak into API errors or
+ordinary logs.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+HEALTH_SUMMARY_SOURCE_ID = "health.summary"
+HEALTH_SUMMARY_MAX_BYTES = 256 * 1024
+
+_ENVELOPE_FIELDS = frozenset({"version", "source_id", "generated_at", "expires_at", "data"})
+_DATA_FIELDS = frozenset(
+    {
+        "time_zone",
+        "window_start_date",
+        "window_end_date",
+        "activity",
+        "sleep",
+        "workouts",
+    }
+)
+_ACTIVITY_DAY_FIELDS = frozenset(
+    {
+        "date",
+        "steps",
+        "walking_running_distance_meters",
+        "move_mode",
+        "active_energy_kcal",
+        "active_energy_goal_kcal",
+        "move_minutes",
+        "move_goal_minutes",
+        "exercise_minutes",
+        "exercise_goal_minutes",
+        "stand_hours",
+        "stand_goal_hours",
+    }
+)
+_SLEEP_NIGHT_FIELDS = frozenset(
+    {
+        "wake_date",
+        "start_at",
+        "end_at",
+        "in_bed_minutes",
+        "asleep_minutes",
+        "awake_minutes",
+        "core_minutes",
+        "deep_minutes",
+        "rem_minutes",
+        "unspecified_minutes",
+    }
+)
+_WORKOUT_FIELDS = frozenset(
+    {
+        "id",
+        "activity_type",
+        "start_at",
+        "end_at",
+        "duration_seconds",
+        "active_energy_kcal",
+        "walking_running_distance_meters",
+        "cycling_distance_meters",
+        "swimming_distance_meters",
+        "wheelchair_distance_meters",
+        "flights_climbed",
+        "swimming_stroke_count",
+        "segments",
+        "segments_truncated",
+    }
+)
+_SEGMENT_FIELDS = frozenset(
+    {
+        "ordinal",
+        "activity_type",
+        "start_at",
+        "end_at",
+        "duration_seconds",
+        "active_energy_kcal",
+        "walking_running_distance_meters",
+        "cycling_distance_meters",
+        "swimming_distance_meters",
+        "wheelchair_distance_meters",
+        "flights_climbed",
+        "swimming_stroke_count",
+    }
+)
+_TIME_ZONE_RE = re.compile(r"^[A-Za-z0-9._+-]+(?:/[A-Za-z0-9._+-]+)*$")
+_WORKOUT_ID_RE = re.compile(r"^[0-9a-f]{24}$")
+
+_WORKOUT_ACTIVITY_TYPES = frozenset(
+    {
+        "american_football",
+        "archery",
+        "australian_football",
+        "badminton",
+        "barre",
+        "baseball",
+        "basketball",
+        "bowling",
+        "boxing",
+        "cardio_dance",
+        "climbing",
+        "cooldown",
+        "core_training",
+        "cricket",
+        "cross_country_skiing",
+        "cross_training",
+        "curling",
+        "cycling",
+        "dance",
+        "dance_inspired_training",
+        "disc_sports",
+        "downhill_skiing",
+        "elliptical",
+        "equestrian_sports",
+        "fencing",
+        "fishing",
+        "fitness_gaming",
+        "flexibility",
+        "functional_strength_training",
+        "golf",
+        "gymnastics",
+        "hand_cycling",
+        "handball",
+        "high_intensity_interval_training",
+        "hiking",
+        "hockey",
+        "hunting",
+        "jump_rope",
+        "kickboxing",
+        "lacrosse",
+        "martial_arts",
+        "mind_and_body",
+        "mixed_cardio",
+        "mixed_metabolic_cardio_training",
+        "other",
+        "paddle_sports",
+        "pickleball",
+        "pilates",
+        "play",
+        "preparation_and_recovery",
+        "racquetball",
+        "rowing",
+        "rugby",
+        "running",
+        "sailing",
+        "skating_sports",
+        "snow_sports",
+        "snowboarding",
+        "soccer",
+        "social_dance",
+        "softball",
+        "squash",
+        "stair_climbing",
+        "stairs",
+        "step_training",
+        "surfing_sports",
+        "swim_bike_run",
+        "swimming",
+        "table_tennis",
+        "tai_chi",
+        "tennis",
+        "track_and_field",
+        "traditional_strength_training",
+        "transition",
+        "underwater_diving",
+        "volleyball",
+        "walking",
+        "water_fitness",
+        "water_polo",
+        "water_sports",
+        "wheelchair_run_pace",
+        "wheelchair_walk_pace",
+        "wrestling",
+        "yoga",
+    }
+)
+
+_ACTIVITY_NULLABLE_INTS = {
+    "steps": 1_000_000,
+    "move_minutes": 1_440,
+    "move_goal_minutes": 1_440,
+    "exercise_minutes": 1_440,
+    "exercise_goal_minutes": 1_440,
+    "stand_hours": 24,
+    "stand_goal_hours": 24,
+}
+_ACTIVITY_NULLABLE_NUMBERS = {
+    "walking_running_distance_meters": 1_000_000,
+    "active_energy_kcal": 100_000,
+    "active_energy_goal_kcal": 100_000,
+}
+_SLEEP_NULLABLE_INTS = {
+    "in_bed_minutes": 1_440,
+    "asleep_minutes": 1_440,
+    "awake_minutes": 1_440,
+    "core_minutes": 1_440,
+    "deep_minutes": 1_440,
+    "rem_minutes": 1_440,
+    "unspecified_minutes": 1_440,
+}
+_WORKOUT_NULLABLE_NUMBERS = {
+    "active_energy_kcal": 100_000,
+    "walking_running_distance_meters": 10_000_000,
+    "cycling_distance_meters": 10_000_000,
+    "swimming_distance_meters": 10_000_000,
+    "wheelchair_distance_meters": 10_000_000,
+}
+_WORKOUT_NULLABLE_INTS = {
+    "flights_climbed": 10_000_000,
+    "swimming_stroke_count": 10_000_000,
+}
+
+
+class InvalidHealthSummary(ValueError):
+    """A privacy-safe strict-contract validation failure."""
+
+
+def _object(value: Any, fields: frozenset[str], path: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise InvalidHealthSummary(f"{path} must be an object")
+    actual = set(value)
+    missing = fields - actual
+    if missing:
+        raise InvalidHealthSummary(f"{path} is missing required fields")
+    if actual - fields:
+        raise InvalidHealthSummary(f"{path} has unexpected fields")
+    return value
+
+
+def _array(value: Any, path: str, *, maximum: int, exact: int | None = None) -> list[Any]:
+    if not isinstance(value, list):
+        raise InvalidHealthSummary(f"{path} must be an array")
+    if exact is not None and len(value) != exact:
+        raise InvalidHealthSummary(f"{path} must contain exactly {exact} entries")
+    if len(value) > maximum:
+        raise InvalidHealthSummary(f"{path} exceeds its {maximum}-entry limit")
+    return value
+
+
+def _iso_date(value: Any, path: str) -> date:
+    if not isinstance(value, str) or len(value) != 10:
+        raise InvalidHealthSummary(f"{path} must be an ISO date")
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise InvalidHealthSummary(f"{path} must be an ISO date") from exc
+    if parsed.isoformat() != value:
+        raise InvalidHealthSummary(f"{path} must be an ISO date")
+    return parsed
+
+
+def _utc_instant(value: Any, path: str) -> datetime:
+    if not isinstance(value, str):
+        raise InvalidHealthSummary(f"{path} must be a UTC ISO 8601 instant")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise InvalidHealthSummary(f"{path} must be a UTC ISO 8601 instant") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() != timedelta(0):
+        raise InvalidHealthSummary(f"{path} must be a UTC ISO 8601 instant")
+    return parsed.astimezone(UTC)
+
+
+def _required_bool(value: Any, path: str) -> None:
+    if not isinstance(value, bool):
+        raise InvalidHealthSummary(f"{path} must be a boolean")
+
+
+def _required_int(value: Any, path: str, *, maximum: int) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or not (0 <= value <= maximum):
+        raise InvalidHealthSummary(f"{path} must be an integer from 0 to {maximum}")
+
+
+def _nullable_int(value: Any, path: str, *, maximum: int) -> None:
+    if value is None:
+        return
+    _required_int(value, path, maximum=maximum)
+
+
+def _nullable_number(value: Any, path: str, *, maximum: float) -> None:
+    if value is None:
+        return
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or not (0 <= float(value) <= maximum)
+    ):
+        raise InvalidHealthSummary(f"{path} must be a finite number from 0 to {maximum:g}")
+
+
+def _activity_type(value: Any, path: str) -> None:
+    if not isinstance(value, str) or value not in _WORKOUT_ACTIVITY_TYPES:
+        raise InvalidHealthSummary(f"{path} must be a recognized activity type")
+
+
+def _interval(
+    value: dict[str, Any],
+    path: str,
+    *,
+    maximum_seconds: int,
+) -> tuple[datetime, datetime]:
+    start = _utc_instant(value.get("start_at"), f"{path}.start_at")
+    end = _utc_instant(value.get("end_at"), f"{path}.end_at")
+    wall_seconds = (end - start).total_seconds()
+    if not (0 < wall_seconds <= maximum_seconds):
+        raise InvalidHealthSummary(
+            f"{path} start_at/end_at must form a positive interval no longer than {maximum_seconds} seconds"
+        )
+    return start, end
+
+
+def _validate_activity(
+    raw: Any,
+    *,
+    expected_dates: list[date],
+) -> None:
+    activity = _object(raw, frozenset({"days"}), "data.activity")
+    days = _array(activity["days"], "data.activity.days", maximum=7, exact=7)
+    for index, raw_day in enumerate(days):
+        path = f"data.activity.days[{index}]"
+        day = _object(raw_day, _ACTIVITY_DAY_FIELDS, path)
+        if _iso_date(day["date"], f"{path}.date") != expected_dates[index]:
+            raise InvalidHealthSummary("data.activity.days dates must exactly match the window")
+        for key, maximum in _ACTIVITY_NULLABLE_INTS.items():
+            _nullable_int(day[key], f"{path}.{key}", maximum=maximum)
+        for key, maximum in _ACTIVITY_NULLABLE_NUMBERS.items():
+            _nullable_number(day[key], f"{path}.{key}", maximum=maximum)
+
+        move_mode = day["move_mode"]
+        if move_mode not in (None, "active_energy", "move_time"):
+            raise InvalidHealthSummary(f"{path}.move_mode is invalid")
+        if move_mode == "active_energy" and any(
+            day[key] is not None for key in ("move_minutes", "move_goal_minutes")
+        ):
+            raise InvalidHealthSummary(f"{path} active_energy mode requires null move minutes")
+        if move_mode == "move_time" and any(
+            day[key] is not None for key in ("active_energy_kcal", "active_energy_goal_kcal")
+        ):
+            raise InvalidHealthSummary(f"{path} move_time mode requires null active energy")
+        if move_mode is None and any(
+            day[key] is not None
+            for key in (
+                "active_energy_kcal",
+                "active_energy_goal_kcal",
+                "move_minutes",
+                "move_goal_minutes",
+                "exercise_minutes",
+                "exercise_goal_minutes",
+                "stand_hours",
+                "stand_goal_hours",
+            )
+        ):
+            raise InvalidHealthSummary(f"{path} null move_mode requires null ring values")
+
+
+def _validate_sleep(
+    raw: Any,
+    *,
+    expected_dates: set[date],
+    timezone: ZoneInfo,
+) -> None:
+    sleep = _object(raw, frozenset({"nights"}), "data.sleep")
+    nights = _array(sleep["nights"], "data.sleep.nights", maximum=7)
+    previous_wake_date: date | None = None
+    for index, raw_night in enumerate(nights):
+        path = f"data.sleep.nights[{index}]"
+        night = _object(raw_night, _SLEEP_NIGHT_FIELDS, path)
+        wake_date = _iso_date(night["wake_date"], f"{path}.wake_date")
+        if wake_date not in expected_dates:
+            raise InvalidHealthSummary(f"{path}.wake_date must be inside the window")
+        if previous_wake_date is not None and wake_date <= previous_wake_date:
+            raise InvalidHealthSummary("data.sleep.nights must have unique ascending wake dates")
+        previous_wake_date = wake_date
+        _start, end = _interval(night, path, maximum_seconds=86_400)
+        if end.astimezone(timezone).date() != wake_date:
+            raise InvalidHealthSummary(f"{path}.wake_date must contain end_at in data.time_zone")
+        for key, maximum in _SLEEP_NULLABLE_INTS.items():
+            _nullable_int(night[key], f"{path}.{key}", maximum=maximum)
+
+
+def _validate_workout_metrics(value: dict[str, Any], path: str) -> None:
+    for key, maximum in _WORKOUT_NULLABLE_NUMBERS.items():
+        _nullable_number(value[key], f"{path}.{key}", maximum=maximum)
+    for key, maximum in _WORKOUT_NULLABLE_INTS.items():
+        _nullable_int(value[key], f"{path}.{key}", maximum=maximum)
+
+
+def _validate_workouts(
+    raw: Any,
+    *,
+    expected_dates: set[date],
+    timezone: ZoneInfo,
+) -> None:
+    workouts = _object(raw, frozenset({"items", "items_truncated"}), "data.workouts")
+    items = _array(workouts["items"], "data.workouts.items", maximum=100)
+    _required_bool(workouts["items_truncated"], "data.workouts.items_truncated")
+
+    seen_ids: set[str] = set()
+    previous_start: datetime | None = None
+    total_segments = 0
+    for workout_index, raw_workout in enumerate(items):
+        path = f"data.workouts.items[{workout_index}]"
+        workout = _object(raw_workout, _WORKOUT_FIELDS, path)
+        workout_id = workout["id"]
+        if not isinstance(workout_id, str) or _WORKOUT_ID_RE.fullmatch(workout_id) is None:
+            raise InvalidHealthSummary(f"{path}.id must be 24 lowercase hexadecimal characters")
+        if workout_id in seen_ids:
+            raise InvalidHealthSummary("data.workouts.items ids must be unique")
+        seen_ids.add(workout_id)
+        _activity_type(workout["activity_type"], f"{path}.activity_type")
+        start, end = _interval(workout, path, maximum_seconds=604_800)
+        if start.astimezone(timezone).date() not in expected_dates:
+            raise InvalidHealthSummary(f"{path}.start_at must fall inside the window")
+        if previous_start is not None and start < previous_start:
+            raise InvalidHealthSummary("data.workouts.items must be sorted by start_at")
+        previous_start = start
+        _required_int(workout["duration_seconds"], f"{path}.duration_seconds", maximum=604_800)
+        if workout["duration_seconds"] > (end - start).total_seconds():
+            raise InvalidHealthSummary(f"{path}.duration_seconds cannot exceed its interval")
+        _validate_workout_metrics(workout, path)
+        _required_bool(workout["segments_truncated"], f"{path}.segments_truncated")
+
+        segments = _array(workout["segments"], f"{path}.segments", maximum=64)
+        if workout["segments_truncated"] and segments:
+            raise InvalidHealthSummary(
+                f"{path}.segments must be empty when segments_truncated is true"
+            )
+        total_segments += len(segments)
+        if total_segments > 256:
+            raise InvalidHealthSummary("data.workouts exceeds the 256-segment snapshot limit")
+
+        previous_segment_start: datetime | None = None
+        for segment_index, raw_segment in enumerate(segments):
+            segment_path = f"{path}.segments[{segment_index}]"
+            segment = _object(raw_segment, _SEGMENT_FIELDS, segment_path)
+            if segment["ordinal"] != segment_index:
+                raise InvalidHealthSummary(
+                    f"{path}.segments ordinals must be zero-based and contiguous"
+                )
+            _activity_type(segment["activity_type"], f"{segment_path}.activity_type")
+            segment_start, segment_end = _interval(
+                segment,
+                segment_path,
+                maximum_seconds=604_800,
+            )
+            if segment_start < start or segment_end > end:
+                raise InvalidHealthSummary(f"{segment_path} must stay inside its workout interval")
+            if previous_segment_start is not None and segment_start < previous_segment_start:
+                raise InvalidHealthSummary(f"{path}.segments must be sorted by start_at")
+            previous_segment_start = segment_start
+            _required_int(
+                segment["duration_seconds"],
+                f"{segment_path}.duration_seconds",
+                maximum=604_800,
+            )
+            if segment["duration_seconds"] > (segment_end - segment_start).total_seconds():
+                raise InvalidHealthSummary(
+                    f"{segment_path}.duration_seconds cannot exceed its interval"
+                )
+            _validate_workout_metrics(segment, segment_path)
+
+
+def validate_health_summary(
+    source_id: str,
+    body: Any,
+    *,
+    active_timezone: str,
+    snapshot_version: str,
+    maximum_ttl_seconds: int,
+) -> tuple[dict[str, Any], float, float]:
+    """Validate and return ``(snapshot, generated_epoch, expires_epoch)``."""
+
+    snapshot = _object(body, _ENVELOPE_FIELDS, "snapshot")
+    if snapshot["version"] != snapshot_version:
+        raise InvalidHealthSummary("unsupported snapshot version")
+    if source_id != HEALTH_SUMMARY_SOURCE_ID or snapshot["source_id"] != source_id:
+        raise InvalidHealthSummary("source_id does not match the health.summary path")
+
+    generated = _utc_instant(snapshot["generated_at"], "generated_at")
+    expires = _utc_instant(snapshot["expires_at"], "expires_at")
+    ttl_seconds = (expires - generated).total_seconds()
+    if not (0 < ttl_seconds <= maximum_ttl_seconds):
+        raise InvalidHealthSummary("expires_at exceeds the maximum retention window")
+
+    data = _object(snapshot["data"], _DATA_FIELDS, "data")
+    time_zone = data["time_zone"]
+    if (
+        not isinstance(time_zone, str)
+        or not (1 <= len(time_zone) <= 64)
+        or _TIME_ZONE_RE.fullmatch(time_zone) is None
+    ):
+        raise InvalidHealthSummary("data.time_zone must be a valid IANA time zone")
+    try:
+        timezone = ZoneInfo(time_zone)
+    except ZoneInfoNotFoundError as exc:
+        raise InvalidHealthSummary("data.time_zone must be a valid IANA time zone") from exc
+    if time_zone != active_timezone:
+        raise InvalidHealthSummary("data.time_zone must match the active Tesserae instance")
+
+    window_start = _iso_date(data["window_start_date"], "data.window_start_date")
+    window_end = _iso_date(data["window_end_date"], "data.window_end_date")
+    if window_end - window_start != timedelta(days=6):
+        raise InvalidHealthSummary("data date window must contain exactly seven calendar dates")
+    if generated.astimezone(timezone).date() != window_end:
+        raise InvalidHealthSummary(
+            "data.window_end_date must contain generated_at in data.time_zone"
+        )
+    expected_dates = [window_start + timedelta(days=offset) for offset in range(7)]
+    expected_date_set = set(expected_dates)
+
+    sections = (data["activity"], data["sleep"], data["workouts"])
+    if all(section is None for section in sections):
+        raise InvalidHealthSummary("at least one Health summary section must be shared")
+    if data["activity"] is not None:
+        _validate_activity(data["activity"], expected_dates=expected_dates)
+    if data["sleep"] is not None:
+        _validate_sleep(data["sleep"], expected_dates=expected_date_set, timezone=timezone)
+    if data["workouts"] is not None:
+        _validate_workouts(data["workouts"], expected_dates=expected_date_set, timezone=timezone)
+
+    return snapshot, generated.timestamp(), expires.timestamp()

--- a/app/settings/companion_routes.py
+++ b/app/settings/companion_routes.py
@@ -42,7 +42,7 @@ SCOPE_LABELS: dict[str, str] = {
     "dashboards:read": "See your dashboards",
     "push:write": "Send dashboards to a display",
     "media:write": "Send photos and images",
-    "personal_data:write": "Publish reminders from the phone",
+    "personal_data:write": "Publish selected personal data from the phone",
     "lineups:read": "See your Lineups",
     "lineups:control": "Start, stop, and step Lineups",
     "lineups:write": "Create and edit Lineups",

--- a/app/state/personal_data_store.py
+++ b/app/state/personal_data_store.py
@@ -1,14 +1,12 @@
 """Latest-only personal-data snapshots for the Companion bridge (#176).
 
-The iOS Companion publishes minimal, expiring Apple Reminders snapshots; the
-server keeps only the *latest* snapshot per paired publisher and source, then
-renders it in a widget. The generic source may group several explicitly
-selected lists, while the legacy fridge source keeps its original one-list
-shape. No history: exactly one snapshot per ``(publisher_id, source_id)``,
-replaced on each accepted PUT and deleted on disable or expiry. The server
-never connects to iCloud, it only stores what each phone explicitly publishes,
-and drops it once expired. Contract:
-``tests/companion/contract/app-v1.openapi.yaml`` (Companion 0.7.0).
+The iOS Companion publishes minimal, expiring Apple Reminders and Health
+summaries; the server keeps only the *latest* snapshot per paired publisher and
+source, then renders it in a widget. No history: exactly one snapshot per
+``(publisher_id, source_id)``, replaced on each accepted PUT and deleted on
+disable or expiry. The server never connects to iCloud or HealthKit, it only
+stores what each phone explicitly publishes, and drops it once expired.
+Contract: ``tests/companion/contract/app-v1.openapi.yaml``.
 
 Each stored record wraps the raw snapshot with the two epochs the API needs for
 ordering and freshness, so this store never parses ISO timestamps itself::
@@ -242,7 +240,7 @@ class PersonalDataSnapshotStore:
         """Remove raw values from snapshots past ``expires_epoch``.
 
         Non-sensitive timing metadata remains as a tombstone so callers can
-        report ``expired`` without retaining Reminder titles or list contents.
+        report ``expired`` without retaining Reminder or Health values.
         Returns the source ids redacted during this call.
         """
         with self._lock:

--- a/tests/companion/test_companion_api.py
+++ b/tests/companion/test_companion_api.py
@@ -128,6 +128,7 @@ def test_capabilities_probe_is_unauthenticated_and_valid(app: Flask) -> None:
         "history",
         "image_framing",
         "personal_data_reminders",
+        "personal_data_health",
         "lineups",
         "lineup_control",
         "lineup_authoring",
@@ -142,7 +143,11 @@ def test_capabilities_probe_is_unauthenticated_and_valid(app: Flask) -> None:
         # without one has nothing honest to answer with.
         "device_timeline",
     }
-    assert body["personal_data"]["sources"] == ["reminders", "reminders.fridge"]
+    assert body["personal_data"]["sources"] == [
+        "reminders",
+        "reminders.fridge",
+        "health.summary",
+    ]
     assert "webpage_push" not in body["features"]
     assert body["limits"]["image_fit_modes"] == list(companion_api.IMAGE_FIT_MODES)
     # Contract 0.6: the zoom bound is mandatory alongside image_framing.

--- a/tests/companion/test_companion_personal_data.py
+++ b/tests/companion/test_companion_personal_data.py
@@ -139,6 +139,45 @@ def _put_multi(app: Flask, token: str, snap: dict[str, Any]) -> Any:
     )
 
 
+def _health_snapshot(
+    generated: datetime,
+    *,
+    ttl_hours: int = 47,
+    sleep: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    window_end = generated.date()
+    window_start = window_end - timedelta(days=6)
+    return {
+        "version": "personal_data_bridge_v1",
+        "source_id": "health.summary",
+        "generated_at": _iso(generated),
+        "expires_at": _iso(generated + timedelta(hours=ttl_hours)),
+        "data": {
+            "time_zone": "UTC",
+            "window_start_date": window_start.isoformat(),
+            "window_end_date": window_end.isoformat(),
+            "activity": None,
+            "sleep": {"nights": []} if sleep is None else sleep,
+            "workouts": None,
+        },
+    }
+
+
+def _put_health(app: Flask, token: str, snap: dict[str, Any]) -> Any:
+    return app.test_client().put(
+        "/api/app/v1/personal-data/health.summary",
+        headers=_auth(token),
+        data=json.dumps(snap),
+    )
+
+
+def _health_contract_fixture() -> dict[str, Any]:
+    fixture_path = (
+        Path(__file__).parent / "contract" / "Fixtures" / "personal-data-health-summary.json"
+    )
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
 class _ChangeCapture:
     def __init__(self) -> None:
         self.events: list[DataChangeEvent] = []
@@ -156,7 +195,12 @@ def test_capabilities_advertise_personal_data(app: Flask) -> None:
     body = app.test_client().get("/api/app/v1").get_json()
     jsonschema.validate(body, schema_for("Capabilities"), format_checker=_FMT)
     assert "personal_data_reminders" in body["features"]
-    assert body["personal_data"]["sources"] == ["reminders", "reminders.fridge"]
+    assert "personal_data_health" in body["features"]
+    assert body["personal_data"]["sources"] == [
+        "reminders",
+        "reminders.fridge",
+        "health.summary",
+    ]
     assert body["limits"]["personal_data_stale_after_seconds"] == 86400
     assert body["limits"]["personal_data_max_ttl_seconds"] == 172800
 
@@ -194,6 +238,167 @@ def test_multi_list_put_then_status_round_trip(app: Flask) -> None:
     body = listing.get_json()
     jsonschema.validate(body, schema_for("PersonalDataStatusResponse"), format_checker=_FMT)
     assert [source["source_id"] for source in body["sources"]] == ["reminders"]
+
+
+def test_health_summary_put_status_and_delete_round_trip(app: Flask) -> None:
+    token = _token(app)
+    now = datetime.now(UTC).replace(microsecond=0)
+    snapshot = _health_snapshot(now)
+
+    response = _put_health(app, token, snapshot)
+
+    assert response.status_code == 200, response.get_data(as_text=True)
+    status = response.get_json()
+    jsonschema.validate(status, schema_for("PersonalDataSourceStatus"), format_checker=_FMT)
+    assert status["source_id"] == "health.summary"
+    assert status["state"] == "fresh"
+    assert app.config["PERSONAL_DATA_STORE"].get("health.summary")["snapshot"] == snapshot
+
+    listing = app.test_client().get("/api/app/v1/personal-data/status", headers=_auth(token))
+    assert [source["source_id"] for source in listing.get_json()["sources"]] == ["health.summary"]
+
+    deleted = app.test_client().delete(
+        "/api/app/v1/personal-data/health.summary", headers=_auth(token)
+    )
+    assert deleted.status_code == 204
+    assert (
+        app.test_client()
+        .get("/api/app/v1/personal-data/status", headers=_auth(token))
+        .get_json()["sources"]
+        == []
+    )
+
+
+def test_full_health_contract_fixture_is_accepted(app: Flask) -> None:
+    token = _token(app)
+    app.config["SETTINGS_STORE"].patch_section("app", {"timezone": "Asia/Shanghai"})
+    snapshot = _health_contract_fixture()
+
+    response = _put_health(app, token, snapshot)
+
+    assert response.status_code == 200, response.get_data(as_text=True)
+    jsonschema.validate(
+        response.get_json(), schema_for("PersonalDataSourceStatus"), format_checker=_FMT
+    )
+
+
+def test_health_changes_are_source_wide_and_ttl_renewal_is_silent(app: Flask) -> None:
+    token = _token(app)
+    capture = _ChangeCapture()
+    app.config["DATA_CHANGE_COORDINATOR"] = capture
+    now = datetime.now(UTC).replace(microsecond=0)
+    initial = _health_snapshot(now)
+
+    assert _put_health(app, token, initial).status_code == 200
+    assert capture.events == [DataChangeEvent("personal_data.health.summary")]
+
+    capture.events.clear()
+    renewal = _health_snapshot(now + timedelta(seconds=1))
+    assert _put_health(app, token, renewal).status_code == 200
+    assert capture.events == []
+
+    capture.events.clear()
+    changed = _health_snapshot(
+        now + timedelta(seconds=2),
+        sleep={
+            "nights": [
+                {
+                    "wake_date": now.date().isoformat(),
+                    "start_at": _iso(now - timedelta(hours=7)),
+                    "end_at": _iso(now),
+                    "in_bed_minutes": 420,
+                    "asleep_minutes": 390,
+                    "awake_minutes": 30,
+                    "core_minutes": None,
+                    "deep_minutes": None,
+                    "rem_minutes": None,
+                    "unspecified_minutes": 390,
+                }
+            ]
+        },
+    )
+    assert _put_health(app, token, changed).status_code == 200
+    assert capture.events == [DataChangeEvent("personal_data.health.summary")]
+
+    capture.events.clear()
+    response = app.test_client().delete(
+        "/api/app/v1/personal-data/health.summary", headers=_auth(token)
+    )
+    assert response.status_code == 204
+    assert capture.events == [DataChangeEvent("personal_data.health.summary")]
+
+
+def test_health_validation_rejects_privacy_and_shape_violations(app: Flask) -> None:
+    token = _token(app)
+    app.config["SETTINGS_STORE"].patch_section("app", {"timezone": "Asia/Shanghai"})
+
+    def rejected(snapshot: dict[str, Any]) -> Any:
+        response = _put_health(app, token, snapshot)
+        assert response.status_code == 400, response.get_data(as_text=True)
+        assert response.get_json()["error"]["code"] == "invalid_snapshot"
+        return response
+
+    all_sections_null = _health_contract_fixture()
+    all_sections_null["data"]["activity"] = None
+    all_sections_null["data"]["sleep"] = None
+    all_sections_null["data"]["workouts"] = None
+    rejected(all_sections_null)
+
+    wrong_timezone = _health_contract_fixture()
+    wrong_timezone["data"]["time_zone"] = "UTC"
+    rejected(wrong_timezone)
+
+    unexpected_identity = _health_contract_fixture()
+    unexpected_identity["data"]["workouts"]["items"][0]["healthkit_uuid"] = "private-id"
+    response = rejected(unexpected_identity)
+    assert "private-id" not in response.get_data(as_text=True)
+
+    boolean_steps = _health_contract_fixture()
+    boolean_steps["data"]["activity"]["days"][0]["steps"] = True
+    rejected(boolean_steps)
+
+    wrong_wake_date = _health_contract_fixture()
+    wrong_wake_date["data"]["sleep"]["nights"][0]["wake_date"] = "2026-08-13"
+    rejected(wrong_wake_date)
+
+    invalid_activity_type = _health_contract_fixture()
+    invalid_activity_type["data"]["workouts"]["items"][0]["activity_type"] = {"raw": "running"}
+    rejected(invalid_activity_type)
+
+    invalid_segment = _health_contract_fixture()
+    workout = invalid_segment["data"]["workouts"]["items"][0]
+    segment = {
+        key: value
+        for key, value in workout.items()
+        if key not in {"id", "segments", "segments_truncated"}
+    }
+    segment["ordinal"] = 1
+    workout["segments"] = [segment]
+    rejected(invalid_segment)
+
+
+def test_health_validation_enforces_ttl_window_and_request_size(app: Flask) -> None:
+    token = _token(app)
+    now = datetime.now(UTC).replace(microsecond=0)
+
+    too_long = _put_health(app, token, _health_snapshot(now, ttl_hours=49))
+    assert too_long.status_code == 400
+    assert too_long.get_json()["error"]["code"] == "invalid_snapshot"
+
+    wrong_window = _health_snapshot(now)
+    wrong_window["data"]["window_start_date"] = (now.date() - timedelta(days=5)).isoformat()
+    response = _put_health(app, token, wrong_window)
+    assert response.status_code == 400
+    assert response.get_json()["error"]["code"] == "invalid_snapshot"
+
+    oversized = _health_snapshot(now)
+    oversized["data"]["private_padding"] = "sensitive" * 40_000
+    response = _put_health(app, token, oversized)
+    assert response.status_code == 400
+    error = response.get_json()["error"]
+    assert error["code"] == "invalid_snapshot"
+    assert error["message"] == "health.summary exceeds the 256 KiB limit"
+    assert "sensitive" not in response.get_data(as_text=True)
 
 
 def test_personal_data_changes_emit_semantic_events_after_storage(app: Flask) -> None:

--- a/tests/companion/test_contract_fixtures.py
+++ b/tests/companion/test_contract_fixtures.py
@@ -250,6 +250,7 @@ def test_personal_data_capabilities_advertise_source_ids_directly() -> None:
         "health.summary",
     ]
     assert "personal_data_reminders" in capabilities["features"]
+    assert "personal_data_health" in capabilities["features"]
     assert "personal_data_reminders_multi_list" not in capabilities["features"]
 
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -172,6 +172,7 @@ def test_excluded_subpaths_recorded_in_metadata(tmp_path: Path) -> None:
         meta = json.loads(zf.read(bk.META_NAME))
     assert "plugins/picture_gallery" in meta["excluded_subpaths"]
     assert "core/renders" in meta["excluded_subpaths"]
+    assert "core/companion_personal_data.json" in meta["excluded_subpaths"]
     assert meta["version"] >= 2
 
 
@@ -193,6 +194,21 @@ def test_render_cache_artifacts_are_excluded(tmp_path: Path) -> None:
     assert not any(n.startswith("core/renders/") for n in names), [
         n for n in names if n.startswith("core/renders/")
     ]
+
+
+def test_personal_data_snapshots_are_excluded(tmp_path: Path) -> None:
+    """Personal-data values are latest-only and must never enter backups."""
+    import zipfile
+
+    root = tmp_path / "data"
+    _seed(root)
+    personal_data = root / "core" / "companion_personal_data.json"
+    personal_data.write_text('{"snapshot":{"title":"private"}}', encoding="utf-8")
+
+    backup = bk.create(root)
+
+    with zipfile.ZipFile(backup.path) as zf:
+        assert "core/companion_personal_data.json" not in zf.namelist()
 
 
 def test_restore_preserves_users_gallery_photos(tmp_path: Path) -> None:

--- a/tests/test_data_change_refresh.py
+++ b/tests/test_data_change_refresh.py
@@ -144,6 +144,28 @@ def test_first_nonempty_snapshot_and_delete_are_narrowed_to_known_lists() -> Non
     assert personal_data_delete_event("reminders", current) == expected
 
 
+def test_health_summary_diff_is_source_wide_and_ignores_envelope_renewal() -> None:
+    before = {
+        "version": "personal_data_bridge_v1",
+        "source_id": "health.summary",
+        "generated_at": "2026-08-14T12:00:00Z",
+        "expires_at": "2026-08-16T12:00:00Z",
+        "data": {"sleep": {"nights": []}},
+    }
+    renewed = {
+        **before,
+        "generated_at": "2026-08-14T12:30:00Z",
+        "expires_at": "2026-08-16T12:30:00Z",
+    }
+    changed = {**renewed, "data": {"sleep": {"nights": [{"wake_date": "2026-08-14"}]}}}
+    expected = DataChangeEvent(source="personal_data.health.summary")
+
+    assert personal_data_update_event("health.summary", None, before) == expected
+    assert personal_data_update_event("health.summary", before, renewed) is None
+    assert personal_data_update_event("health.summary", renewed, changed) == expected
+    assert personal_data_delete_event("health.summary", changed) == expected
+
+
 def test_matching_pages_respects_placement_opt_in_and_selector(tmp_path: Path) -> None:
     registry = PluginRegistry(
         plugins={


### PR DESCRIPTION
## Summary

- advertise `health.summary` and the separate `personal_data_health` capability
- strictly validate the bounded seven-day Activity, Sleep, and Workouts snapshot before latest-only storage
- emit source-wide semantic refresh events while ignoring envelope-only renewal
- keep personal-data snapshots out of backups and broaden the operator-facing scope description beyond Reminders

## Privacy and lifecycle

- accepts only the contract fields; raw samples, routes, heart rate, HealthKit identifiers, source/device identity, and free-form metadata are rejected as unexpected fields
- enforces the existing 48-hour maximum TTL and a 256 KiB request limit
- retains one expiring snapshot per publisher and source, separate from History
- returns path/rule-only validation errors without echoing submitted Health values

## Contract and discussion

- Implements the merged contract from [Companion PR #7](https://github.com/charmmmz/tesserae-companion-ios/pull/7).
- Follows the server checklist accepted in [Discussion #176](https://github.com/dmellok/tesserae/discussions/176#discussioncomment-18044602).
- The Apple Health widget remains a separate community-catalog repository change.

## Validation

- `python -m pytest -q tests/companion/test_companion_personal_data.py tests/companion/test_companion_api.py tests/companion/test_contract_fixtures.py tests/test_data_change_refresh.py tests/test_backup.py` — 135 passed
- `mypy --python-version 3.12 app/health_summary.py app/companion_api.py app/data_change_refresh.py app/state/personal_data_store.py app/backup.py` — passed
- `ruff check` and `ruff format --check` on the changed Python files — passed
- `git diff --check` — clean