### PR TITLE
feat(widgets): added translation system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are
 [SemVer](https://semver.org/) (pre-1.0, so minors can carry breaking changes).
 
+## [Unreleased]
+
+### Added
+
+- **Widgets can now be translated into other languages, starting with Calendar Day in French.**
+  Widget authors can add a translation for their widget's on-screen text; Tesserae shows the
+  right language automatically. A widget with no translation yet keeps working exactly as
+  before, in English.
+- **You can now choose what language your dashboards display in.** Set one default for the
+  whole install under Settings → Server, or give an individual panel its own language under Settings → Devices.
+
 ## [0.364.4], 2026-08-25
 
 ### Fixed

--- a/app/composer.py
+++ b/app/composer.py
@@ -36,6 +36,7 @@ from werkzeug.wrappers import Response as WerkzeugResponse
 
 from app import widget_next_change
 from app.bindings import apply_binding
+from app.locale_resolve import resolve_locale
 from app.panel import PANEL_PRESETS, resolve_panel_for_page
 from app.plugin_http import fetch_json
 from app.plugin_loader import Font, PluginRegistry
@@ -71,6 +72,29 @@ def clamp_screenshot_dim(value: int) -> int:
 def _registry() -> PluginRegistry:
     registry: PluginRegistry = current_app.config["PLUGIN_REGISTRY"]
     return registry
+
+
+def _resolve_locale_for_device_id(device_id: str) -> str:
+    """Effective locale for a render targeting ``device_id`` (possibly
+    ``""``, meaning no bound device -- a non-push preview): the
+    device's own override if it has one, else the app-wide default.
+    Shared by the grid path (``_resolve_page_locale``) and the canvas
+    path (``_build_canvas_els``), the two places a render actually
+    knows which device it's for."""
+    store = current_app.config.get("SETTINGS_STORE")
+    app_section = store.get_section("app") or {} if store is not None else {}
+    devices = current_app.config.get("DEVICE_REGISTRY")
+    device = devices.devices.get(device_id) if devices is not None and device_id else None
+    return resolve_locale(app_section, device)
+
+
+def _resolve_page_locale(page_dict: dict[str, Any]) -> str:
+    """Effective locale for this render: the page's ``target_device_id``
+    (already resolved by ``compose()`` before ``_hydrate_page`` runs, see
+    ``_preview_target_device`` / the explicit ``?device_id=``) if bound
+    to a real device, else the app-wide default. One call per page, not
+    per cell -- every widget on a page renders in the same locale."""
+    return _resolve_locale_for_device_id(str(page_dict.get("target_device_id") or ""))
 
 
 def _app_location_dict() -> dict[str, Any] | None:
@@ -739,6 +763,7 @@ def _hydrate_page(
 ) -> dict[str, Any]:
     """Resolve options, fonts, server-side data, and visual layout."""
     registry = _registry()
+    locale = _resolve_page_locale(page_dict)
     page_font = _resolve_font(page_dict.get("font"), registry)
     page_font_family = page_font.name if page_font else "system-ui"
     # Default to ``light`` when no per-page override is set so the
@@ -885,6 +910,7 @@ def _hydrate_page(
     for idx, meta in enumerate(cells_meta):
         cell = meta["cell"]
         plugin_id = meta["plugin_id"]
+        plugin = registry.get(plugin_id) if plugin_id else None
         cells_out.append(
             {
                 **cell,
@@ -897,6 +923,13 @@ def _hydrate_page(
                 "data": data_by_cell_index.get(idx),
                 "font_family": meta["font_family"],
                 "full_bleed": meta["full_bleed"],
+                # Locales contract (see docs/widgets.md#locales-strings):
+                # every cell renders in the same page-level locale, and
+                # gets its own widget's resolved strings map, {} for a
+                # widget that hasn't opted into ``locales`` -- ctx.t()
+                # then falls through to client.js's own hardcoded text.
+                "locale": locale,
+                "strings": plugin.strings_for(locale) if plugin else {},
                 # Touch attributes (issue #49): stamped on the cell
                 # container so the render-time extractor picks the whole
                 # cell up as a region. Cell override wins over the
@@ -913,6 +946,7 @@ def _hydrate_page(
         "font_family": page_font_family,
         "font_face_css": _font_face_css(registry.fonts),
         "corner_radius": corner_radius,
+        "locale": locale,
     }
 
 
@@ -982,6 +1016,12 @@ def _build_canvas_els(
     paint: a widget that advances state per render should move for the panel,
     not for someone opening the editor (#209)."""
     from app.widget_samples import get_sample
+
+    # Locales contract (docs/widgets.md#locales-strings): one locale for
+    # every widget element on this canvas, same "resolve once, not per
+    # element" rule the grid path follows.
+    locale = _resolve_locale_for_device_id(target_device_id)
+    registry = _registry()
 
     # Dedupe fetches across elements that resolve to the same widget +
     # options: a canvas often has several data primitives (temp, humidity,
@@ -1220,12 +1260,16 @@ def _build_canvas_els(
             "options": {},
             "data": None,
             "data_source": "none",
+            "locale": locale,
+            "strings": {},
         }
         if e.widget:
             opts, data, wsrc = _resolve_source(e.widget, e.options, e.w, e.h)
             item["options"] = opts
             item["data"] = data
             item["data_source"] = wsrc
+            plugin = registry.get(e.widget)
+            item["strings"] = plugin.strings_for(locale) if plugin else {}
         _apply_binds(e, item)
         _stamp_touch(item, e)
         els_out.append(item)
@@ -1298,6 +1342,7 @@ def _render_canvas(
         theme=layout.theme or "light",
         style=layout.style or "standard",
         font_family=font.name if font else "system-ui, sans-serif",
+        locale=_resolve_locale_for_device_id(target_device_id),
         bg=layout.bg or "",
         bg_image=layout.bg_image or "",
         bg_fit=layout.bg_fit or "cover",

--- a/app/device_loader.py
+++ b/app/device_loader.py
@@ -198,6 +198,19 @@ class Device:
                 out[stride_key] = value
         return out
 
+    @property
+    def locale(self) -> str | None:
+        """This device's own locale override, or ``None`` if it doesn't
+        declare one. An instance's manifest is a copy of its kind's
+        manifest with per-instance fields layered on (see
+        ``load_instance_file``), so this reads correctly for both —
+        an instance's own ``locale`` wins, falling through to the
+        kind's if the instance didn't set one. ``None`` here means
+        "defer to the app-wide default", resolved by
+        ``app.locale_resolve.resolve_locale``."""
+        value = self.manifest.get("locale")
+        return str(value) if isinstance(value, str) and value.strip() else None
+
     def parse_status(self, payload: bytes) -> dict[str, Any]:
         """Normalise a heartbeat payload. Falls back to ``{"raw": ...}`` if
         the device's parser raises so the UI still has something to show."""
@@ -572,6 +585,9 @@ def load_instance_file(
     # device on incoming /api/display requests.
     if isinstance(raw_inst.get("access_token"), str) and raw_inst["access_token"].strip():
         inst_manifest["access_token"] = raw_inst["access_token"].strip()
+    # Per-device locale override (see app.locale_resolve).
+    if isinstance(raw_inst.get("locale"), str) and raw_inst["locale"].strip():
+        inst_manifest["locale"] = raw_inst["locale"].strip()
     # Per-panel cloud-relay frame key (base64url of the 32-byte X25519+HKDF
     # shared secret, set at rendezvous pairing). Carried through so
     # app.relay_publisher can seal each frame for a transport="relay" device.

--- a/app/device_service.py
+++ b/app/device_service.py
@@ -1118,6 +1118,49 @@ def update_instance_quiet_hours(
     return InstanceResult(reloaded)
 
 
+def update_instance_locale(
+    *,
+    devices: DeviceRegistry,
+    renderers: RendererRegistry,
+    data_root: Path,
+    instance_id: str,
+    locale: str | None,
+) -> InstanceResult:
+    """Patch a registered instance's ``locale`` field on disk and
+    hot-reload it in place. A blank value clears the override so the
+    device falls back to the app-wide default on next reload (see
+    app.locale_resolve.resolve_locale). Not format-validated here, same
+    trade-off update_instance_quiet_hours already accepts for HH:MM: a
+    malformed value just fails to match any of the widget's strings at
+    read time and the panel renders in English, rather than a write-time
+    rejection the admin has to puzzle out."""
+    device = devices.get(instance_id)
+    if device is None or device.kind_of is None:
+        return InstanceResult(None, f"Unknown device {instance_id!r}.")
+
+    inst_file = device.path
+    try:
+        raw = json.loads(inst_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as err:
+        return InstanceResult(None, f"Couldn't read {inst_file.name}: {err}")
+
+    clean_locale = (locale or "").strip()
+    if not clean_locale:
+        raw.pop("locale", None)
+    else:
+        raw["locale"] = clean_locale
+    inst_file.write_text(json.dumps(raw, indent=2) + "\n", encoding="utf-8")
+
+    devices.devices.pop(instance_id, None)
+    _drop_clones(renderers, instance_id)
+    reloaded = load_instance_file(devices, inst_file=inst_file, data_root=data_root)
+    if reloaded is None:
+        last_err = devices.errors[-1] if devices.errors else None
+        return InstanceResult(None, last_err.message if last_err else "unknown error")
+    clone_for_instances(renderers, devices)
+    return InstanceResult(reloaded)
+
+
 def update_instance_battery_offset(
     *,
     devices: DeviceRegistry,

--- a/app/locale_resolve.py
+++ b/app/locale_resolve.py
@@ -1,0 +1,88 @@
+"""Locale resolution: per-device override + a single app-level default.
+
+Two layers, same shape as ``app.quiet_hours``:
+
+* **App-level** (Settings -> Server -> App): the default locale for the
+  whole install, ``settings.app.locale``.
+* **Per-device override** (an instance or kind's ``locale`` field): a
+  panel in a different room -- or a different household member's desk
+  -- can render in its own language off one server. This is the "German
+  kitchen panel, English office panel" case the plugin locales contract
+  exists for.
+
+``resolve_locale`` is a pure function like ``resolve_quiet_hours``: it
+takes a plain settings dict and a duck-typed device (anything with a
+``.manifest`` dict, so tests can pass a ``SimpleNamespace`` instead of
+a real ``Device``), never touches ``current_app`` itself. Callers reach
+it the same way they reach quiet hours: ``resolve_locale(settings_store
+.get_section("app") or {}, device)``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+DEFAULT_LOCALE = "en"
+
+# POSIX locale env vars, most to least specific, matching the order a
+# libc locale lookup itself would use. "C" / "POSIX" mean "no locale
+# configured", not "render in a language called C", so they're skipped
+# rather than returned.
+_LOCALE_ENV_VARS: tuple[str, ...] = ("LC_ALL", "LANG")
+
+
+def _device_locale(device: Any | None) -> str | None:
+    """Pull a ``locale`` string off a Device-like object, or ``None``.
+
+    Reads ``.manifest`` rather than a ``Device.locale`` property so
+    this module stays decoupled from ``app.device_loader`` (same
+    reasoning as ``app.quiet_hours._device_override``) and so tests
+    can pass a bare ``SimpleNamespace(manifest={...})``."""
+    if device is None:
+        return None
+    manifest = getattr(device, "manifest", None)
+    if isinstance(manifest, dict):
+        value = manifest.get("locale")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _system_locale() -> str | None:
+    """Best-effort host locale from the standard POSIX env vars,
+    normalised to a BCP-47-ish tag (``fr_FR.UTF-8`` -> ``fr-FR``).
+
+    Deliberately not ``locale.getdefaultlocale()`` (deprecated since
+    3.11, removed in 3.13) -- reading the env vars directly is the
+    same technique ``app.tz_resolve`` already uses for ``TZ``, and
+    keeps this module free of a stdlib API on its way out."""
+    for var in _LOCALE_ENV_VARS:
+        raw = os.environ.get(var, "").strip()
+        if not raw or raw.upper() in ("C", "POSIX"):
+            continue
+        tag = raw.split(".", 1)[0].replace("_", "-")  # drop ".UTF-8", "_" -> "-"
+        if tag:
+            return tag
+    return None
+
+
+def resolve_locale(app_settings: dict[str, Any], device: Any | None = None) -> str:
+    """Effective locale for rendering ``device``'s pages.
+
+    Resolution order:
+
+    1. Per-device override (``device.manifest["locale"]``), when set.
+    2. App-level ``settings.app.locale``, when set and not ``"system"``.
+    3. ``"system"`` (or app-level unset) -> the host's own locale via
+       ``LC_ALL`` / ``LANG``.
+    4. ``"en"``, the ultimate fallback so callers always get a
+       non-empty, renderable tag.
+    """
+    override = _device_locale(device)
+    if override:
+        return override
+    raw = str(app_settings.get("locale") or "system").strip()
+    if raw and raw.lower() != "system":
+        return raw
+    return _system_locale() or DEFAULT_LOCALE

--- a/app/panels_routes.py
+++ b/app/panels_routes.py
@@ -42,6 +42,7 @@ from pydantic import ValidationError
 from werkzeug.wrappers import Response
 
 from app import experiments
+from app.locale_resolve import resolve_locale
 from app.panels_schema import build_catalog
 from app.plugin_loader import PluginRegistry
 from app.state.page_store import Page, PageStore
@@ -65,6 +66,17 @@ def _guard() -> None:
 def _registry() -> PluginRegistry:
     registry: PluginRegistry = current_app.config["PLUGIN_REGISTRY"]
     return registry
+
+
+def _editor_locale() -> str:
+    """Locale the editor's live preview renders widget text in. The
+    preview isn't for any particular device (it's a look at the
+    design, not a paint -- see composer.py's own preview/paint
+    distinction), so it always resolves the app-wide default rather
+    than any one device's override."""
+    store = current_app.config.get("SETTINGS_STORE")
+    app_section = store.get_section("app") or {} if store is not None else {}
+    return resolve_locale(app_section, None)
 
 
 def _pages() -> PageStore:
@@ -661,7 +673,14 @@ def catalog() -> Response:
     canvas appearance options (themes / styles / fonts) the editor's pickers
     consume."""
     _guard()
-    return jsonify({"widgets": build_catalog(_registry()), "appearance": _appearance()})
+    locale = _editor_locale()
+    return jsonify(
+        {
+            "widgets": build_catalog(_registry(), locale),
+            "appearance": _appearance(),
+            "locale": locale,
+        }
+    )
 
 
 @bp.post("/data.json")

--- a/app/panels_schema.py
+++ b/app/panels_schema.py
@@ -8,7 +8,7 @@ palette can list a widget and expand it to its parts.
 
 The catalog entry the editor consumes is
 ``{key, name, icon, desc, fragments:[...], updates_on_change,
-updates_on_schedule}``.
+updates_on_schedule, strings}``.
 
 mypy --strict does not apply here; see pyproject.toml.
 """
@@ -65,9 +65,14 @@ def _preview_sample(plugin: Plugin) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
-def catalog_entry(plugin: Plugin) -> dict[str, Any]:
-    """Catalog entry for a placeable widget: identity, fragments, and a preview
-    sample for the editor's live mount."""
+def catalog_entry(plugin: Plugin, locale: str = "en") -> dict[str, Any]:
+    """Catalog entry for a placeable widget: identity, fragments, a preview
+    sample for the editor's live mount, and this widget's resolved strings
+    for ``locale`` ({} for a widget that hasn't declared any locales --
+    see Plugin.strings_for). The editor's live preview isn't rendering
+    for any particular device, so it always uses the app-wide default
+    locale (composer.py's ``_resolve_locale_for_device_id("")``), same
+    as an unbound grid/canvas preview."""
     return {
         "key": plugin.id,
         "name": plugin.name,
@@ -82,12 +87,13 @@ def catalog_entry(plugin: Plugin) -> dict[str, Any]:
             and plugin.manifest["updates"].get("on_change")
         ),
         "updates_on_schedule": [dict(spec) for spec in plugin.on_schedule_updates],
+        "strings": plugin.strings_for(locale),
     }
 
 
-def build_catalog(registry: PluginRegistry) -> list[dict[str, Any]]:
+def build_catalog(registry: PluginRegistry, locale: str = "en") -> list[dict[str, Any]]:
     """Assemble the editor's widget palette: every renderable widget plugin
     (kind ``widget``), each with its fragments, sorted by display name."""
-    entries = [catalog_entry(p) for p in registry.widgets()]
+    entries = [catalog_entry(p, locale) for p in registry.widgets()]
     entries.sort(key=lambda e: str(e["name"]).lower())
     return entries

--- a/app/plugin_loader.py
+++ b/app/plugin_loader.py
@@ -124,6 +124,10 @@ class Plugin:
     # block (or an undeclared snapshot when the field is absent).
     # See app/capabilities.py for the enforcement layer.
     capabilities: Capabilities | None = None
+    # locale -> {key: translated text}, empty for a widget that hasn't
+    # opted into the locales contract, so strings_for() always degrades
+    # to the widget's own hardcoded text.
+    strings: dict[str, dict[str, str]] = field(default_factory=dict)
 
     @property
     def kind(self) -> str:
@@ -156,6 +160,28 @@ class Plugin:
             if value in ("strict", "extended"):
                 return str(value)
         return "strict"
+
+    def strings_for(self, locale: str) -> dict[str, str]:
+        """Resolved ``{key: text}`` map for ``locale``, or ``{}`` for a
+        widget that hasn't declared any (the common case today — its
+        ``client.js`` keeps its own hardcoded text and ``ctx.t()``
+        degrades to returning the key/fallback text unchanged).
+
+        Falls back in three steps so a caller doesn't need to know
+        which locales a widget actually ships: exact tag (``fr-CA``),
+        then base language (``fr``), then ``"en"`` — every widget's
+        hardcoded fallback text is English, so that's the one locale
+        ``strings_for`` can always assume exists rather than guess at
+        a per-widget default. A locale a widget genuinely has no
+        strings for still renders — in English — rather than blank."""
+        if not self.strings:
+            return {}
+        if locale in self.strings:
+            return self.strings[locale]
+        base = locale.split("-", 1)[0]
+        if base in self.strings:
+            return self.strings[base]
+        return self.strings.get("en", {})
 
     @property
     def on_change_updates(self) -> list[dict[str, str]]:
@@ -421,6 +447,38 @@ def _scan_plugin_dir(
             capabilities=_parse_capabilities(plugin_id, manifest.get("requires")),
         )
         registry.plugins[plugin_id] = plugin
+
+        for raw_locale in manifest.get("locales", []):
+            locale = str(raw_locale)
+            strings_path = child / "strings" / f"{locale}.json"
+            try:
+                raw_strings = json.loads(strings_path.read_text(encoding="utf-8"))
+            except FileNotFoundError:
+                registry.errors.append(
+                    LoaderError(
+                        plugin_id,
+                        child,
+                        f"locales declares {locale!r} but strings/{locale}.json is missing",
+                    )
+                )
+                continue
+            except (json.JSONDecodeError, OSError) as err:
+                registry.errors.append(
+                    LoaderError(plugin_id, child, f"strings/{locale}.json invalid: {err}")
+                )
+                continue
+            if not isinstance(raw_strings, dict) or not all(
+                isinstance(k, str) and isinstance(v, str) for k, v in raw_strings.items()
+            ):
+                registry.errors.append(
+                    LoaderError(
+                        plugin_id,
+                        child,
+                        f"strings/{locale}.json must be a flat {{string: string}} map",
+                    )
+                )
+                continue
+            plugin.strings[locale] = {str(k): str(v) for k, v in raw_strings.items()}
 
         if plugin.kind == "font":
             for raw_font in manifest.get("fonts", []):

--- a/app/plugin_loader.py
+++ b/app/plugin_loader.py
@@ -50,6 +50,12 @@ _ALLOWED_ASSET_PREFIXES: tuple[str, ...] = ("static/", "files/")
 
 _COMPAT_RE = re.compile(r"^(\d+)\.(x|\d+)")
 
+# Matches schema/plugin.schema.json's `locales` item pattern exactly.
+# This is the point that turns the value into a
+# filename, so it validates again right before that happens instead
+# of relying on a caller having gone through jsonschema first.
+_LOCALE_TAG_RE = re.compile(r"^[a-z]{2,3}(-[A-Z]{2})?\Z")
+
 
 # A folder skipped because an earlier scan root already claimed its id.
 # Shared with the Widgets page, which offers to delete the shadowed copy,
@@ -450,6 +456,13 @@ def _scan_plugin_dir(
 
         for raw_locale in manifest.get("locales", []):
             locale = str(raw_locale)
+            if not _LOCALE_TAG_RE.match(locale):
+                registry.errors.append(
+                    LoaderError(
+                        plugin_id, child, f"locales entry {locale!r} is not a valid locale tag"
+                    )
+                )
+                continue
             strings_path = child / "strings" / f"{locale}.json"
             try:
                 raw_strings = json.loads(strings_path.read_text(encoding="utf-8"))

--- a/app/settings/devices_routes.py
+++ b/app/settings/devices_routes.py
@@ -1367,6 +1367,24 @@ def devices_update_combined(instance_id: str) -> Response:
                     ok_messages.append("button map saved")
                     any_change = True
 
+    # 7. Per-device locale override (see app.locale_resolve). Blank
+    # clears the override so this device falls back to the app-wide
+    # default; a select rather than free text, so this is really "pick
+    # one of the locales we know about" not "type a BCP-47 tag".
+    if "locale" in form:
+        locale_result = device_service.update_instance_locale(
+            devices=devices_registry,
+            renderers=renderers(),
+            data_root=device_data_root(),
+            instance_id=instance_id,
+            locale=form.get("locale"),
+        )
+        if not locale_result.ok:
+            flash(locale_result.error or "Couldn't save locale.", "error")
+        else:
+            ok_messages.append("locale saved")
+            any_change = True
+
     if any_change:
         rebuild_transport_fn()()
         if device.transport == "relay":

--- a/app/settings/field_defs.py
+++ b/app/settings/field_defs.py
@@ -90,6 +90,30 @@ APP_FIELDS: list[dict[str, Any]] = [
         ),
     },
     {
+        # See app.locale_resolve.resolve_locale: this is the fallback a
+        # device's own locale override (Settings -> Devices, General
+        # tab) reads when it's set to "Use app default". 'system'
+        # mirrors the timezone field above exactly, both in the
+        # sentinel value and in what it means (ask the host OS).
+        "name": "locale",
+        "type": "select",
+        "label": "Panel text language",
+        "default": "system",
+        "group": "location",
+        "choices": [
+            {"value": "system", "label": "System (host language)"},
+            {"value": "en", "label": "English"},
+            {"value": "fr", "label": "Français"},
+        ],
+        "help": (
+            "Default language widgets render their panel text in, for every "
+            "device that hasn't set its own override on Settings → Devices. "
+            "'System' uses this server's own OS language. Only widgets that "
+            "ship a translation for the picked language actually change; "
+            "others keep rendering their built-in English text."
+        ),
+    },
+    {
         # v0.69.6 (issue #52 item 5): app-level location picker replaces
         # the flat lat/lon pair below. Stores the same
         # ``{latitude, longitude, name}`` dict that per-cell widget
@@ -329,7 +353,7 @@ APP_FIELD_GROUPS: list[dict[str, Any]] = [
     {
         "id": "location",
         "title": "Location & time",
-        "description": "Default coordinates for weather widgets and the scheduler's timezone.",
+        "description": "Default coordinates for weather widgets, the scheduler's timezone, and the default panel text language.",
         "icon": "compass",
         "master": None,
     },

--- a/app/settings/index_routes.py
+++ b/app/settings/index_routes.py
@@ -1177,6 +1177,15 @@ def _build_sections() -> list[dict[str, Any]]:
                     if is_instance
                     else None
                 ),
+                # Per-device locale override (see app.locale_resolve).
+                # Instances-only, same reasoning as quiet_hours /
+                # battery_offset above: a kind's own manifest isn't
+                # editable through this UI. Saved through the combined
+                # form (no dedicated AJAX endpoint -- unlike quiet hours
+                # / battery offset this isn't a dependent-field group,
+                # just one select).
+                "locale": (device.manifest.get("locale") or "" if is_instance else ""),
+                "locale_editable": is_instance,
                 # Per-device button map (physical button wakes). The
                 # textarea shows the stored per-device override (empty
                 # when nothing is set); the "effective map" fold-out

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -397,6 +397,9 @@ export default async function render(shadow, ctx) {
     weight: 400
   },
   data: { ... } | null,    // server.py fetch() result, if present
+  locale: "fr",            // active locale for this render, see "Locales & strings" below
+  strings: { ... },        // this widget's resolved strings for `locale`, {} if untranslated
+  t(key, fallback) { ... },// strings[key] ?? fallback ?? key
   preview: false           // true when rendered in the editor iframe
 }
 ```
@@ -416,6 +419,53 @@ resolved colour strings.
   animations, CSS transitions, requestAnimationFrame loops.
 * **Error path**: if `ctx.data?.error` is set (server.py raised),
   render a small error card with `ph-warning-circle` and the message.
+
+### Locales & strings
+
+Optional. A widget with no `locales` in its manifest renders exactly as
+before this existed: `ctx.locale` and `ctx.strings` are still present,
+but `ctx.strings` is `{}`, so `ctx.t(key, fallback)` always returns
+`fallback` (or `key` if you omit it). There's no reason to touch
+`client.js` at all unless you want the widget's panel text to actually
+translate.
+
+To opt in:
+
+```json
+// plugin.json
+"locales": ["en", "fr"]
+```
+
+```json
+// strings/en.json
+{ "sunrise": "Sunrise", "daylight": "Daylight" }
+// strings/fr.json
+{ "sunrise": "Lever du soleil", "daylight": "Durée du jour" }
+```
+
+```js
+// client.js
+label.textContent = ctx.t("sunrise", "Sunrise");
+```
+
+`ctx.locale` is resolved once per page render (every widget on a page
+gets the same one) from, in order: the target device's own `locale`
+(Settings → Devices), the app-wide `settings.app.locale`, the host's
+own locale, else `"en"`. `ctx.strings` is the widget's own
+`strings/<locale>.json`, falling back to the base language
+(`fr-CA` → `fr`) and then to English if the exact tag isn't shipped.
+
+Dates and numbers aren't part of this contract: use
+`Intl.DateTimeFormat(ctx.locale, {...})` /
+`Intl.NumberFormat(ctx.locale, {...})` directly rather than a hand-rolled
+month/weekday table, so day names, ordering, and separators come from
+the browser's own locale data instead of one you'd have to maintain.
+
+Translating a widget is a normal contribution to that widget: a PR
+adding `strings/<locale>.json` (bundled widgets) or a new catalog
+release (marketplace widgets, installed the normal way from Browse).
+There's no separate override mechanism, and no per-widget forking
+required to add a language.
 
 ---
 

--- a/plugins/calendar_day/client.js
+++ b/plugins/calendar_day/client.js
@@ -34,6 +34,20 @@ export function styleLabel(full, style, minimalMap) {
   return full.toUpperCase();
 }
 
+export function localizedFull(date, unit, locale) {
+  const lang = (locale || "en").split("-")[0];
+  if (lang === "en") {
+    return unit === "weekday" ? WEEKDAY_FULL[(date.getDay() + 6) % 7] : MONTH_FULL[date.getMonth()];
+  }
+  return new Intl.DateTimeFormat(locale, { [unit]: "long" }).format(date);
+}
+
+export function minimalMapFor(unit, locale) {
+  const lang = (locale || "en").split("-")[0];
+  if (lang !== "en") return {};
+  return unit === "weekday" ? DOW_MINIMAL : MONTH_MINIMAL;
+}
+
 function escapeHtml(s) {
   return String(s ?? "").replace(/[&<>"']/g, (c) => ({
     "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
@@ -207,8 +221,11 @@ function hourLabels(range) {
 // by how many events overlap that hour. 0 events = empty surface-
 // sunken; 1+ events scale through accent-4 (teal) at increasing
 // opacity. Quick scan of "where the day is busy". Half-open intervals
-// [hour, hour+1).
-function densityStrip(range, timed) {
+// [hour, hour+1). ``t`` is ctx.t(): the hover tooltip is the one piece
+// of this widget's text that needs a plural, and ctx.t() has no
+// interpolation of its own, so the sentence is composed here from
+// three translated atoms (singular noun / plural noun / "at").
+function densityStrip(range, timed, t) {
   const cells = [];
   const maxCount = Math.max(
     1,
@@ -234,8 +251,9 @@ function densityStrip(range, timed) {
     const bg = count === 0
       ? "var(--surface-sunken)"
       : `color-mix(in oklab, var(--accent-4) ${(alpha * 100).toFixed(0)}%, var(--surface))`;
+    const noun = t(count === 1 ? "event" : "events", count === 1 ? "event" : "events");
     cells.push(
-      `<span class="tt-density-cell" style="background:${bg}" title="${count} event${count === 1 ? "" : "s"} at ${String(h).padStart(2, "0")}:00"></span>`
+      `<span class="tt-density-cell" style="background:${bg}" title="${count} ${noun} ${t("at", "at")} ${String(h).padStart(2, "0")}:00"></span>`
     );
   }
   return `<div class="tt-density" aria-hidden="true">${cells.join("")}</div>`;
@@ -243,6 +261,7 @@ function densityStrip(range, timed) {
 
 export default function render(shadow, ctx) {
   const data = ctx?.data ?? {};
+  const t = ctx?.t || ((key, fallback) => fallback ?? key);
   const css = `<link rel="stylesheet" href="/static/style/spectra-widgets.css">`;
 
   if (data.error) {
@@ -256,13 +275,14 @@ export default function render(shadow, ctx) {
 
   const options = readOptions(ctx);
   const labelStyle = ["full", "short", "minimal"].includes(options.date_label_style) ? options.date_label_style : "full";
+  const locale = ctx?.locale || "en";
 
   const isoDate = data.date || new Date().toISOString().slice(0, 10);
   const [y, m, d] = isoDate.split("-").map(Number);
   const localDate = new Date(y, m - 1, d);
   const dayNum = String(d);
-  const monthName = styleLabel(MONTH_FULL[m - 1] || "", labelStyle, MONTH_MINIMAL);
-  const weekday = styleLabel(WEEKDAY_FULL[(localDate.getDay() + 6) % 7], labelStyle, DOW_MINIMAL);
+  const monthName = styleLabel(localizedFull(localDate, "month", locale), labelStyle, minimalMapFor("month", locale));
+  const weekday = styleLabel(localizedFull(localDate, "weekday", locale), labelStyle, minimalMapFor("weekday", locale));
 
   const events = Array.isArray(data.events) ? data.events : [];
   const allDay = events.filter((e) => e.all_day);
@@ -309,7 +329,7 @@ export default function render(shadow, ctx) {
     : "";
 
   const emptyHint = events.length === 0
-    ? `<div style="position:absolute;inset:0;display:grid;place-items:center"><p class="u-muted">No events today.</p></div>`
+    ? `<div style="position:absolute;inset:0;display:grid;place-items:center"><p class="u-muted">${escapeHtml(t("no_events", "No events today."))}</p></div>`
     : "";
 
   const now = new Date();
@@ -322,7 +342,7 @@ export default function render(shadow, ctx) {
     : "";
 
   const showDensity = options.show_density !== false;
-  const density = (showDensity && timed.length) ? densityStrip(range, timed) : "";
+  const density = (showDensity && timed.length) ? densityStrip(range, timed, t) : "";
 
   const titleScale = clampScale(options.event_title_scale, 1.0, 0.01, 10.0);
   const timeScale = clampScale(options.event_time_scale, 1.0, 0.01, 10.0);

--- a/plugins/calendar_day/plugin.json
+++ b/plugins/calendar_day/plugin.json
@@ -1,10 +1,11 @@
 {
   "tesserae_compat": "1.x",
   "name": "Calendar, Day",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "kind": "widget",
   "description": "Today's agenda with tunable event text sizing, a configurable visible-hour range, and a location toggle. Reads from feeds configured in Widgets \u2192 Calendar Feeds; each feed's colour drives the stripe / marker / fill colour.",
   "icon": "ph-calendar-check",
+  "locales": ["en", "fr"],
   "supports": {
     "sizes": [
       "xs",

--- a/plugins/calendar_day/strings/en.json
+++ b/plugins/calendar_day/strings/en.json
@@ -1,0 +1,6 @@
+{
+  "no_events": "No events today.",
+  "event": "event",
+  "events": "events",
+  "at": "at"
+}

--- a/plugins/calendar_day/strings/fr.json
+++ b/plugins/calendar_day/strings/fr.json
@@ -1,0 +1,6 @@
+{
+  "no_events": "Aucun événement aujourd'hui.",
+  "event": "événement",
+  "events": "événements",
+  "at": "à"
+}

--- a/plugins/calendar_day/tests/clamp_check.mjs
+++ b/plugins/calendar_day/tests/clamp_check.mjs
@@ -4,7 +4,16 @@
 // test_scale_sliders_clamp_to_bounds before the clamp moved from
 // server.py to client.js.
 import assert from "node:assert/strict";
-import { clampScale, clampToDay, computeRange, pctSpan, readOptions, styleLabel } from "../client.js";
+import {
+  clampScale,
+  clampToDay,
+  computeRange,
+  localizedFull,
+  minimalMapFor,
+  pctSpan,
+  readOptions,
+  styleLabel,
+} from "../client.js";
 
 assert.equal(clampScale(undefined, 1.0, 0.7, 1.5), 1.0, "missing falls back to default");
 assert.equal(clampScale(null, 1.0, 0.7, 1.5), 1.0, "null falls back to default");
@@ -84,5 +93,19 @@ assert.equal(styleLabel("Tuesday", "short", {}), "TUE", "short is a 3-letter abb
 assert.equal(styleLabel("Tuesday", "minimal", DOW_MINIMAL), "TU", "minimal uses the disambiguation map");
 assert.equal(styleLabel("Thursday", "minimal", DOW_MINIMAL), "TH", "Tue/Thu don't collide at 1 char");
 assert.equal(styleLabel("Zzyzx", "minimal", {}), "ZZ", "unmapped label falls back to first 2 chars");
+
+// locales contract (docs/widgets.md#locales-strings): localizedFull() /
+// minimalMapFor() are what feed a locale-aware name into styleLabel above.
+// A Monday, so weekday indices are unambiguous either way.
+const monday = new Date(2026, 0, 5);
+assert.equal(localizedFull(monday, "weekday", "en"), "Monday", "English reads the hardcoded array, not Intl");
+assert.equal(localizedFull(monday, "month", "en-US"), "January", "English variants (en-US) still count as English");
+assert.equal(localizedFull(monday, "weekday", "fr"), "lundi", "non-English asks Intl for the real localised name");
+assert.equal(localizedFull(monday, "month", "fr"), "janvier", "same for months");
+assert.equal(localizedFull(monday, "weekday", ""), "Monday", "no locale at all defaults to English");
+
+assert.equal(minimalMapFor("weekday", "en").Tuesday, "Tu", "English gets the real disambiguation map");
+assert.deepEqual(minimalMapFor("weekday", "fr"), {}, "non-English gets {} -- styleLabel's generic slice, not English abbreviations");
+assert.deepEqual(minimalMapFor("month", "de"), {}, "same for months");
 
 console.log("clamp_check.mjs: all assertions passed");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.364.4"
+version = "0.365.0"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/schema/device.schema.json
+++ b/schema/device.schema.json
@@ -82,6 +82,11 @@
         },
         "name": { "type": "string", "description": "Friendly name shown in the UI." }
       }
+    },
+    "locale": {
+      "type": "string",
+      "pattern": "^[a-z]{2,3}(-[A-Z]{2})?\\Z",
+      "description": "locale this device renders widget panel text in (e.g. 'fr', 'pt-BR'). An instance overrides its kind's value if the kind declares one; absent at both levels falls back to the app-wide default (settings.app.locale). Lets one server drive a German kitchen panel and an English office panel with the same widgets. See app/locale_resolve.py."
     }
   }
 }

--- a/schema/plugin.schema.json
+++ b/schema/plugin.schema.json
@@ -241,7 +241,7 @@
     "locales": {
       "type": "array",
       "description": "locale tags this widget ships panel text for (e.g. 'en', 'fr', 'pt-BR'). Each tag must have a matching strings/<tag>.json file next to plugin.json, a flat { \"key\": \"translated text\" } map. A widget's own hardcoded fallback text is always assumed to be English; strings/en.json is what a locale with no exact or base-language match falls back to. The host resolves the active locale (per device, falling back to the app default) and hands the widget ctx.locale + ctx.strings/ctx.t() at render time. See docs/widgets.md#locales-strings.",
-      "items": { "type": "string", "pattern": "^[a-z]{2,3}(-[A-Z]{2})?$" },
+      "items": { "type": "string", "pattern": "^[a-z]{2,3}(-[A-Z]{2})?\\Z" },
       "minItems": 1,
       "uniqueItems": true
     },

--- a/schema/plugin.schema.json
+++ b/schema/plugin.schema.json
@@ -238,6 +238,13 @@
       "uniqueItems": true,
       "description": "Declared capability list. Each entry is `<category>:<value>`. Supported categories: `network:<hostname>` (specific egress target; `network:*` for unrestricted but flagged in review), `settings:plugin` (own plugin settings, the common case; `settings:plugin/<other_id>` for a sibling's; `settings:app` for top-level app settings like lat/lon), `filesystem:write:<path>` (write outside data_dir; reads are implicit for data_dir and the plugin folder), `plugin:<other_id>` (this widget fetches through another plugin, so that plugin's declared hosts are allowed while this one runs; needed because the delegate's request happens inside this widget's capability scope). Enforcement in v1: network egress is blocked at the socket layer for hostnames not in the list; settings + filesystem entries are review-only. Widgets without a `requires:` block load with no enforcement (existing behaviour) but should declare in new submissions, the catalog review checklist demands it."
     },
+    "locales": {
+      "type": "array",
+      "description": "locale tags this widget ships panel text for (e.g. 'en', 'fr', 'pt-BR'). Each tag must have a matching strings/<tag>.json file next to plugin.json, a flat { \"key\": \"translated text\" } map. A widget's own hardcoded fallback text is always assumed to be English; strings/en.json is what a locale with no exact or base-language match falls back to. The host resolves the active locale (per device, falling back to the app default) and hands the widget ctx.locale + ctx.strings/ctx.t() at render time. See docs/widgets.md#locales-strings.",
+      "items": { "type": "string", "pattern": "^[a-z]{2,3}(-[A-Z]{2})?$" },
+      "minItems": 1,
+      "uniqueItems": true
+    },
     "fonts": {
       "type": "array",
       "items": {
@@ -269,6 +276,11 @@
     {
       "description": "Only placeable widgets may declare update capabilities.",
       "if": { "required": ["updates"] },
+      "then": { "properties": { "kind": { "const": "widget" } } }
+    },
+    {
+      "description": "Only placeable widgets render panel text, so only they may declare locales.",
+      "if": { "required": ["locales"] },
       "then": { "properties": { "kind": { "const": "widget" } } }
     }
   ]

--- a/static/composer.js
+++ b/static/composer.js
@@ -102,6 +102,16 @@ function buildCtx(cell, options, pluginData, fontFamily) {
   // default) is the whole widget, so grid cells and un-decomposed widgets
   // are unaffected.
   const fragment = cell.dataset.fragment || "full";
+  // Locales contract (docs/widgets.md#locales-strings): the host resolves
+  // one locale for the whole page (composer.py's _resolve_page_locale)
+  // and each cell's own widget's resolved strings map, {} for a widget
+  // that hasn't declared any `locales`. ctx.t() degrades to `fallback`
+  // (or the bare key) in that case, so an untranslated widget's own
+  // literal text, passed as the fallback argument, is what renders --
+  // unchanged from before this existed.
+  const locale = cell.dataset.locale || "en";
+  let strings = {};
+  try { strings = JSON.parse(cell.dataset.strings || "{}"); } catch { strings = {}; }
   return {
     cell: {
       w: virtualW,
@@ -116,6 +126,9 @@ function buildCtx(cell, options, pluginData, fontFamily) {
     font: { family: fontFamily, weight: 400 },
     data: pluginData,
     fragment,
+    locale,
+    strings,
+    t(key, fallback) { return strings[key] ?? fallback ?? key; },
     preview: new URLSearchParams(location.search).get("preview") === "1",
   };
 }

--- a/static/panels/editor.js
+++ b/static/panels/editor.js
@@ -456,6 +456,12 @@
     return one ? dataForSrc(one) : null;
   }
   function ctxFor(e) {
+    // Locales contract (docs/widgets.md#locales-strings): the catalog
+    // entry (fetched once at load, see the S.locale assignment above)
+    // already carries this widget's strings resolved for S.locale; {}
+    // for a widget that hasn't declared any, same as a real render.
+    var w = widgetFor(e.widget);
+    var strings = (w && w.strings) || {};
     return {
       cell: {
         w: e.w, h: e.h, size: resolveSize(e.w, e.h),
@@ -466,6 +472,9 @@
       font: { family: fontFamily(S.doc.font), weight: 400 },
       data: dataFor(e),
       fragment: e.fragment || "full",
+      locale: S.locale || "en",
+      strings: strings,
+      t: function (key, fallback) { return strings[key] != null ? strings[key] : (fallback != null ? fallback : key); },
       preview: false,
     };
   }
@@ -3683,6 +3692,11 @@
       .then(function (res) {
         S.catalog = (res[0] && res[0].widgets) || [];
         S.appearance = (res[0] && res[0].appearance) || { themes: [], styles: [], fonts: [] };
+        // Locales contract (docs/widgets.md#locales-strings): the app-wide
+        // default locale, resolved server-side since the editor's preview
+        // isn't rendering for any particular device. Each catalog entry
+        // already carries its own widget's resolved `strings` for it.
+        S.locale = (res[0] && res[0].locale) || "en";
         var palette = $("panels-palette");
         if (palette) renderPalette(palette);
         hydrateDoc(res[1]);

--- a/templates/_device_card.html
+++ b/templates/_device_card.html
@@ -418,6 +418,25 @@
         {% endfor %}
         {% endif %}
 
+        {# Per-device locale override (see app.locale_resolve). Widgets
+           placed on pages bound to this device render their panel text
+           in this locale instead of the app-wide default -- the
+           "German kitchen panel, English office panel" case. Blank =
+           inherit the app default. Only en/fr have real translations
+           today (calendar_day); picking anything else falls back to
+           each widget's own English text, which is still useful for
+           spotting layout issues before a translation exists. #}
+        {% if section.locale_editable %}
+        {{ select_field(section.id ~ '-locale', 'locale', 'Panel text locale',
+                        value=section.locale, blank_label='Use app default',
+                        options=[
+                          {'value': 'en', 'label': 'English'},
+                          {'value': 'fr', 'label': 'Français'}
+                        ],
+                        help='Overrides the app-wide default for widgets rendered on this device. Only widgets that have shipped a translation for the picked language actually change; others keep their built-in English text.',
+                        form=_combined_form_id) }}
+        {% endif %}
+
         {# Per-device quiet hours override + dependent dim of Start/End. #}
         {% if section.quiet_hours_endpoint %}
         <div class="dx-quiet-hours" data-dep-group>

--- a/templates/compose.html
+++ b/templates/compose.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{ page.locale|default('en') }}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -138,6 +138,8 @@
          data-panel-h="{{ page.panel.h }}"
          data-font-family="{{ cell.font_family }}"
          data-cell-zoom="{{ cell.zoom }}"
+         data-locale="{{ cell.locale }}"
+         data-strings='{{ cell.strings|tojson }}'
          {% if cell.on_tap_attr %}data-on-tap="{{ cell.on_tap_attr }}"{% endif %}
          {% if cell.on_swipe_attr %}data-on-swipe="{{ cell.on_swipe_attr }}"{% endif %}
          {% if cell.on_slide_attr %}data-on-slide="{{ cell.on_slide_attr }}"{% endif %}

--- a/templates/panels_compose.html
+++ b/templates/panels_compose.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{ locale|default('en') }}">
 <head>
   <meta charset="utf-8">
   {# Canvas render target (issue #60). Playwright screenshots this at panel
@@ -78,6 +78,8 @@
          data-panel-h="{{ ch }}"
          data-cell-zoom="1"
          data-font-family="{{ font_family }}, system-ui, sans-serif"
+         data-locale="{{ e.locale }}"
+         data-strings='{{ e.strings|tojson }}'
          {% if e.on_tap_attr %}data-on-tap="{{ e.on_tap_attr }}"{% endif %}
          {% if e.on_swipe_attr %}data-on-swipe="{{ e.on_swipe_attr }}"{% endif %}
          {% if e.on_slide_attr %}data-on-slide="{{ e.on_slide_attr }}"{% endif %}

--- a/tests/test_app_locale_setting.py
+++ b/tests/test_app_locale_setting.py
@@ -1,0 +1,39 @@
+"""App-wide default locale (Settings -> Server -> Location & time), the
+fallback a device's own override reads when set to "Use app default"
+(see app.locale_resolve.resolve_locale)."""
+
+from __future__ import annotations
+
+from flask.testing import FlaskClient
+
+
+def _sign_in(client: FlaskClient) -> None:
+    client.post("/setup", data={"password": "abcdefgh", "password_confirm": "abcdefgh"})
+
+
+def test_locale_field_defaults_to_system(client: FlaskClient) -> None:
+    _sign_in(client)
+    body = client.get("/settings/server").get_data(as_text=True)
+    # The App card renders on the same Settings page; "system" is the
+    # unsaved default, same sentinel + meaning as the timezone field.
+    assert 'name="locale"' in body or "System (host language)" in body
+
+
+def test_saving_the_locale_persists_it(app, client: FlaskClient) -> None:
+    _sign_in(client)
+    resp = client.post("/settings/app", data={"locale": "fr"})
+    assert resp.status_code in (200, 302)
+    assert app.config["SETTINGS_STORE"].get_section("app").get("locale") == "fr"
+
+
+def test_saved_app_locale_is_what_a_device_without_its_own_override_resolves_to(
+    app, client: FlaskClient
+) -> None:
+    """End-to-end: the field this commit adds is exactly what
+    resolve_locale() falls back to for a device with no override --
+    it's not a second, disconnected concept."""
+    from app.locale_resolve import resolve_locale
+
+    client.post("/settings/app", data={"locale": "de"})
+    app_section = app.config["SETTINGS_STORE"].get_section("app")
+    assert resolve_locale(app_section, None) == "de"

--- a/tests/test_composer_locale.py
+++ b/tests/test_composer_locale.py
@@ -1,0 +1,151 @@
+"""Locales contract, render-pipeline half: composer.py resolves one
+locale per page and each cell's own widget's strings, and hands both
+to the browser as data-locale / data-strings (composer.js turns them
+into ctx.locale / ctx.strings / ctx.t()).
+
+/_test/render exercises the grid path (_hydrate_page, compose.html).
+A canvas-kind Page exercises the freeform path (_build_canvas_els,
+panels_compose.html) -- a second, separate render surface with its
+own element-building code, so the locales contract needs wiring there
+too, not just the grid."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+
+from app.main import REPO_ROOT, create_app
+
+
+def _write_i18n_widget(data_root: Path, plugin_id: str) -> None:
+    """An authored widget (data_root/authored/<id>/) declaring one
+    locale, so the real plugin registry resolves real strings without
+    touching the bundled plugins/ dir."""
+    d = data_root / "authored" / plugin_id
+    (d / "strings").mkdir(parents=True)
+    (d / "plugin.json").write_text(
+        json.dumps(
+            {
+                "tesserae_compat": "1.x",
+                "name": "i18n test widget",
+                "version": "0.0.1",
+                "kind": "widget",
+                "supports": {"sizes": ["md"]},
+                "locales": ["fr"],
+            }
+        )
+    )
+    (d / "client.js").write_text("export default function render(shadow, ctx) {}\n")
+    (d / "strings" / "fr.json").write_text(json.dumps({"greeting": "Bonjour"}))
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> Flask:
+    _write_i18n_widget(tmp_path, "mini_i18n")
+    return create_app(testing=True, data_root=tmp_path, plugins_dir=REPO_ROOT / "plugins")
+
+
+@pytest.fixture
+def client(app: Flask) -> FlaskClient:
+    return app.test_client()
+
+
+def _cell_dataset(html: str, attr: str) -> str:
+    """Pull one data-<attr>=...'s value out of the rendered cell markup.
+    compose.html quotes plain-string attrs (data-locale) with " and
+    tojson attrs (data-strings) with ', so this reads whichever
+    quote character actually follows the attribute name."""
+    marker = f"data-{attr}="
+    idx = html.index(marker) + len(marker)
+    quote = html[idx]
+    start = idx + 1
+    end = html.index(quote, start)
+    return html[start:end]
+
+
+def test_untranslated_widget_gets_english_locale_and_empty_strings(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No locales declared -> {} strings, so ctx.t() falls through to
+    the widget's own literal text. Locks in that this whole contract
+    is a no-op for the ~40 widgets that haven't opted in yet."""
+    monkeypatch.delenv("LC_ALL", raising=False)
+    monkeypatch.delenv("LANG", raising=False)
+    resp = client.get("/_test/render?plugin=clock&size=md")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert _cell_dataset(body, "locale") == "en"
+    assert json.loads(_cell_dataset(body, "strings")) == {}
+
+
+def test_app_level_locale_setting_is_honoured(client: FlaskClient, app: Flask) -> None:
+    app.config["SETTINGS_STORE"].patch_section("app", {"locale": "fr"})
+    resp = client.get("/_test/render?plugin=clock&size=md")
+    assert _cell_dataset(resp.get_data(as_text=True), "locale") == "fr"
+
+
+def test_translated_widget_gets_its_resolved_strings(client: FlaskClient, app: Flask) -> None:
+    app.config["SETTINGS_STORE"].patch_section("app", {"locale": "fr"})
+    resp = client.get("/_test/render?plugin=mini_i18n&size=md")
+    body = resp.get_data(as_text=True)
+    assert _cell_dataset(body, "locale") == "fr"
+    strings = json.loads(_cell_dataset(body, "strings"))
+    assert strings == {"greeting": "Bonjour"}
+
+
+def test_translated_widget_falls_back_to_english_for_unshipped_locale(
+    client: FlaskClient, app: Flask
+) -> None:
+    """mini_i18n only ships fr; requesting de resolves to {} (it has no
+    English strings/ either -- the fallback chain bottoms out cleanly
+    rather than erroring)."""
+    app.config["SETTINGS_STORE"].patch_section("app", {"locale": "de"})
+    resp = client.get("/_test/render?plugin=mini_i18n&size=md")
+    body = resp.get_data(as_text=True)
+    assert _cell_dataset(body, "locale") == "de"
+    strings = json.loads(_cell_dataset(body, "strings"))
+    assert strings == {}
+
+
+# -- canvas path (panels_compose.html / _build_canvas_els) --------------
+
+
+def _canvas_page(page_id: str, plugin_id: str) -> object:
+    from app.state.page_store import Page
+    from app.state.panel_store import CanvasLayout, Element
+
+    return Page(
+        id=page_id,
+        name="Canvas",
+        layout_kind="canvas",
+        canvas=CanvasLayout(w=200, h=200, els=[Element(id="e1", widget=plugin_id, w=200, h=200)]),
+    )
+
+
+def test_canvas_path_translated_widget_gets_its_resolved_strings(
+    client: FlaskClient, app: Flask
+) -> None:
+    app.config["SETTINGS_STORE"].patch_section("app", {"locale": "fr"})
+    app.config["PAGE_STORE"].save(_canvas_page("canvas_i18n", "mini_i18n"))
+    resp = client.get("/compose/canvas_i18n")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert _cell_dataset(body, "locale") == "fr"
+    assert json.loads(_cell_dataset(body, "strings")) == {"greeting": "Bonjour"}
+
+
+def test_canvas_path_untranslated_widget_gets_empty_strings(
+    client: FlaskClient, app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("LC_ALL", raising=False)
+    monkeypatch.delenv("LANG", raising=False)
+    app.config["PAGE_STORE"].save(_canvas_page("canvas_clock", "clock"))
+    resp = client.get("/compose/canvas_clock")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert _cell_dataset(body, "locale") == "en"
+    assert json.loads(_cell_dataset(body, "strings")) == {}

--- a/tests/test_composer_locale.py
+++ b/tests/test_composer_locale.py
@@ -149,3 +149,25 @@ def test_canvas_path_untranslated_widget_gets_empty_strings(
     body = resp.get_data(as_text=True)
     assert _cell_dataset(body, "locale") == "en"
     assert json.loads(_cell_dataset(body, "strings")) == {}
+
+
+# -- calendar_day: the real pilot widget, not a synthetic fixture -------
+
+
+def test_calendar_day_receives_its_real_french_strings(client: FlaskClient, app: Flask) -> None:
+    """End-to-end proof against the actual bundled widget (not mini_i18n):
+    calendar_day declares locales in plugins/calendar_day/plugin.json and
+    ships plugins/calendar_day/strings/fr.json, so this is what a real
+    contributed translation looks like flowing all the way to the DOM."""
+    app.config["SETTINGS_STORE"].patch_section("app", {"locale": "fr"})
+    resp = client.get("/_test/render?plugin=calendar_day&size=md")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert _cell_dataset(body, "locale") == "fr"
+    strings = json.loads(_cell_dataset(body, "strings"))
+    assert strings == {
+        "no_events": "Aucun événement aujourd'hui.",
+        "event": "événement",
+        "events": "événements",
+        "at": "à",
+    }

--- a/tests/test_device_loader.py
+++ b/tests/test_device_loader.py
@@ -171,3 +171,77 @@ def parse_status(payload):
     parsed = device.parse_status(b"x")
     assert "error" in parsed
     assert "RuntimeError" in parsed["error"]
+
+
+# ---------------------------------------------------------------------
+# per-device locale
+# ---------------------------------------------------------------------
+
+
+def test_locale_absent_by_default() -> None:
+    """A device (kind or instance) that never mentions locale defers to
+    the app-wide default -- None here means "no override", not
+    "render in English"."""
+    from types import ModuleType
+
+    from app.device_loader import Device
+
+    device = Device(
+        id="lounge_frame",
+        path=Path("/tmp/lounge_frame"),
+        manifest={"name": "Lounge", "status_topic": "t"},
+        module=ModuleType("stub"),
+        data_dir=Path("/tmp/lounge_frame_data"),
+    )
+    assert device.locale is None
+
+
+def test_locale_property_reads_manifest() -> None:
+    from types import ModuleType
+
+    from app.device_loader import Device
+
+    device = Device(
+        id="kitchen",
+        path=Path("/tmp/kitchen"),
+        manifest={"name": "Kitchen", "status_topic": "t", "locale": "de"},
+        module=ModuleType("stub"),
+        data_dir=Path("/tmp/kitchen_data"),
+    )
+    assert device.locale == "de"
+
+
+def test_instance_locale_overrides_kind(tmp_path: Path, schema_path: Path) -> None:
+    """An instance's own locale wins over its kind's -- the German
+    kitchen panel / English office panel off one server scenario."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "kitchen.json").write_text(
+        json.dumps(
+            {
+                "id": "kitchen",
+                "kind": "pi_bin_client",
+                "name": "Kitchen",
+                "status_topic": "tesserae/pi_bin/kitchen/status",
+                "locale": "de",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (data_dir / "office.json").write_text(
+        json.dumps(
+            {
+                "id": "office",
+                "kind": "pi_bin_client",
+                "name": "Office",
+                "status_topic": "tesserae/pi_bin/office/status",
+            }
+        ),
+        encoding="utf-8",
+    )
+    registry = device_loader.discover(
+        REPO_ROOT / "devices", schema_path=schema_path, data_root=data_dir
+    )
+    assert registry.errors == []
+    assert registry.devices["kitchen"].locale == "de"
+    assert registry.devices["office"].locale is None

--- a/tests/test_device_locale_settings.py
+++ b/tests/test_device_locale_settings.py
@@ -1,0 +1,102 @@
+"""Per-device locale override (Settings -> Devices -> General), the
+"let me alternate and see the diff" control: app.locale_resolve reads
+Device.locale, this is where a human sets it."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+from app.main import REPO_ROOT, create_app
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> Flask:
+    a = create_app(
+        testing=False,
+        data_root=tmp_path,
+        plugins_dir=REPO_ROOT / "plugins",
+        renderers_dir=REPO_ROOT / "renderers",
+    )
+    a.config["TESTING"] = True
+    return a
+
+
+def _sign_in(client) -> None:
+    client.post("/setup", data={"password": "abcdefgh", "password_confirm": "abcdefgh"})
+
+
+def _add_device(client, instance_id: str = "kitchen") -> None:
+    client.post(
+        "/settings/devices/add",
+        data={"kind": "circuitpython_generic", "id": instance_id, "name": "Kitchen"},
+    )
+
+
+def test_saving_a_locale_persists_and_reloads(app: Flask) -> None:
+    client = app.test_client()
+    _sign_in(client)
+    _add_device(client)
+    assert app.config["DEVICE_REGISTRY"].get("kitchen").locale is None
+
+    resp = client.post("/settings/devices/kitchen/save", data={"locale": "fr"})
+    assert resp.status_code == 302
+    assert app.config["DEVICE_REGISTRY"].get("kitchen").locale == "fr"
+
+    # Persisted to disk, not just the in-memory registry -- survives a
+    # full reload the way a restart would exercise.
+    on_disk = (Path(app.config["DATA_ROOT"]) / "devices" / "kitchen.json").read_text()
+    assert '"locale": "fr"' in on_disk
+
+
+def test_clearing_the_locale_reverts_to_the_app_default(app: Flask) -> None:
+    client = app.test_client()
+    _sign_in(client)
+    _add_device(client)
+    client.post("/settings/devices/kitchen/save", data={"locale": "de"})
+    assert app.config["DEVICE_REGISTRY"].get("kitchen").locale == "de"
+
+    client.post("/settings/devices/kitchen/save", data={"locale": ""})
+    assert app.config["DEVICE_REGISTRY"].get("kitchen").locale is None
+
+
+def test_alternating_locales_changes_a_real_compose_render(app: Flask) -> None:
+    """The actual "alternate and see the diff" workflow: bind a page to
+    the device, flip the device's locale, and watch calendar_day's
+    resolved strings change between renders without touching the page
+    or the app-wide setting."""
+    from app.state.page_store import Cell, Page
+
+    client = app.test_client()
+    _sign_in(client)
+    _add_device(client)
+    app.config["PAGE_STORE"].save(
+        Page(
+            id="agenda",
+            name="Agenda",
+            layout_kind="grid",
+            device_ids=["kitchen"],
+            cells=[Cell(id="c1", plugin="calendar_day", x=0, y=0, w=400, h=300, options={})],
+        )
+    )
+
+    def _cell_dataset(body: str, attr: str) -> str:
+        marker = f"data-{attr}="
+        idx = body.index(marker) + len(marker)
+        quote = body[idx]
+        start = idx + 1
+        end = body.index(quote, start)
+        return body[start:end]
+
+    client.post("/settings/devices/kitchen/save", data={"locale": "fr"})
+    body_fr = client.get("/compose/agenda").get_data(as_text=True)
+    assert _cell_dataset(body_fr, "locale") == "fr"
+    assert json.loads(_cell_dataset(body_fr, "strings"))["event"] == "événement"
+
+    client.post("/settings/devices/kitchen/save", data={"locale": "en"})
+    body_en = client.get("/compose/agenda").get_data(as_text=True)
+    assert _cell_dataset(body_en, "locale") == "en"
+    assert json.loads(_cell_dataset(body_en, "strings"))["event"] == "event"

--- a/tests/test_locale_resolve.py
+++ b/tests/test_locale_resolve.py
@@ -1,0 +1,70 @@
+"""Locale resolution: per-device override, app-level default, system
+fallback, ultimate "en" fallback. Same shape as test_quiet_hours.py."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.locale_resolve import DEFAULT_LOCALE, resolve_locale
+
+
+def _device(locale: str | None) -> SimpleNamespace:
+    """Build a Device-like stand-in with a manifest dict."""
+    manifest: dict = {"id": "d", "kind": "pi_png_client"}
+    if locale is not None:
+        manifest["locale"] = locale
+    return SimpleNamespace(manifest=manifest)
+
+
+def test_device_override_wins_over_app_setting() -> None:
+    app = {"locale": "en"}
+    assert resolve_locale(app, _device("de")) == "de"
+
+
+def test_no_device_falls_back_to_app_setting() -> None:
+    app = {"locale": "fr"}
+    assert resolve_locale(app, None) == "fr"
+    assert resolve_locale(app, _device(None)) == "fr"
+
+
+def test_blank_device_locale_falls_back_to_app_setting() -> None:
+    """A device manifest with an empty-string locale (e.g. a form that
+    submitted a blank field) is treated as absent, not as a literal
+    empty-string override."""
+    app = {"locale": "fr"}
+    assert resolve_locale(app, _device("")) == "fr"
+    assert resolve_locale(app, _device("   ")) == "fr"
+
+
+def test_app_setting_system_falls_back_to_host_locale(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LC_ALL", "de_DE.UTF-8")
+    monkeypatch.setenv("LANG", "en_US.UTF-8")
+    assert resolve_locale({"locale": "system"}, None) == "de-DE"
+
+
+def test_unset_app_setting_behaves_like_system(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LC_ALL", "fr_FR.UTF-8")
+    assert resolve_locale({}, None) == "fr-FR"
+
+
+def test_lang_used_when_lc_all_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LC_ALL", raising=False)
+    monkeypatch.setenv("LANG", "pt_BR.UTF-8")
+    assert resolve_locale({}, None) == "pt-BR"
+
+
+def test_c_and_posix_locale_are_treated_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ "C" / "POSIX" mean "no locale configured" at the OS level, not a
+    literal locale to render in."""
+    monkeypatch.setenv("LC_ALL", "C")
+    monkeypatch.setenv("LANG", "POSIX")
+    assert resolve_locale({}, None) == DEFAULT_LOCALE
+
+
+def test_no_env_vars_falls_back_to_en(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LC_ALL", raising=False)
+    monkeypatch.delenv("LANG", raising=False)
+    assert resolve_locale({}, None) == "en"
+    assert DEFAULT_LOCALE == "en"

--- a/tests/test_panels.py
+++ b/tests/test_panels.py
@@ -111,6 +111,22 @@ def test_catalog_includes_appearance(app: Flask) -> None:
     assert isinstance(ap["fonts"], list)
 
 
+def test_catalog_locale_defaults_to_app_setting(
+    app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The editor preview isn't for any particular device, so its locale
+    is always the app-wide default -- same value a device-less
+    grid/canvas render would resolve to."""
+    monkeypatch.delenv("LC_ALL", raising=False)
+    monkeypatch.delenv("LANG", raising=False)
+    client = app.test_client()
+    _sign_in(client)
+    assert client.get("/pages/canvas/catalog.json").get_json()["locale"] == "en"
+
+    app.config["SETTINGS_STORE"].patch_section("app", {"locale": "fr"})
+    assert client.get("/pages/canvas/catalog.json").get_json()["locale"] == "fr"
+
+
 def test_appearance_roundtrips(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TESSERAE_EXPERIMENT_COMPOSER", "1")
     client = app.test_client()
@@ -198,9 +214,12 @@ def test_compose_applies_theme_and_background(app: Flask) -> None:
 
 
 class _FakePlugin:
-    def __init__(self, pid: str, manifest: dict[str, Any]) -> None:
+    def __init__(
+        self, pid: str, manifest: dict[str, Any], strings: dict[str, dict[str, str]] | None = None
+    ) -> None:
         self.id = pid
         self.manifest = manifest
+        self.strings = strings or {}
 
     @property
     def name(self) -> str:
@@ -215,6 +234,9 @@ class _FakePlugin:
         return [
             dict(spec) for spec in raw if isinstance(spec, dict) and spec.get("kind") == "daily"
         ]
+
+    def strings_for(self, locale: str) -> dict[str, str]:
+        return self.strings.get(locale, {})
 
 
 class _FakeRegistry:
@@ -272,6 +294,21 @@ def test_catalog_entry_shape() -> None:
     plain = catalog_entry(_FakePlugin("plain", {"name": "Plain"}))  # type: ignore[arg-type]
     assert plain["updates_on_change"] is False
     assert plain["updates_on_schedule"] == []
+    assert plain["strings"] == {}  # no locales declared -> untouched by the contract
+
+
+def test_catalog_entry_carries_resolved_strings_for_locale() -> None:
+    translated = _FakePlugin("greeter", {"name": "Greeter"}, strings={"fr": {"hello": "Bonjour"}})
+    assert catalog_entry(translated)["strings"] == {}  # default locale is "en"
+    assert catalog_entry(translated, "fr")["strings"] == {"hello": "Bonjour"}  # type: ignore[arg-type]
+
+
+def test_build_catalog_passes_locale_through() -> None:
+    registry = _FakeRegistry(
+        [_FakePlugin("greeter", {"name": "Greeter"}, strings={"fr": {"hello": "Bonjour"}})]
+    )
+    catalog = build_catalog(registry, "fr")  # type: ignore[arg-type]
+    assert catalog[0]["strings"] == {"hello": "Bonjour"}
 
 
 def test_build_catalog_sorts_by_name() -> None:

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -329,3 +329,96 @@ def test_discover_bundled_wins_on_duplicate_id(tmp_path: Path, schema_path: Path
     )
     assert registry.plugins["shared"].name == "Bundled copy"
     assert any(err.plugin_id == "shared" and "duplicate" in err.message for err in registry.errors)
+
+
+# ---------------------------------------------------------------------
+# locales contract
+# ---------------------------------------------------------------------
+
+
+def test_locales_loads_strings_files(tmp_path: Path, schema_path: Path) -> None:
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    plugin_dir = _write_minimal_plugin(plugins_dir, "greeter", {"locales": ["en", "fr"]})
+    strings_dir = plugin_dir / "strings"
+    strings_dir.mkdir()
+    (strings_dir / "en.json").write_text(json.dumps({"hello": "Hello"}))
+    (strings_dir / "fr.json").write_text(json.dumps({"hello": "Bonjour"}))
+
+    registry = plugin_loader.discover(
+        plugins_dir, schema_path=schema_path, data_root=tmp_path / "data"
+    )
+    assert registry.errors == []
+    plugin = registry.plugins["greeter"]
+    assert plugin.strings_for("fr") == {"hello": "Bonjour"}
+    assert plugin.strings_for("en") == {"hello": "Hello"}
+
+
+def test_locales_missing_strings_file_is_a_soft_error(tmp_path: Path, schema_path: Path) -> None:
+    """A declared locale with no matching strings/<locale>.json file
+    doesn't fail the whole plugin, it's a loader warning and the
+    widget keeps loading (falls back to its English text)."""
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    _write_minimal_plugin(plugins_dir, "half_translated", {"locales": ["en", "fr"]})
+
+    registry = plugin_loader.discover(
+        plugins_dir, schema_path=schema_path, data_root=tmp_path / "data"
+    )
+    assert "half_translated" in registry.plugins
+    assert any(
+        err.plugin_id == "half_translated" and "strings/en.json" in err.message
+        for err in registry.errors
+    )
+
+
+def test_strings_for_falls_back_to_base_language(tmp_path: Path, schema_path: Path) -> None:
+    """fr-CA with no exact match falls back to plain fr before giving
+    up on English, so a widget doesn't need every regional variant
+    declared to serve a close-enough translation."""
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    plugin_dir = _write_minimal_plugin(plugins_dir, "greeter", {"locales": ["en", "fr"]})
+    strings_dir = plugin_dir / "strings"
+    strings_dir.mkdir()
+    (strings_dir / "en.json").write_text(json.dumps({"hello": "Hello"}))
+    (strings_dir / "fr.json").write_text(json.dumps({"hello": "Bonjour"}))
+
+    registry = plugin_loader.discover(
+        plugins_dir, schema_path=schema_path, data_root=tmp_path / "data"
+    )
+    assert registry.plugins["greeter"].strings_for("fr-CA") == {"hello": "Bonjour"}
+
+
+def test_strings_for_falls_back_to_english_then_empty() -> None:
+    plugin_with_strings = plugin_loader.Plugin(
+        id="greeter",
+        path=Path("/tmp/greeter"),
+        manifest={"kind": "widget", "name": "Greeter", "supports": {"sizes": ["md"]}},
+        data_dir=Path("/tmp/greeter_data"),
+        strings={"en": {"hello": "Hello"}},
+    )
+    assert plugin_with_strings.strings_for("de") == {"hello": "Hello"}
+
+    untranslated = plugin_loader.Plugin(
+        id="toy",
+        path=Path("/tmp/toy"),
+        manifest={"kind": "widget", "name": "Toy", "supports": {"sizes": ["md"]}},
+        data_dir=Path("/tmp/toy_data"),
+    )
+    assert untranslated.strings_for("fr") == {}
+
+
+def test_locales_rejected_on_non_widget_kind(tmp_path: Path, schema_path: Path) -> None:
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    _write_minimal_plugin(
+        plugins_dir,
+        "data_source",
+        {"kind": "data", "supports": {"sizes": []}, "locales": ["en"]},
+    )
+    registry = plugin_loader.discover(
+        plugins_dir, schema_path=schema_path, data_root=tmp_path / "data"
+    )
+    assert "data_source" not in registry.plugins
+    assert any("manifest schema" in err.message for err in registry.errors)

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -354,6 +354,41 @@ def test_locales_loads_strings_files(tmp_path: Path, schema_path: Path) -> None:
     assert plugin.strings_for("en") == {"hello": "Hello"}
 
 
+def test_locale_tag_regex_rejects_trailing_newline_smuggling() -> None:
+    """Python's `$` also matches just before a trailing newline, so a
+    naively `$`-anchored pattern would accept 'fr\\n' as if it were
+    'fr'. The locale tag becomes a filename (strings/<locale>.json),
+    so this has to be a hard reject, not a value that gets silently
+    normalised. `\\Z` (true end-of-string) is what actually closes
+    this off; this test pins that choice directly against the regex
+    the loader re-checks right before building that path, independent
+    of whether the schema layer ran first."""
+    from app.plugin_loader import _LOCALE_TAG_RE
+
+    assert _LOCALE_TAG_RE.match("fr") is not None
+    assert _LOCALE_TAG_RE.match("en-US") is not None
+    assert _LOCALE_TAG_RE.match("fr\n") is None
+    assert _LOCALE_TAG_RE.match("en-US\n") is None
+    assert _LOCALE_TAG_RE.match("../../../etc/passwd") is None
+
+
+def test_locales_manifest_rejects_smuggled_trailing_newline(
+    tmp_path: Path, schema_path: Path
+) -> None:
+    """End-to-end: the schema pattern itself (not just the loader's
+    internal re-check) refuses a locale tag carrying a trailing
+    newline, so a manifest can't even pass validation with one."""
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    _write_minimal_plugin(plugins_dir, "sneaky", {"locales": ["fr\n"]})
+
+    registry = plugin_loader.discover(
+        plugins_dir, schema_path=schema_path, data_root=tmp_path / "data"
+    )
+    assert "sneaky" not in registry.plugins
+    assert any("manifest schema" in err.message for err in registry.errors)
+
+
 def test_locales_missing_strings_file_is_a_soft_error(tmp_path: Path, schema_path: Path) -> None:
     """A declared locale with no matching strings/<locale>.json file
     doesn't fail the whole plugin, it's a loader warning and the


### PR DESCRIPTION
> [!WARNING]
> DISCLAIMER : My knowledge about python is pretty broad and about Flask is non-existent. I used Claude Code and my web developer experience to read and thoroughly review every change made by AI. Extra care should be given to that PR to be sure no very obvious bug / security risk was introduced because I'm no Python expert.

## What this changes

This changes adds the ability to contribute on widgets translations in a standardized way. Settings were also added on the devices and the system to override the used locale that is automatically inferred from the environment Tesserae is running on.  

## Why

Based on [this discussion](https://github.com/dmellok/tesserae/discussions/134) that is a feature some users would like to contribute to and use. It enables better customization and readability for every non-English user.

## Test plan

- [ ] `pytest -q` -> couldn't run it, it ran for 1 hour straight twice and crashed my computer twice...
- [x] `ruff check . && ruff format --check .`
- [x] `mypy app`
- [x] Manually verified: preview of french translated "calendar_day" widget and update of default locale settings for devices / system

## Checklist

- [x] Tests added for new behaviour (or note why none made sense)
- [x] `ruff` + `mypy` clean
- [x] User-facing changes documented (README, `docs/`, or both)
- [x] CHANGELOG entry added under `## [Unreleased]` if user-facing
- [x] `pyproject.toml` version bumped if this is going to be tagged