### PR TITLE
Add Seeed Sticky mono and grayscale SKUs

### DIFF
--- a/hardware/seeed/sticky.json
+++ b/hardware/seeed/sticky.json
@@ -1,0 +1,21 @@
+{
+  "tesserae_compat": "1.x",
+  "id": "seeed_sticky",
+  "name": "Seeed Sticky",
+  "vendor": "Seeed Studio",
+  "icon": "device-tablet",
+  "description": "3.97 inch monochrome ePaper reader, ESP32-S3, 800x480 panel composed portrait (480x800 presentation). Speaks Tesserae's v1 REST device API when running CrossInk firmware with Tesserae client support: the dashboard is painted as the reader's sleep screen on an explicit sleep transition, so the radio never comes up on a timer. Server-side pack via esp32_bw_bin produces a raw 1-bpp mono buffer (48000 bytes) that is byte-identical to the firmware's framebuffer and is painted with no on-device decode.",
+  "protocol": "esp32_bw_client",
+  "panel": {
+    "w": 480,
+    "h": 800,
+    "orientation": "portrait_flipped",
+    "name": "3.97 inch monochrome ePaper (800x480 native)",
+    "gamut": "mono",
+    "native_w": 800,
+    "native_h": 480
+  },
+  "refresh_floor_s": 60,
+  "image_format": "bin",
+  "notes_md": "**Not yet confirmed on hardware.** Contributed alongside CrossInk's Sticky board support, which is itself derived from the V01 schematic and Seeed's vendor peripheral demo rather than from a validated unit. Treat the orientation as provisional until someone reports back from a real device.\n\nWire format is exactly 48000 bytes (800*480/8), MSB=leftmost pixel, bit-set=white, bit-clear=black; no header, no padding, no checksum. The panel is the same 800x480 SSD1677 used by the Xteink X4 and de-link, and CrossInk drives all three through the same framebuffer path, so the packed frame is byte-identical to `xteink_x4`.\n\n`orientation` is inherited from `xteink_x4` on that basis: CrossInk's Portrait transform is board-independent, and both boards ship the same `NO_FLIP` panel-mount setting, so the same 180-degree offset from the renderer's default should apply. CrossInk's own board profile flags the Sticky's mount transform as pending hardware validation. If a unit paints upside-down, the fix is `portrait` here, and it likely means upstream needs `ROTATE_180` in the board profile too.\n\nSee `seeed_sticky_gray` for the 4-level grayscale variant of the same panel."
+}

--- a/hardware/seeed/sticky_gray.json
+++ b/hardware/seeed/sticky_gray.json
@@ -1,0 +1,24 @@
+{
+  "tesserae_compat": "1.x",
+  "id": "seeed_sticky_gray",
+  "name": "Seeed Sticky (4-level grayscale)",
+  "vendor": "Seeed Studio",
+  "icon": "device-tablet",
+  "description": "Seeed Sticky driven in its 4-level grayscale mode rather than pure 1-bit mono. Same 800x480 panel composed portrait (480x800 presentation) and the same CrossInk sleep-screen client as seeed_sticky, but the server packs a 2-bpp buffer (96000 bytes) via esp32_gray2_bin and the firmware composites it as a base frame plus two grayscale planes. Pick this over seeed_sticky when the dashboard has photos or shading; stay on seeed_sticky for text and line art, where the extra levels buy little and the frame is half the size.",
+  "protocol": "esp32_bw_client",
+  "panel": {
+    "w": 480,
+    "h": 800,
+    "orientation": "portrait_flipped",
+    "name": "3.97 inch ePaper, 4-level grayscale (800x480 native)",
+    "gamut": "gray_4",
+    "native_w": 800,
+    "native_h": 480
+  },
+  "renderers": [
+    "esp32_gray2_bin"
+  ],
+  "refresh_floor_s": 60,
+  "image_format": "bin",
+  "notes_md": "**Not yet confirmed on hardware.** Grayscale sibling of `seeed_sticky`, and it carries the same caveat: CrossInk's Sticky board support is derived from the V01 schematic and Seeed's vendor demo rather than from a validated unit, so the orientation here is provisional.\n\nMirrors the `xteink_x4_gray` pattern: same `esp32_bw_client` protocol and panel block as the mono entry, with the renderer overridden to `esp32_gray2_bin`.\n\nWire format is exactly 96000 bytes (800*480/4), 4 px/byte, MSB-first, `0b00` black to `0b11` white, linear. That packing and those level semantics match CrossInk's own 2-bpp bitmap reader byte for byte, so the firmware expands the frame straight into its `GRAYSCALE_LSB` / `GRAYSCALE_MSB` planes with no decode: LSB set where the level is 1, MSB set where it is 1 or 2, and the base frame white only where the level is 3.\n\nThe Sticky's SSD1677 is the same controller CrossInk drives in grayscale on the X4, and the firmware reports grayscale capability for this board, so the three-pass composite should behave as it does there.\n\nCosts relative to `seeed_sticky`: double the download per refresh, and three panel passes instead of one (base frame plus two planes), so a noticeably longer sleep-entry paint on battery. Choose the mono entry for text and line art, this one for photos and shading."
+}


### PR DESCRIPTION
Adds `seeed_sticky` and `seeed_sticky_gray` to the catalog.

CrossInk gained Seeed Sticky board support, and the Tesserae client in my CrossInk fork now announces itself as `seeed_sticky` / `seeed_sticky_gray` instead of reusing the Xteink X4 kind. Without these entries that pairing has nowhere to land.

### Why it mirrors the X4 pair

The Sticky is the same 800x480 SSD1677 panel as `xteink_x4` and de-link, and CrossInk drives all three through one framebuffer path. The packed frame is byte-identical to the X4's:

- mono: 48000 bytes (800*480/8), MSB-first, bit-set = white
- grayscale: 96000 bytes (800*480/4), MSB-first, `0b00` black to `0b11` white

So both entries are the `xteink_x4` / `xteink_x4_gray` pair with the panel description swapped, and the gray one overriding `renderers` to `esp32_gray2_bin`.

### Not hardware-confirmed, and the notes say so

CrossInk's Sticky board profile is derived from the V01 schematic and Seeed's vendor peripheral demo rather than from a validated unit, and it explicitly flags the panel mount transform as pending validation. I have flashed a unit but have not yet confirmed what it paints.

`portrait_flipped` is inherited from `xteink_x4` on the reasoning that CrossInk's Portrait transform is board-independent and both board profiles ship the same `NO_FLIP` mount setting, so the same 180-degree offset from the renderer default should apply. If a real unit paints upside-down, the fix is `portrait` here, and it probably means upstream CrossInk needs `ROTATE_180` in the board profile too. Both `notes_md` blocks lead with that caveat so nobody reads these as validated.

`url` is omitted rather than guessed at, since I could not confirm a product page.

### Verification

- Both files validate against `schema/hardware.schema.json`
- `pytest tests/test_hardware_catalog.py tests/test_manifest.py tests/test_manifest_stability.py` - 35 passed