### PR TITLE
feat(widgets): added locale selector to dev previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 [Keep a Changelog](https://keepachangelog.com/); versions are
 [SemVer](https://semver.org/) (pre-1.0, so minors can carry breaking changes).
 
+## [Unreleased]
+
+### Added
+
+- **The dev widget previews can be rendered in a chosen language.** `/_test/widgets` and
+  `/_test/preview` now carry an English / French locale picker; it adds `?locale=<tag>` to the
+  render so a contributor can check a widget's translated strings and its `Intl` date / number
+  formatting without touching any install-wide or per-device setting.
+
 ## [0.367.3], 2026-08-27
 
 ### Fixed

--- a/app/composer.py
+++ b/app/composer.py
@@ -759,11 +759,22 @@ def _fetch_plugin_data(
 
 
 def _hydrate_page(
-    page_dict: dict[str, Any], *, preview: bool = False, sample: bool = False, fresh: bool = False
+    page_dict: dict[str, Any],
+    *,
+    preview: bool = False,
+    sample: bool = False,
+    fresh: bool = False,
+    locale: str | None = None,
 ) -> dict[str, Any]:
-    """Resolve options, fonts, server-side data, and visual layout."""
+    """Resolve options, fonts, server-side data, and visual layout.
+
+    ``locale`` forces the render language, used by the dev ``/_test/*``
+    preview surfaces' language picker. Left ``None`` (or ``""``) it
+    resolves exactly as production does: the target device's own
+    override, then the app-wide default, then the host locale (see
+    ``_resolve_page_locale``)."""
     registry = _registry()
-    locale = _resolve_page_locale(page_dict)
+    locale = locale or _resolve_page_locale(page_dict)
     page_font = _resolve_font(page_dict.get("font"), registry)
     page_font_family = page_font.name if page_font else "system-ui"
     # Default to ``light`` when no per-page override is set so the
@@ -1874,6 +1885,11 @@ def test_render() -> str:
     # data_dir cache) and skips the render path's last-good fallback. Default off.
     fresh = request.args.get("fresh") in ("1", "true", "True")
 
+    # ?locale=<bcp47> forces the render language for the dev preview
+    # surfaces' language picker (/_test/widgets, /_test/preview). Absent
+    # -> the production resolution (device override / app default / host).
+    locale_override = request.args.get("locale") or ""
+
     # Per-widget content zoom from the gallery's zoom picker. Same
     # 0.5–3.0 clamp the Cell model enforces; out-of-range or unparseable
     # values silently fall back to 1.0.
@@ -1928,7 +1944,9 @@ def test_render() -> str:
     }
     return render_template(
         "compose.html",
-        page=_hydrate_page(page, preview=True, sample=sample_mode, fresh=fresh),
+        page=_hydrate_page(
+            page, preview=True, sample=sample_mode, fresh=fresh, locale=locale_override
+        ),
         for_push=False,
         preview_mode=False,
     )
@@ -2014,6 +2032,11 @@ _PREVIEW_PANELS: Final[list[dict[str, Any]]] = [
 ]
 _PREVIEW_PANEL_IDS: Final[set[str]] = {p["id"] for p in _PREVIEW_PANELS}
 _DEFAULT_PREVIEW_PANEL_ID: Final[str] = "waveshare_e6_13_3"
+
+_PREVIEW_LOCALES: Final[list[dict[str, str]]] = [
+    {"id": "en", "label": "English"},
+    {"id": "fr", "label": "Français"},
+]
 
 
 # Multi-cell layout for the preview synthetic page. Spiral halving:
@@ -2132,6 +2155,7 @@ def _parse_preview_args() -> dict[str, Any]:
     widget_id = request.args.get("widget") or ""
     theme_id = request.args.get("theme") or "light"
     style_id = request.args.get("style") or "standard"
+    locale_id = request.args.get("locale") or ""
     sample_mode = request.args.get("sample") == "1"
     panel_id = request.args.get("panel") or _DEFAULT_PREVIEW_PANEL_ID
     if panel_id not in _PREVIEW_PANEL_IDS:
@@ -2150,6 +2174,7 @@ def _parse_preview_args() -> dict[str, Any]:
         "widget_id": widget_id,
         "theme_id": theme_id,
         "style_id": style_id,
+        "locale_id": locale_id,
         "sample": sample_mode,
         "panel_id": panel_id,
         "panel_w": preset.w,
@@ -2215,8 +2240,10 @@ def test_widget_preview() -> str:
         themes=_MATRIX_THEMES,
         styles=_MATRIX_STYLES,
         panels=_PREVIEW_PANELS,
+        locales=_PREVIEW_LOCALES,
         theme_id=parsed["theme_id"],
         style_id=parsed["style_id"],
+        locale_id=parsed["locale_id"],
         panel_id=parsed["panel_id"],
         panel_w=parsed["panel_w"],
         panel_h=parsed["panel_h"],
@@ -2254,7 +2281,9 @@ def test_widget_preview_page() -> str:
     )
     return render_template(
         "compose.html",
-        page=_hydrate_page(page, preview=True, sample=parsed["sample"]),
+        page=_hydrate_page(
+            page, preview=True, sample=parsed["sample"], locale=parsed["locale_id"]
+        ),
         for_push=False,
         preview_mode=True,
     )
@@ -2290,4 +2319,5 @@ def test_widget_gallery() -> str:
         "widget_gallery.html",
         widgets=rows,
         size_dims=SIZE_DIMENSIONS,
+        locales=_PREVIEW_LOCALES,
     )

--- a/app/composer.py
+++ b/app/composer.py
@@ -1888,7 +1888,12 @@ def test_render() -> str:
     # ?locale=<bcp47> forces the render language for the dev preview
     # surfaces' language picker (/_test/widgets, /_test/preview). Absent
     # -> the production resolution (device override / app default / host).
+    # Clamped to the picker's own tags: the value reaches the client as
+    # ``ctx.locale``, and a free-typed invalid tag would make
+    # ``Intl.DateTimeFormat`` throw mid-render.
     locale_override = request.args.get("locale") or ""
+    if locale_override not in _PREVIEW_LOCALE_IDS:
+        locale_override = ""
 
     # Per-widget content zoom from the gallery's zoom picker. Same
     # 0.5–3.0 clamp the Cell model enforces; out-of-range or unparseable
@@ -2037,6 +2042,7 @@ _PREVIEW_LOCALES: Final[list[dict[str, str]]] = [
     {"id": "en", "label": "English"},
     {"id": "fr", "label": "Français"},
 ]
+_PREVIEW_LOCALE_IDS: Final[set[str]] = {loc["id"] for loc in _PREVIEW_LOCALES}
 
 
 # Multi-cell layout for the preview synthetic page. Spiral halving:
@@ -2156,6 +2162,8 @@ def _parse_preview_args() -> dict[str, Any]:
     theme_id = request.args.get("theme") or "light"
     style_id = request.args.get("style") or "standard"
     locale_id = request.args.get("locale") or ""
+    if locale_id not in _PREVIEW_LOCALE_IDS:
+        locale_id = ""
     sample_mode = request.args.get("sample") == "1"
     panel_id = request.args.get("panel") or _DEFAULT_PREVIEW_PANEL_ID
     if panel_id not in _PREVIEW_PANEL_IDS:

--- a/app/composer.py
+++ b/app/composer.py
@@ -2281,9 +2281,7 @@ def test_widget_preview_page() -> str:
     )
     return render_template(
         "compose.html",
-        page=_hydrate_page(
-            page, preview=True, sample=parsed["sample"], locale=parsed["locale_id"]
-        ),
+        page=_hydrate_page(page, preview=True, sample=parsed["sample"], locale=parsed["locale_id"]),
         for_push=False,
         preview_mode=True,
     )

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -467,6 +467,11 @@ release (marketplace widgets, installed the normal way from Browse).
 There's no separate override mechanism, and no per-widget forking
 required to add a language.
 
+To eyeball a translation without changing any settings, the dev preview
+surfaces (`/_test/widgets` and `/_test/preview`) carry a language picker; 
+it just adds `?locale=<tag>` to the render,
+which is also handy on a raw `/_test/render?plugin=<id>&locale=fr` URL.
+
 ---
 
 ## `server.py` contract (optional)

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -468,9 +468,9 @@ There's no separate override mechanism, and no per-widget forking
 required to add a language.
 
 To eyeball a translation without changing any settings, the dev preview
-surfaces (`/_test/widgets` and `/_test/preview`) carry a language picker; 
-it just adds `?locale=<tag>` to the render,
-which is also handy on a raw `/_test/render?plugin=<id>&locale=fr` URL.
+surfaces (`/_test/widgets` and `/_test/preview`) carry a language picker;
+it just adds `?locale=<tag>` to the render, which is also handy on a raw
+`/_test/render?plugin=<id>&locale=fr` URL.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.367.3"
+version = "0.368.0"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/templates/widget_gallery.html
+++ b/templates/widget_gallery.html
@@ -565,6 +565,21 @@ Not linked from the main nav, visit /_test/widgets directly. #}
           <i class="ph ph-database" aria-hidden="true"></i>
           <span data-sample-label>Sample data</span>
         </button>
+        {# Render-locale picker: threads ?locale=<tag> onto every iframe so
+           each widget's ctx.locale / ctx.strings (and the Intl date /
+           number formatting it drives) reflect the chosen language.
+           "System default" sends no param, so the preview matches what a
+           bound device would actually show. Persisted to localStorage. #}
+        <label class="widget-pill" title="Preview locale">
+          <i class="ph ph-translate" aria-hidden="true"></i>
+          <span class="visually-hidden">Preview locale</span>
+          <select data-locale-select>
+            <option value="">System default</option>
+            {% for loc in locales %}
+            <option value="{{ loc.id }}">{{ loc.label }}</option>
+            {% endfor %}
+          </select>
+        </label>
         <div class="orient-toggle" role="radiogroup" aria-label="Orientation">
           <button type="button" data-orient="landscape" class="is-active" aria-pressed="true">
             <i class="ph ph-rectangle" aria-hidden="true"></i>Landscape
@@ -678,10 +693,14 @@ Not linked from the main nav, visit /_test/widgets directly. #}
     const SAMPLE_KEY   = "tesserae:gallery-sample";
     const ZOOM_KEY     = "tesserae:gallery-zooms";
     const REVIEWED_KEY = "tesserae:gallery-reviewed";
+    const LOCALE_KEY   = "tesserae:gallery-locale";
 
     const state = {
       orient: "landscape",
       sample: true,
+      // "" = let the server resolve the locale as production would;
+      // any other value is a forced BCP-47 tag from the picker.
+      locale: "",
       selected: new Set(),
       // Per-widget content zoom. {widget_id: "1" | "1.5" | …}.
       zooms: {},
@@ -694,6 +713,7 @@ Not linked from the main nav, visit /_test/widgets directly. #}
     const toggle         = document.querySelector(".orient-toggle");
     const sampleBtn      = document.querySelector("[data-sample-toggle]");
     const sampleLabel    = document.querySelector("[data-sample-label]");
+    const localeSelect   = document.querySelector("[data-locale-select]");
     const emptyState     = document.querySelector("[data-gallery-empty]");
     const loadedCount    = document.querySelector("[data-loaded-count]");
     const checkboxes     = Array.from(document.querySelectorAll("[data-widget-toggle]"));
@@ -720,6 +740,7 @@ Not linked from the main nav, visit /_test/widgets directly. #}
       const url = new URL(iframe.dataset.baseSrc, location.origin);
       url.searchParams.set("_o", state.orient === "portrait" ? "p" : "l");
       if (state.sample)  url.searchParams.set("sample", "1");
+      if (state.locale)  url.searchParams.set("locale", state.locale);
       const zoom = state.zooms[widgetId];
       if (zoom && zoom !== "1") url.searchParams.set("zoom", zoom);
       return url.pathname + url.search;
@@ -809,6 +830,7 @@ Not linked from the main nav, visit /_test/widgets directly. #}
           if (openLink) {
             const url = new URL(openLink.dataset.baseHref, location.origin);
             if (state.sample) url.searchParams.set("sample", "1");
+            if (state.locale) url.searchParams.set("locale", state.locale);
             const zoom = state.zooms[id];
             if (zoom && zoom !== "1") url.searchParams.set("zoom", zoom);
             openLink.href = url.pathname + url.search;
@@ -908,6 +930,14 @@ Not linked from the main nav, visit /_test/widgets directly. #}
       });
     }
 
+    if (localeSelect) {
+      localeSelect.addEventListener("change", () => {
+        state.locale = localeSelect.value;
+        try { localStorage.setItem(LOCALE_KEY, state.locale); } catch {}
+        applyAll();
+      });
+    }
+
     // Per-widget zoom pickers. Server clamps 0.5–3.0; iframe rewrites
     // when the value changes.
     zoomPickers.forEach((picker) => {
@@ -941,6 +971,14 @@ Not linked from the main nav, visit /_test/widgets directly. #}
       const s = localStorage.getItem(SAMPLE_KEY);
       if (s === "0") state.sample = false;
     } catch {}
+
+    try {
+      const l = localStorage.getItem(LOCALE_KEY);
+      if (l && localeSelect && [...localeSelect.options].some((o) => o.value === l)) {
+        state.locale = l;
+      }
+    } catch {}
+    if (localeSelect) localeSelect.value = state.locale;
 
     loadSelected();
     checkboxes.forEach((cb) => { cb.checked = state.selected.has(cb.value); });

--- a/templates/widget_preview.html
+++ b/templates/widget_preview.html
@@ -284,6 +284,22 @@
         </select>
       </div>
 
+      <h2>Locale</h2>
+      <div class="field">
+        {# Forces ``ctx.locale`` for every cell in the preview, and with
+           it the widget's own ``strings/<tag>.json`` and anything it
+           derives via ``Intl.DateTimeFormat`` / ``Intl.NumberFormat``.
+           "System default" omits ?locale so the language resolves
+           exactly as a bound device would (device override / app
+           setting / host locale). #}
+        <select name="locale" data-auto-submit>
+          <option value="">System default</option>
+          {% for loc in locales %}
+          <option value="{{ loc.id }}" {% if loc.id == locale_id %}selected{% endif %}>{{ loc.label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+
       <h2>Look</h2>
       <div class="pickers">
         <div class="field">
@@ -398,11 +414,13 @@
         <span class="chip">panel <strong>{{ panel_w }}×{{ panel_h }}</strong></span>
         <span class="chip">theme <strong>{{ theme_id }}</strong></span>
         <span class="chip">style <strong>{{ style_id }}</strong></span>
+        {% if locale_id %}<span class="chip">locale <strong>{{ locale_id }}</strong></span>{% endif %}
         {% if sample %}<span class="chip">sample data</span>{% endif %}
       </div>
     </header>
 
     {% set preview_qs = '?widget=' ~ widget.id ~ '&panel=' ~ panel_id ~ '&theme=' ~ theme_id ~ '&style=' ~ style_id %}
+    {% if locale_id %}{% set preview_qs = preview_qs ~ '&locale=' ~ (locale_id | urlencode) %}{% endif %}
     {% if sample %}{% set preview_qs = preview_qs ~ '&sample=1' %}{% endif %}
     {% if opts_json %}{% set preview_qs = preview_qs ~ '&opts=' ~ (opts_json | urlencode) %}{% endif %}
 

--- a/tests/test_composer_locale.py
+++ b/tests/test_composer_locale.py
@@ -171,3 +171,52 @@ def test_calendar_day_receives_its_real_french_strings(client: FlaskClient, app:
         "events": "événements",
         "at": "à",
     }
+
+
+# -- dev preview surfaces: the ?locale= override + the picker ----------
+
+
+def test_test_render_locale_param_forces_render_language(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The dev gallery's language picker rides on ``/_test/render?locale=``.
+    It overrides the production resolution (no app-level locale set here,
+    host locale cleared) so a reviewer can eyeball any widget in any
+    language without touching Settings."""
+    monkeypatch.delenv("LC_ALL", raising=False)
+    monkeypatch.delenv("LANG", raising=False)
+    plain = client.get("/_test/render?plugin=calendar_day&size=md")
+    assert _cell_dataset(plain.get_data(as_text=True), "locale") == "en"
+
+    forced = client.get("/_test/render?plugin=calendar_day&size=md&locale=fr")
+    body = forced.get_data(as_text=True)
+    assert _cell_dataset(body, "locale") == "fr"
+    assert json.loads(_cell_dataset(body, "strings"))["event"] == "événement"
+
+
+def test_widget_preview_page_honours_locale_param(client: FlaskClient) -> None:
+    """The single-widget preview's iframe (``/_test/preview/page``) threads
+    the picked locale through ``_parse_preview_args`` the same way."""
+    resp = client.get("/_test/preview/page?widget=calendar_day&locale=fr")
+    assert resp.status_code == 200
+    assert _cell_dataset(resp.get_data(as_text=True), "locale") == "fr"
+
+
+def test_widget_gallery_offers_the_locale_picker(client: FlaskClient) -> None:
+    resp = client.get("/_test/widgets")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "data-locale-select" in body
+    assert ">System default<" in body  # the leading "resolve as prod" option
+    assert 'value="en"' in body
+    assert 'value="fr"' in body
+
+
+def test_widget_preview_controls_include_the_locale_select(client: FlaskClient) -> None:
+    resp = client.get("/_test/preview?widget=calendar_day&locale=fr")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'name="locale"' in body
+    assert ">System default<" in body
+    # The picked tag round-trips as the selected option.
+    assert 'value="fr" selected' in body

--- a/tests/test_composer_locale.py
+++ b/tests/test_composer_locale.py
@@ -194,6 +194,18 @@ def test_test_render_locale_param_forces_render_language(
     assert json.loads(_cell_dataset(body, "strings"))["event"] == "événement"
 
 
+def test_test_render_unknown_locale_falls_back_to_production_resolution(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A free-typed ``?locale=`` outside the picker's tags is dropped, not
+    forwarded: it would reach the client as ``ctx.locale`` and an invalid
+    BCP-47 tag makes ``Intl.DateTimeFormat`` throw mid-render."""
+    monkeypatch.delenv("LC_ALL", raising=False)
+    monkeypatch.delenv("LANG", raising=False)
+    resp = client.get("/_test/render?plugin=calendar_day&size=md&locale=zz-not-a-tag")
+    assert _cell_dataset(resp.get_data(as_text=True), "locale") == "en"
+
+
 def test_widget_preview_page_honours_locale_param(client: FlaskClient) -> None:
     """The single-widget preview's iframe (``/_test/preview/page``) threads
     the picked locale through ``_parse_preview_args`` the same way."""

--- a/uv.lock
+++ b/uv.lock
@@ -1934,7 +1934,7 @@ wheels = [
 
 [[package]]
 name = "tesserae"
-version = "0.367.3"
+version = "0.368.0"
 source = { editable = "." }
 dependencies = [
     { name = "amqtt" },


### PR DESCRIPTION
## What this changes

Adds a locale selector at the top of widget preview dev page.

<img width="1815" height="748" alt="image" src="https://github.com/user-attachments/assets/73e49fc3-7e37-43f6-ab0f-062b14f70be2" />

## Why

This facilitate widget translations and makes it easier to check whether the added translation is right or not.

## Test plan

<!-- The commands you ran and what you verified. Reviewers should be
able to repeat this. Skip the obvious (don't say "ran the tests") and
call out what's *not* covered by automated tests, UI, hardware,
manual flows. -->

- [ ] `pytest -q` -> still takes way too long to run on my locale machine, sorry
- [x] `ruff check . && ruff format --check .`
- [x] `mypy app`
- [x] Manually verified: validate the selector updates the showed widgets and displays the values based on the selected locale

## Checklist

- [x] Tests added for new behaviour (or note why none made sense)
- [x] `ruff` + `mypy` clean
- [x] User-facing changes documented (README, `docs/`, or both)
- [x] CHANGELOG entry added under `## [Unreleased]` if user-facing
- [x] `pyproject.toml` version bumped if this is going to be tagged
