### PR TITLE
feat(widgets): calendar_week french translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to Tesserae are recorded here. Format loosely follows
   `/_test/preview` now carry an English / French locale picker; it adds `?locale=<tag>` to the
   render so a contributor can check a widget's translated strings and its `Intl` date / number
   formatting without touching any install-wide or per-device setting.
+- **The Calendar (week) widget is translated to French.** Header, event counts, and the
+  weekday / month labels follow the render locale; non-English names come from `Intl`
+  rather than a hand-rolled table.
 
 ## [0.367.3], 2026-08-27
 

--- a/plugins/calendar_week/client.js
+++ b/plugins/calendar_week/client.js
@@ -25,14 +25,16 @@ const WEEKDAY_FULL = [
 // date_label_style cell option: "short" (default, current 3-letter
 // behaviour), "minimal" (1-2 chars, just enough to stay unambiguous), or
 // "full" (the whole word). Base label is always the *full* localised
-// name, short/minimal are derived from it.
+// name, short/minimal are derived from it. Labels keep their natural
+// casing here; display casing belongs to CSS (--label-transform), so
+// sentence-case styles like Editorial stay sentence-case.
 const DOW_MINIMAL = { Monday: "M", Tuesday: "Tu", Wednesday: "W", Thursday: "Th", Friday: "F", Saturday: "Sa", Sunday: "Su" };
 const MONTH_MINIMAL = { January: "Ja", February: "F", March: "Mr", April: "Ap", May: "My", June: "Jn", July: "Jl", August: "Au", September: "S", October: "O", November: "N", December: "D" };
 
 export function styleLabel(full, style, minimalMap) {
-  if (style === "minimal") return (minimalMap[full] || full.slice(0, 2)).toUpperCase();
-  if (style === "short") return full.slice(0, 3).toUpperCase();
-  return full.toUpperCase();
+  if (style === "minimal") return minimalMap[full] || full.slice(0, 2);
+  if (style === "short") return full.slice(0, 3);
+  return full;
 }
 
 // locales contract (docs/widgets.md#locales-strings): English keeps the

--- a/plugins/calendar_week/client.js
+++ b/plugins/calendar_week/client.js
@@ -13,25 +13,44 @@
 // widget), and date_label_style (short/minimal weekday+month
 // abbreviations).
 
-const MONTH_SHORT = [
-  "JAN", "FEB", "MAR", "APR", "MAY", "JUN",
-  "JUL", "AUG", "SEP", "OCT", "NOV", "DEC",
+const MONTH_FULL = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
 ];
-const DOW = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"];
+const WEEKDAY_FULL = [
+  "Monday", "Tuesday", "Wednesday", "Thursday",
+  "Friday", "Saturday", "Sunday",
+];
 
 // date_label_style cell option: "short" (default, current 3-letter
 // behaviour), "minimal" (1-2 chars, just enough to stay unambiguous), or
-// "full" (the whole word, derived from the short code since that's all
-// this widget stores).
-const DOW_MINIMAL = { SUN: "SU", MON: "M", TUE: "TU", WED: "W", THU: "TH", FRI: "F", SAT: "SA" };
-const MONTH_MINIMAL = { JAN: "JA", FEB: "F", MAR: "MR", APR: "AP", MAY: "MY", JUN: "JN", JUL: "JL", AUG: "AU", SEP: "S", OCT: "O", NOV: "N", DEC: "D" };
-const DOW_FULL = { SUN: "Sunday", MON: "Monday", TUE: "Tuesday", WED: "Wednesday", THU: "Thursday", FRI: "Friday", SAT: "Saturday" };
-const MONTH_FULL = { JAN: "January", FEB: "February", MAR: "March", APR: "April", MAY: "May", JUN: "June", JUL: "July", AUG: "August", SEP: "September", OCT: "October", NOV: "November", DEC: "December" };
+// "full" (the whole word). Base label is always the *full* localised
+// name, short/minimal are derived from it.
+const DOW_MINIMAL = { Monday: "M", Tuesday: "Tu", Wednesday: "W", Thursday: "Th", Friday: "F", Saturday: "Sa", Sunday: "Su" };
+const MONTH_MINIMAL = { January: "Ja", February: "F", March: "Mr", April: "Ap", May: "My", June: "Jn", July: "Jl", August: "Au", September: "S", October: "O", November: "N", December: "D" };
 
-export function styleShortLabel(label, style, minimalMap, fullMap) {
-  if (style === "minimal") return minimalMap[label] || label.slice(0, 2);
-  if (style === "full") return (fullMap && fullMap[label]) || label;
-  return label;
+export function styleLabel(full, style, minimalMap) {
+  if (style === "minimal") return (minimalMap[full] || full.slice(0, 2)).toUpperCase();
+  if (style === "short") return full.slice(0, 3).toUpperCase();
+  return full.toUpperCase();
+}
+
+// locales contract (docs/widgets.md#locales-strings): English keeps the
+// hardcoded arrays above (so styleLabel's minimal map, keyed by the
+// English full name, still resolves); any other locale asks Intl for
+// the real localised name instead of a hand-rolled weekday/month table.
+export function localizedFull(date, unit, locale) {
+  const lang = (locale || "en").split("-")[0];
+  if (lang === "en") {
+    return unit === "weekday" ? WEEKDAY_FULL[(date.getDay() + 6) % 7] : MONTH_FULL[date.getMonth()];
+  }
+  return new Intl.DateTimeFormat(locale, { [unit]: "long" }).format(date);
+}
+
+export function minimalMapFor(unit, locale) {
+  const lang = (locale || "en").split("-")[0];
+  if (lang !== "en") return {};
+  return unit === "weekday" ? DOW_MINIMAL : MONTH_MINIMAL;
 }
 
 function escapeHtml(s) {
@@ -188,12 +207,13 @@ function hourLabels(range) {
   return out.join("");
 }
 
-function fmtRange(startIso, endIso, labelStyle) {
+function fmtRange(startIso, endIso, labelStyle, locale) {
   if (!startIso || !endIso) return "";
   const [sy, sm, sd] = startIso.split("-").map(Number);
   const [ey, em, ed] = endIso.split("-").map(Number);
-  const startMonth = styleShortLabel(MONTH_SHORT[sm - 1] || "", labelStyle, MONTH_MINIMAL, MONTH_FULL);
-  const endMonth = styleShortLabel(MONTH_SHORT[em - 1] || "", labelStyle, MONTH_MINIMAL, MONTH_FULL);
+  const monthMinimalMap = minimalMapFor("month", locale);
+  const startMonth = styleLabel(localizedFull(new Date(sy, sm - 1, sd), "month", locale), labelStyle, monthMinimalMap);
+  const endMonth = styleLabel(localizedFull(new Date(ey, em - 1, ed), "month", locale), labelStyle, monthMinimalMap);
   const startBit = `${startMonth} ${sd}`;
   const endBit = (sm === em) ? `${ed}` : `${endMonth} ${ed}`;
   const year = sy === ey ? `${sy}` : `${sy}/${ey}`;
@@ -203,6 +223,8 @@ function fmtRange(startIso, endIso, labelStyle) {
 export default function render(shadow, ctx) {
   const data = ctx?.data ?? {};
   const opts = ctx?.cell?.options || {};
+  const locale = ctx?.locale || "en";
+  const t = ctx?.t || ((key, fallback) => fallback ?? key);
   const hideLabels = opts.hide_labels === true;
   const titleScale = clampScale(opts.event_title_scale, 1.0, 0.01, 10.0);
   const locScale = clampScale(opts.event_location_scale, 1.0, 0.01, 10.0);
@@ -229,13 +251,17 @@ export default function render(shadow, ctx) {
   const days = Array.isArray(data.days) ? data.days.slice(0, 7) : [];
   const range = computeRange(days, startHour, endHour);
   const span = Math.max(1, range.end - range.start);
-  const rangeMeta = fmtRange(data.start, data.end, labelStyle);
+  const rangeMeta = fmtRange(data.start, data.end, labelStyle, locale);
 
+  const dowMinimalMap = minimalMapFor("weekday", locale);
   const heads = days.map((d) => {
-    const name = styleShortLabel(DOW[d.weekday] || "", labelStyle, DOW_MINIMAL, DOW_FULL);
+    const [dy, dm, dd] = (d.date || "").split("-").map(Number);
+    const dowFull = Number.isFinite(dy) ? localizedFull(new Date(dy, dm - 1, dd), "weekday", locale) : "";
+    const name = dowFull ? styleLabel(dowFull, labelStyle, dowMinimalMap) : "";
     const isToday = !!d.is_today;
     const isWeekend = d.weekday === 5 || d.weekday === 6;
     const count = Array.isArray(d.events) ? d.events.length : 0;
+    const noun = t(count === 1 ? "event" : "events", count === 1 ? "event" : "events");
     const classes = ["tt-col-head"];
     if (isToday) classes.push("is-today");
     if (isWeekend) classes.push("is-weekend");
@@ -243,7 +269,7 @@ export default function render(shadow, ctx) {
       <div class="${classes.join(" ")}">
         <span class="tt-col-dow">${escapeHtml(name)}</span>
         <span class="tt-col-day">${escapeHtml(String(d.day || ""))}</span>
-        ${count > 0 ? `<span class="tt-col-count" title="${count} event${count === 1 ? "" : "s"}">${count}</span>` : ""}
+        ${count > 0 ? `<span class="tt-col-count" title="${count} ${noun}">${count}</span>` : ""}
       </div>`;
   }).join("");
 
@@ -441,7 +467,7 @@ export default function render(shadow, ctx) {
       <div class="w-body" style="gap:var(--space-3)">
         <div class="cal-head">
           <div class="cal-head-row">
-            <span class="cal-head-title">THIS WEEK</span>
+            <span class="cal-head-title">${escapeHtml(t("this_week", "THIS WEEK"))}</span>
             <span class="cal-head-meta">${escapeHtml(rangeMeta)}</span>
           </div>
           <div class="cal-head-rule"></div>

--- a/plugins/calendar_week/plugin.json
+++ b/plugins/calendar_week/plugin.json
@@ -5,6 +5,7 @@
   "kind": "widget",
   "description": "Seven-day strip timetable with tunable event text sizing/spacing, configurable visible hour range, and a location toggle. Each event's colour comes from its feed (Widgets → Calendar Feeds).",
   "icon": "ph-calendar",
+  "locales": ["en", "fr"],
   "supports": {
     "sizes": [
       "sm",

--- a/plugins/calendar_week/strings/en.json
+++ b/plugins/calendar_week/strings/en.json
@@ -1,0 +1,5 @@
+{
+  "this_week": "THIS WEEK",
+  "event": "event",
+  "events": "events"
+}

--- a/plugins/calendar_week/strings/fr.json
+++ b/plugins/calendar_week/strings/fr.json
@@ -1,0 +1,5 @@
+{
+  "this_week": "CETTE SEMAINE",
+  "event": "événement",
+  "events": "événements"
+}

--- a/plugins/calendar_week/tests/clamp_check.mjs
+++ b/plugins/calendar_week/tests/clamp_check.mjs
@@ -1,7 +1,7 @@
 // Plain-node self-check (no test framework in this repo).
 // Run: node tests/clamp_check.mjs
 import assert from "node:assert/strict";
-import { clampScale, clampToDay, computeRange, pctSpan, styleShortLabel } from "../client.js";
+import { clampScale, clampToDay, computeRange, localizedFull, minimalMapFor, pctSpan, styleLabel } from "../client.js";
 
 assert.equal(clampScale(undefined, 1.0, 0.7, 1.5), 1.0, "missing falls back to default");
 assert.equal(clampScale(null, 1.0, 0.7, 1.5), 1.0, "null falls back to default");
@@ -43,13 +43,27 @@ assert.deepEqual(pctSpan(0, 24, 8, 4), { top: 0, height: 100 }, "a full 0-24h pa
 assert.deepEqual(pctSpan(0, 24, 8, 10), { top: 0, height: 100 }, "still clamps to 100% with a wider (but still partial) range");
 assert.deepEqual(pctSpan(20, 24, 8, 4), { top: 100, height: 2 }, "a span entirely after the visible range clamps to the bottom edge, not off it");
 
-// date_label_style: short (current) / minimal (1-2 chars) / full (whole word).
-const DOW_MINIMAL = { TUE: "TU", THU: "TH" };
-const DOW_FULL = { TUE: "Tuesday" };
-assert.equal(styleShortLabel("TUE", "short", DOW_MINIMAL), "TUE", "short passes the existing label through unchanged");
-assert.equal(styleShortLabel("TUE", "minimal", DOW_MINIMAL), "TU", "minimal uses the disambiguation map");
-assert.equal(styleShortLabel("ZZZ", "minimal", {}), "ZZ", "unmapped label falls back to first 2 chars");
-assert.equal(styleShortLabel("TUE", "full", DOW_MINIMAL, DOW_FULL), "Tuesday", "full looks up the whole word");
-assert.equal(styleShortLabel("ZZZ", "full", {}, {}), "ZZZ", "unmapped full falls back to the short label as-is");
+// date_label_style: full (default) / short (3-letter) / minimal (1-2
+// chars, disambiguated). Base label is always the full name.
+const DOW_MINIMAL = { Tuesday: "Tu", Thursday: "Th" };
+assert.equal(styleLabel("Monday", "full", {}), "MONDAY", "full keeps the whole word, upper-cased");
+assert.equal(styleLabel("Tuesday", "short", {}), "TUE", "short is a 3-letter abbreviation");
+assert.equal(styleLabel("Tuesday", "minimal", DOW_MINIMAL), "TU", "minimal uses the disambiguation map");
+assert.equal(styleLabel("Thursday", "minimal", DOW_MINIMAL), "TH", "Tue/Thu don't collide at 1 char");
+assert.equal(styleLabel("Zzyzx", "minimal", {}), "ZZ", "unmapped label falls back to first 2 chars");
+
+// locales contract (docs/widgets.md#locales-strings): localizedFull() /
+// minimalMapFor() are what feed a locale-aware name into styleLabel above.
+// A Monday, so weekday indices are unambiguous either way.
+const monday = new Date(2026, 0, 5);
+assert.equal(localizedFull(monday, "weekday", "en"), "Monday", "English reads the hardcoded array, not Intl");
+assert.equal(localizedFull(monday, "month", "en-US"), "January", "English variants (en-US) still count as English");
+assert.equal(localizedFull(monday, "weekday", "fr"), "lundi", "non-English asks Intl for the real localised name");
+assert.equal(localizedFull(monday, "month", "fr"), "janvier", "same for months");
+assert.equal(localizedFull(monday, "weekday", ""), "Monday", "no locale at all defaults to English");
+
+assert.equal(minimalMapFor("weekday", "en").Tuesday, "Tu", "English gets the real disambiguation map");
+assert.deepEqual(minimalMapFor("weekday", "fr"), {}, "non-English gets {} -- styleLabel's generic slice, not English abbreviations");
+assert.deepEqual(minimalMapFor("month", "de"), {}, "same for months");
 
 console.log("clamp_check.mjs: all assertions passed");

--- a/plugins/calendar_week/tests/clamp_check.mjs
+++ b/plugins/calendar_week/tests/clamp_check.mjs
@@ -44,13 +44,14 @@ assert.deepEqual(pctSpan(0, 24, 8, 10), { top: 0, height: 100 }, "still clamps t
 assert.deepEqual(pctSpan(20, 24, 8, 4), { top: 100, height: 2 }, "a span entirely after the visible range clamps to the bottom edge, not off it");
 
 // date_label_style: full (default) / short (3-letter) / minimal (1-2
-// chars, disambiguated). Base label is always the full name.
+// chars, disambiguated). Base label is always the full name; display
+// casing is CSS's job (--label-transform), not styleLabel's.
 const DOW_MINIMAL = { Tuesday: "Tu", Thursday: "Th" };
-assert.equal(styleLabel("Monday", "full", {}), "MONDAY", "full keeps the whole word, upper-cased");
-assert.equal(styleLabel("Tuesday", "short", {}), "TUE", "short is a 3-letter abbreviation");
-assert.equal(styleLabel("Tuesday", "minimal", DOW_MINIMAL), "TU", "minimal uses the disambiguation map");
-assert.equal(styleLabel("Thursday", "minimal", DOW_MINIMAL), "TH", "Tue/Thu don't collide at 1 char");
-assert.equal(styleLabel("Zzyzx", "minimal", {}), "ZZ", "unmapped label falls back to first 2 chars");
+assert.equal(styleLabel("Monday", "full", {}), "Monday", "full keeps the whole word, natural casing");
+assert.equal(styleLabel("Tuesday", "short", {}), "Tue", "short is a 3-letter abbreviation");
+assert.equal(styleLabel("Tuesday", "minimal", DOW_MINIMAL), "Tu", "minimal uses the disambiguation map");
+assert.equal(styleLabel("Thursday", "minimal", DOW_MINIMAL), "Th", "Tue/Thu don't collide at 1 char");
+assert.equal(styleLabel("Zzyzx", "minimal", {}), "Zz", "unmapped label falls back to first 2 chars");
 
 // locales contract (docs/widgets.md#locales-strings): localizedFull() /
 // minimalMapFor() are what feed a locale-aware name into styleLabel above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.368.0"
+version = "0.369.0"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/uv.lock
+++ b/uv.lock
@@ -1934,7 +1934,7 @@ wheels = [
 
 [[package]]
 name = "tesserae"
-version = "0.368.0"
+version = "0.369.0"
 source = { editable = "." }
 dependencies = [
     { name = "amqtt" },


### PR DESCRIPTION
## What this changes

Translates the calendar_week widget to french

<img width="1456" height="453" alt="image" src="https://github.com/user-attachments/assets/190585c8-4157-494a-856a-1d279dd85ee2" />

## Why

Make the widget accessible to french speaking users

## Test plan

<!-- The commands you ran and what you verified. Reviewers should be
able to repeat this. Skip the obvious (don't say "ran the tests") and
call out what's *not* covered by automated tests, UI, hardware,
manual flows. -->

- [ ] `pytest -q` -> still unable to run the tests under 1.5h without crashing
- [x] `ruff check . && ruff format --check .`
- [x] `mypy app`
- [x] Manually verified: every part of the widget is correctly translated to french

## Checklist

- [x] Tests added for new behaviour (or note why none made sense)
- [x] `ruff` + `mypy` clean
- [ ] User-facing changes documented (README, `docs/`, or both)
- [x] CHANGELOG entry added under `## [Unreleased]` if user-facing
- [x] `pyproject.toml` version bumped if this is going to be tagged
