### PR TITLE
Add Companion device setup pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are
 [SemVer](https://semver.org/) (pre-1.0, so minors can carry breaking changes).
 
+## [Unreleased]
+
+### Added
+
+- **Companion can securely register a physically nearby display during
+  Bluetooth setup.** Authenticated app sessions with `device_setup:write` may
+  mint a short-lived, single-use firmware registration code through
+  `POST /api/app/v1/device-pairings`. Firmware still redeems that code through
+  the existing device registration endpoint, so the app never receives a
+  display token. Existing Companion sessions require an explicit operator
+  grant; new pairings include the setup permission.
+
 ## [0.316.0], 2026-08-18
 
 ### Added
@@ -80,7 +92,6 @@ All notable changes to Tesserae are recorded here. Format loosely follows
   Home Assistant entities in the order shown by the editor. Reordering keeps
   the handle focused across the move, so arrow keys step an entry more than
   once and ticking a row doesn't drop keyboard focus to the page.
-
 ## [0.313.0], 2026-08-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ All notable changes to Tesserae are recorded here. Format loosely follows
   mint a short-lived, single-use firmware registration code through
   `POST /api/app/v1/device-pairings`. Firmware still redeems that code through
   the existing device registration endpoint, so the app never receives a
-  display token. Existing Companion sessions require an explicit operator
-  grant; new pairings include the setup permission.
+  display token. Each Companion session keeps at most one unredeemed code;
+  requesting another invalidates the previous one. Existing Companion sessions
+  require an explicit operator grant; new pairings include the setup permission.
 
 ## [0.316.0], 2026-08-18
 

--- a/app/companion_api.py
+++ b/app/companion_api.py
@@ -566,7 +566,10 @@ def create_device_pairing() -> Any:
     so the app never receives a firmware access token and this route cannot
     directly create a device.
     """
-    record = _firmware_pairings().issue(note=f"Companion: {g.companion.name}"[:64])
+    record = _firmware_pairings().issue(
+        note=f"Companion: {g.companion.name}"[:64],
+        owner_key=f"companion:{g.companion.token_id}",
+    )
     expires_at = datetime.fromtimestamp(record.expires_at, UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
     return jsonify({"code": record.code, "expires_at": expires_at}), 201
 

--- a/app/companion_api.py
+++ b/app/companion_api.py
@@ -146,6 +146,7 @@ _REMINDER_PRIORITIES = frozenset(("none", "low", "medium", "high"))
 # assuming the full set, so unshipped surfaces degrade cleanly.
 FEATURES = (
     "devices",
+    "device_setup",
     "dashboards",
     "dashboard_push",
     "image_push",
@@ -208,6 +209,10 @@ def _tokens() -> CompanionTokenStore:
 
 def _companion_pairings() -> PairingStore:
     return current_app.config["COMPANION_PAIRING_STORE"]  # type: ignore[no-any-return]
+
+
+def _firmware_pairings() -> PairingStore:
+    return current_app.config["PAIRING_STORE"]  # type: ignore[no-any-return]
 
 
 def _devices() -> DeviceRegistry:
@@ -549,6 +554,21 @@ def pair() -> Any:
         "instance": _instance(),
     }
     return jsonify(payload), 201
+
+
+@bp.post("/device-pairings")
+@_require_companion("device_setup:write")
+def create_device_pairing() -> Any:
+    """Mint a registration code for one physically-nearby display.
+
+    Companion passes the code to firmware over its authenticated BLE setup
+    channel. Firmware still redeems it through ``POST /api/v1/device/register``,
+    so the app never receives a firmware access token and this route cannot
+    directly create a device.
+    """
+    record = _firmware_pairings().issue(note=f"Companion: {g.companion.name}"[:64])
+    expires_at = datetime.fromtimestamp(record.expires_at, UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return jsonify({"code": record.code, "expires_at": expires_at}), 201
 
 
 @bp.get("/session")

--- a/app/settings/companion_routes.py
+++ b/app/settings/companion_routes.py
@@ -39,7 +39,7 @@ TESTFLIGHT_URL = "https://testflight.apple.com/join/gjQar3TK"
 # granting a capability rather than editing an ACL.
 SCOPE_LABELS: dict[str, str] = {
     "devices:read": "See your displays",
-    "device_setup:write": "Set up nearby displays",
+    "device_setup:write": "Set up a nearby display",
     "dashboards:read": "See your dashboards",
     "push:write": "Send dashboards to a display",
     "media:write": "Send photos and images",

--- a/app/settings/companion_routes.py
+++ b/app/settings/companion_routes.py
@@ -39,6 +39,7 @@ TESTFLIGHT_URL = "https://testflight.apple.com/join/gjQar3TK"
 # granting a capability rather than editing an ACL.
 SCOPE_LABELS: dict[str, str] = {
     "devices:read": "See your displays",
+    "device_setup:write": "Set up nearby displays",
     "dashboards:read": "See your dashboards",
     "push:write": "Send dashboards to a display",
     "media:write": "Send photos and images",

--- a/app/state/companion_token_store.py
+++ b/app/state/companion_token_store.py
@@ -58,6 +58,11 @@ from typing import Any
 # grant instead (#207).
 COMPANION_SCOPES: tuple[str, ...] = (
     "devices:read",
+    # A newly paired app may mint a short-lived firmware registration code for
+    # a physically-nearby display. It never receives the resulting device
+    # credential. Existing pairings retain their saved scope set and must be
+    # granted this ability explicitly by an operator.
+    "device_setup:write",
     "dashboards:read",
     "push:write",
     "media:write",
@@ -73,16 +78,21 @@ COMPANION_SCOPES: tuple[str, ...] = (
     "gallery:write",
 )
 
-# Scopes an operator can grant to an existing pairing from Settings, on top
-# of the set above. Each one is here because it shouldn't arrive by default:
-# rewriting household scheduling is a different ask from pushing a picture,
-# and a client paired months ago shouldn't silently acquire it because the
-# server upgraded (#207).
+# Scopes an operator can toggle on an existing pairing from Settings. Most do
+# not arrive by default: rewriting household scheduling is a different ask
+# from pushing a picture, and a client paired months ago shouldn't silently
+# acquire it because the server upgraded (#207). ``device_setup:write`` is the
+# exception: new pairings include it so onboarding works immediately, while
+# listing it here lets an operator grant it to old pairings or revoke it.
 # ``offline_albums:write`` is here for the same reason: it changes what a
 # physical display does on its own, with the radio off, for hours at a
 # time, which is a stronger action than putting a photo in a library and a
 # different one from pushing a frame (#230).
-OPTIONAL_SCOPES: tuple[str, ...] = ("lineups:write", "offline_albums:write")
+OPTIONAL_SCOPES: tuple[str, ...] = (
+    "lineups:write",
+    "offline_albums:write",
+    "device_setup:write",
+)
 
 # Every scope this server recognises. A record carrying anything else was
 # either hand-edited or written by a newer build; it's dropped on load
@@ -267,9 +277,9 @@ class CompanionTokenStore:
         Takes effect on the client's next request; the bearer is unchanged,
         so the operator can hand an app a new ability without making the
         user re-pair, and take it back the same way. Only scopes in
-        ``OPTIONAL_SCOPES`` move: the pairing set isn't editable here,
-        because withdrawing it would leave a working app failing in ways
-        the operator didn't intend. Returns whether anything changed."""
+        ``OPTIONAL_SCOPES`` move. Most are additional grants; selected
+        security-sensitive defaults may also be listed so the operator can
+        withdraw them. Returns whether anything changed."""
         if scope not in OPTIONAL_SCOPES:
             return False
         with self._lock:

--- a/app/state/pairing_store.py
+++ b/app/state/pairing_store.py
@@ -44,6 +44,7 @@ class PairingCode:
     issued_at: float
     expires_at: float
     note: str  # human-readable description ("for bedroom Pico"); admin UI only
+    owner_key: str | None = None  # opaque issuer identity; never shown in the UI
 
 
 class PairingStore:
@@ -57,13 +58,24 @@ class PairingStore:
         self._codes: dict[str, PairingCode] = {}
         self._lock = threading.Lock()
 
-    def issue(self, *, note: str = "") -> PairingCode:
+    def issue(self, *, note: str = "", owner_key: str | None = None) -> PairingCode:
         """Mint a fresh code. Returns the new PairingCode; the caller
         shows the ``code`` field to the admin so they can paste it
-        into firmware."""
+        into firmware.
+
+        When ``owner_key`` is supplied, a new code replaces that owner's
+        previous live code. This keeps automated issuers such as one paired
+        Companion session from filling the shared pending-code list while
+        preserving the admin UI's existing ability to issue multiple codes."""
         now = time.time()
         with self._lock:
             self._gc(now)
+            if owner_key is not None:
+                replaced = [
+                    code for code, record in self._codes.items() if record.owner_key == owner_key
+                ]
+                for code in replaced:
+                    self._codes.pop(code, None)
             for _ in range(64):
                 code = self._generate_code()
                 if code not in self._codes:
@@ -72,6 +84,7 @@ class PairingStore:
                         issued_at=now,
                         expires_at=now + self._ttl_s,
                         note=note,
+                        owner_key=owner_key,
                     )
                     self._codes[code] = record
                     return record

--- a/tests/companion/contract/app-v1.openapi.yaml
+++ b/tests/companion/contract/app-v1.openapi.yaml
@@ -80,6 +80,8 @@ paths:
         authenticated BLE; the display redeems it through the existing
         firmware registration endpoint. The code is single-use and never
         grants the Companion access to the resulting firmware credential.
+        Issuing another code invalidates any previous unredeemed code created
+        by the same Companion session.
       responses:
         "201":
           description: Firmware registration code created
@@ -1515,10 +1517,11 @@ components:
       required: [code, expires_at]
       properties:
         code:
-          description: Single-use code accepted by the firmware register endpoint
+          description: >-
+            Single-use code accepted by the firmware register endpoint. Treat
+            this response value as secret and do not write it to logs.
           type: string
           pattern: "^[0-9]{6}$"
-          writeOnly: true
         expires_at:
           type: string
           format: date-time

--- a/tests/companion/contract/app-v1.openapi.yaml
+++ b/tests/companion/contract/app-v1.openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Tesserae Companion API
-  version: 0.13.0
+  version: 0.14.0
   description: >-
     Companion API contract for community-built clients. Previews, History,
     resend, remote-image push, webpage push, and server-advertised image fit
@@ -69,6 +69,28 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "409":
           $ref: "#/components/responses/Conflict"
+  /api/app/v1/device-pairings:
+    post:
+      tags: [Pairing]
+      operationId: createFirmwareDevicePairing
+      summary: Mint a short-lived registration code for one nearby display
+      description: >-
+        Requires the device_setup feature and device_setup:write scope. The
+        Companion passes the returned code to a physically-nearby display over
+        authenticated BLE; the display redeems it through the existing
+        firmware registration endpoint. The code is single-use and never
+        grants the Companion access to the resulting firmware credential.
+      responses:
+        "201":
+          description: Firmware registration code created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FirmwareDevicePairing"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /api/app/v1/session:
     get:
       tags: [Pairing]
@@ -1275,6 +1297,7 @@ components:
             type: string
             enum:
               - devices
+              - device_setup
               - dashboards
               - dashboard_push
               - image_push
@@ -1444,6 +1467,7 @@ components:
             type: string
             enum:
               - devices:read
+              - device_setup:write
               - dashboards:read
               - push:write
               - media:write
@@ -1471,6 +1495,7 @@ components:
             type: string
             enum:
               - devices:read
+              - device_setup:write
               - dashboards:read
               - push:write
               - media:write
@@ -1484,6 +1509,19 @@ components:
         settings_url:
           description: Relative URL for this token's Companion permission settings
           type: string
+    FirmwareDevicePairing:
+      type: object
+      additionalProperties: false
+      required: [code, expires_at]
+      properties:
+        code:
+          description: Single-use code accepted by the firmware register endpoint
+          type: string
+          pattern: "^[0-9]{6}$"
+          writeOnly: true
+        expires_at:
+          type: string
+          format: date-time
     Instance:
       type: object
       additionalProperties: false

--- a/tests/companion/test_companion_api.py
+++ b/tests/companion/test_companion_api.py
@@ -120,6 +120,7 @@ def test_capabilities_probe_is_unauthenticated_and_valid(app: Flask) -> None:
     # covered in test_companion_previews.
     assert set(body["features"]) == {
         "devices",
+        "device_setup",
         "dashboards",
         "dashboard_push",
         "image_push",
@@ -181,6 +182,7 @@ def test_pair_exchanges_code_for_scoped_token(app: Flask) -> None:
     assert body["token"].startswith("tc_live_")
     assert set(body["scopes"]) == {
         "devices:read",
+        "device_setup:write",
         "dashboards:read",
         "push:write",
         "media:write",
@@ -235,6 +237,61 @@ def test_firmware_pairing_code_cannot_mint_a_companion_token(app: Flask) -> None
     resp = _pair(client, firmware_code)
     assert resp.status_code == 400
     assert resp.get_json()["error"]["code"] == "pairing_expired"
+
+
+def test_companion_can_mint_single_use_firmware_pairing_code(app: Flask) -> None:
+    token = _token(app)
+    resp = app.test_client().post(
+        "/api/app/v1/device-pairings",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 201
+    body = resp.get_json()
+    _validate(body, "FirmwareDevicePairing")
+    assert len(body["code"]) == 6
+
+    registered = app.test_client().post(
+        "/api/v1/device/register",
+        headers={"X-Pairing-Code": body["code"], "Content-Type": "application/json"},
+        data=json.dumps(
+            {
+                "device_id": "nearby-display",
+                "kind": "pico_bin_client",
+                "panel_w": 1600,
+                "panel_h": 1200,
+                "fw_version": "1.14.0",
+            }
+        ),
+    )
+    assert registered.status_code == 201
+
+    replay = app.test_client().post(
+        "/api/v1/device/register",
+        headers={"X-Pairing-Code": body["code"], "Content-Type": "application/json"},
+        data=json.dumps(
+            {
+                "device_id": "replay-display",
+                "kind": "pico_bin_client",
+                "panel_w": 1600,
+                "panel_h": 1200,
+                "fw_version": "1.14.0",
+            }
+        ),
+    )
+    assert replay.status_code == 403
+
+
+def test_device_pairing_requires_dedicated_scope(app: Flask) -> None:
+    token = _token(app)
+    record = app.config["COMPANION_TOKENS"].list_active()[0]
+    record.scopes.remove("device_setup:write")
+
+    resp = app.test_client().post(
+        "/api/app/v1/device-pairings",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 403
+    assert resp.get_json()["error"]["code"] == "forbidden"
 
 
 # -- read models ---------------------------------------------------------

--- a/tests/companion/test_companion_api.py
+++ b/tests/companion/test_companion_api.py
@@ -281,10 +281,28 @@ def test_companion_can_mint_single_use_firmware_pairing_code(app: Flask) -> None
     assert replay.status_code == 403
 
 
+def test_companion_reissue_replaces_its_previous_firmware_pairing_code(app: Flask) -> None:
+    token = _token(app)
+    client = app.test_client()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    first = client.post("/api/app/v1/device-pairings", headers=headers)
+    second = client.post("/api/app/v1/device-pairings", headers=headers)
+
+    assert first.status_code == 201
+    assert second.status_code == 201
+    first_code = first.get_json()["code"]
+    second_code = second.get_json()["code"]
+    assert first_code != second_code
+    assert app.config["PAIRING_STORE"].consume(first_code) is None
+    assert app.config["PAIRING_STORE"].consume(second_code) is not None
+
+
 def test_device_pairing_requires_dedicated_scope(app: Flask) -> None:
     token = _token(app)
-    record = app.config["COMPANION_TOKENS"].list_active()[0]
-    record.scopes.remove("device_setup:write")
+    store = app.config["COMPANION_TOKENS"]
+    record = store.list_active()[0]
+    assert store.set_optional_scope(record.token_id, "device_setup:write", granted=False)
 
     resp = app.test_client().post(
         "/api/app/v1/device-pairings",
@@ -292,6 +310,22 @@ def test_device_pairing_requires_dedicated_scope(app: Flask) -> None:
     )
     assert resp.status_code == 403
     assert resp.get_json()["error"]["code"] == "forbidden"
+
+
+def test_existing_pairing_does_not_gain_device_setup_scope_on_load(
+    app: Flask, tmp_path: Path
+) -> None:
+    from app.state.companion_token_store import CompanionTokenStore
+
+    _token(app)
+    path = tmp_path / "core" / "companion_tokens.json"
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    records = raw["tokens"] if isinstance(raw, dict) and "tokens" in raw else raw
+    records[0]["scopes"].remove("device_setup:write")
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+    reloaded = CompanionTokenStore(path).list_active()[0]
+    assert "device_setup:write" not in reloaded.scopes
 
 
 # -- read models ---------------------------------------------------------

--- a/tests/companion/test_contract_fixtures.py
+++ b/tests/companion/test_contract_fixtures.py
@@ -128,6 +128,8 @@ def test_openapi_shape_and_operation_ids_are_stable() -> None:
         if method in {"get", "post", "put", "patch", "delete"}
     ]
     assert len(operation_ids) == len(set(operation_ids))
+    firmware_code = SPEC["components"]["schemas"]["FirmwareDevicePairing"]["properties"]["code"]
+    assert "writeOnly" not in firmware_code
 
 
 @pytest.mark.parametrize(("fixture_name", "schema_name"), CASES.items())

--- a/tests/companion/test_contract_fixtures.py
+++ b/tests/companion/test_contract_fixtures.py
@@ -90,10 +90,11 @@ CASES = {
 
 def test_openapi_shape_and_operation_ids_are_stable() -> None:
     assert SPEC["openapi"] == "3.0.3"
-    assert SPEC["info"]["version"] == "0.13.0"
+    assert SPEC["info"]["version"] == "0.14.0"
     assert set(SPEC["paths"]) == {
         "/api/app/v1",
         "/api/app/v1/pair",
+        "/api/app/v1/device-pairings",
         "/api/app/v1/session",
         "/api/app/v1/personal-data/status",
         "/api/app/v1/personal-data/{source_id}",

--- a/tests/test_pairing_store.py
+++ b/tests/test_pairing_store.py
@@ -21,6 +21,24 @@ def test_issue_two_codes_returns_distinct_values() -> None:
     assert a.code != b.code
 
 
+def test_issue_replaces_the_same_owners_pending_code() -> None:
+    store = PairingStore()
+    first = store.issue(owner_key="companion:one")
+    second = store.issue(owner_key="companion:one")
+
+    assert first.code != second.code
+    assert store.consume(first.code) is None
+    assert [record.code for record in store.list_pending()] == [second.code]
+
+
+def test_issue_keeps_codes_from_different_owners() -> None:
+    store = PairingStore()
+    first = store.issue(owner_key="companion:one")
+    second = store.issue(owner_key="companion:two")
+
+    assert {record.code for record in store.list_pending()} == {first.code, second.code}
+
+
 def test_consume_succeeds_once_then_fails() -> None:
     store = PairingStore()
     record = store.issue()


### PR DESCRIPTION
## Summary

Let an authenticated Companion app mint a short-lived firmware registration
code for a physically nearby display during Bluetooth onboarding.

## What changed

- advertise the additive `device_setup` Companion capability
- add `POST /api/app/v1/device-pairings`, protected by
  `device_setup:write`
- issue a normal firmware pairing code from the existing `PAIRING_STORE`; the
  display still redeems it through `/api/v1/device/register`
- include device setup permission on new Companion pairings without silently
  granting it to existing stored pairings
- let an operator grant or revoke the permission per paired Companion in
  Settings
- update the vendored Companion OpenAPI contract to 0.14.0
- cover authorization, registration, and single-use replay rejection

## Why

The Companion should not receive or manufacture a display access token. This
keeps the existing firmware registration boundary intact: the app requests an
ephemeral code, transfers it locally over authenticated BLE, and the display
redeems it directly with Tesserae.

## Security properties

- requires an authenticated Companion bearer with a dedicated scope
- firmware pairing codes remain short-lived and single-use
- Companion and firmware pairing stores remain separate
- the app never receives the resulting firmware credential
- existing Companion sessions do not gain the new permission on server upgrade

## Validation

- `pytest tests/companion/test_companion_api.py tests/companion/test_contract_fixtures.py tests/test_page_routes.py -q` — 187 passed
- `ruff check` on changed Python files
- `ruff format --check` on changed Python files
- `mypy app` — 189 source files passed
- `git diff --check`

## Related firmware

- dmellok/tesserae-device-firmware#11
