### PR TITLE
docs(widgets): document RENDER_SAFE_ENDPOINTS for plugins serving their own media

### DIFF
--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -315,6 +315,46 @@ keeps Flask from colliding with the host's `templates/index.html`).
 Extend `_base.html` for visual consistency with the rest of the
 admin UI; the `card_head` macro + `card` class wrap content.
 
+### Serving your own media, `RENDER_SAFE_ENDPOINTS`
+
+Blueprint routes sit behind the password gate. A render happens over
+loopback with no session, so a widget whose markup points at its own
+plugin route — an `<img src>` handed to the panel, say — needs that
+route reachable during the render, or every panel shows a broken image
+while the browser preview looks fine.
+
+A plugin declares such routes by name:
+
+```python
+# plugins/<id>/server.py
+RENDER_SAFE_ENDPOINTS: tuple[str, ...] = (
+    "picture_gallery_admin.serve_image",
+    "picture_gallery_admin.serve_thumbnail",
+)
+```
+
+The loader collects these into `app.config["RENDER_SAFE_ENDPOINTS"]` and
+`app/auth.py` consults them. `picture_gallery` is the in-tree example.
+
+**Read-only, always.** Anything that writes, deletes, or reaches the
+network does not belong in this list. The routes found when this was
+tightened were mutations — `shutil.rmtree` on a gallery folder, calendar
+feed writes, CalDAV discovery against a caller-supplied URL — and those
+stay gated. Reviewing the list is part of reviewing a plugin.
+
+**You may not need it.** A loopback `GET`/`HEAD` of a plugin's own
+sub-route already passes without a declaration. What that rule does not
+cover, and a declaration does:
+
+- the plugin **index** (`/plugins/<id>/`) stays gated even on a read, since
+  it lists loader errors and plugin contents
+- routes outside the `/plugins/<id>/…` prefix
+- being explicit, so the requirement survives someone tightening the gate
+  later
+
+Declaring a route you serve media from is the safer default even where the
+sub-route rule would carry it today.
+
 ---
 
 ## `client.js` contract


### PR DESCRIPTION
Closes #253.

Adds a `Serving your own media, RENDER_SAFE_ENDPOINTS` section to `docs/widgets.md`, directly after the `blueprint()` contract as the issue asks. Covers the three points requested: what the declaration is for, that it is opt-in and must stay read-only, and that reviewing the list is part of reviewing a plugin.

## One addition beyond the issue

The issue frames the declaration as the thing standing between a widget and broken images. Reading `app/auth.py`, that is no longer the whole picture — `_path_is_loopback_only` grants a loopback `GET`/`HEAD` of a plugin's **own sub-route** without any declaration (rule 3, added in #255).

So documenting only "declare it or your images break" would have been wrong for the common case. Instead the section says the declaration may not be needed, and names what the sub-route rule does *not* cover:

- the plugin **index** (`/plugins/<id>/`), which stays gated even on a read (#221)
- routes outside the `/plugins/<id>/…` prefix
- being explicit, so the requirement survives a later tightening of the gate

with the recommendation to declare media routes anyway.

Each of those claims is pinned by a test already in the tree, which is how I checked them rather than reasoning from the code:

| claim | test |
|---|---|
| GET of an own sub-route passes with `frozenset()` | `test_a_plugin_can_serve_its_own_media_to_the_renderer` |
| plugin index refused even on a read | `test_a_plugin_index_is_still_refused_even_on_a_read` |
| writes refused regardless | `test_a_write_to_a_plugin_route_is_still_refused` |

The read-only warning uses the concrete examples from `auth.py`'s own docstring (`shutil.rmtree` on a gallery folder, calendar feed writes, CalDAV discovery), so the docs and the rationale in the code say the same thing.

Documentation only — no code touched.
