### PR TITLE
feat(widgets): calendar_month translated to french

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 - **The Calendar (week) widget is translated to French.** Header, event counts, and the
   weekday / month labels follow the render locale; non-English names come from `Intl`
   rather than a hand-rolled table.
+- **The Calendar (month) widget is translated to French.** Month title, weekday header,
+  and the week-start note follow the render locale, on the same `Intl` + `strings/` path
+  as the week widget. The weekday header row now upper-cases by default like the other
+  calendar labels (sentence-case styles still get sentence case via `--label-transform`).
 
 ## [0.367.3], 2026-08-27
 

--- a/plugins/calendar_month/client.js
+++ b/plugins/calendar_month/client.js
@@ -26,19 +26,44 @@ function escapeHtml(s) {
   }[c]));
 }
 
-const DOW = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-const DOW_SUN = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const MONTH_FULL = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+const WEEKDAY_FULL = [
+  "Monday", "Tuesday", "Wednesday", "Thursday",
+  "Friday", "Saturday", "Sunday",
+];
 
 // date_label_style cell option: "short" (default, current 3-letter
 // behaviour), "minimal" (1-2 chars, just enough to stay unambiguous), or
-// "full" (the whole word).
-const DOW_MINIMAL = { Sun: "Su", Mon: "M", Tue: "Tu", Wed: "W", Thu: "Th", Fri: "F", Sat: "Sa" };
-const DOW_FULL = { Sun: "Sunday", Mon: "Monday", Tue: "Tuesday", Wed: "Wednesday", Thu: "Thursday", Fri: "Friday", Sat: "Saturday" };
+// "full" (the whole word). Base label is always the *full* localised
+// name, short/minimal are derived from it.
+const DOW_MINIMAL = { Monday: "M", Tuesday: "Tu", Wednesday: "W", Thursday: "Th", Friday: "F", Saturday: "Sa", Sunday: "Su" };
+const MONTH_MINIMAL = { January: "Ja", February: "F", March: "Mr", April: "Ap", May: "My", June: "Jn", July: "Jl", August: "Au", September: "S", October: "O", November: "N", December: "D" };
 
-export function styleShortLabel(label, style, minimalMap, fullMap) {
-  if (style === "minimal") return minimalMap[label] || label.slice(0, 2);
-  if (style === "full") return (fullMap && fullMap[label]) || label;
-  return label;
+export function styleLabel(full, style, minimalMap) {
+  if (style === "minimal") return (minimalMap[full] || full.slice(0, 2)).toUpperCase();
+  if (style === "short") return full.slice(0, 3).toUpperCase();
+  return full.toUpperCase();
+}
+
+// locales contract (docs/widgets.md#locales-strings): English keeps the
+// hardcoded arrays above (so styleLabel's minimal map, keyed by the
+// English full name, still resolves); any other locale asks Intl for
+// the real localised name instead of a hand-rolled weekday/month table.
+export function localizedFull(date, unit, locale) {
+  const lang = (locale || "en").split("-")[0];
+  if (lang === "en") {
+    return unit === "weekday" ? WEEKDAY_FULL[(date.getDay() + 6) % 7] : MONTH_FULL[date.getMonth()];
+  }
+  return new Intl.DateTimeFormat(locale, { [unit]: "long" }).format(date);
+}
+
+export function minimalMapFor(unit, locale) {
+  const lang = (locale || "en").split("-")[0];
+  if (lang !== "en") return {};
+  return unit === "weekday" ? DOW_MINIMAL : MONTH_MINIMAL;
 }
 
 // Clamps a cell-option slider value, defaulting on missing/non-numeric
@@ -77,9 +102,13 @@ function heatBackground(count) {
   return `background: color-mix(in oklab, var(--accent-4) ${alpha.toFixed(0)}%, var(--surface));`;
 }
 
+const WEEK_ANCHOR_DAYS = [5, 6, 7, 8, 9, 10, 11]; // Mon..Sun
+
 export default function render(shadow, ctx) {
   const data = ctx?.data ?? {};
   const opts = ctx?.cell?.options || {};
+  const locale = ctx?.locale || "en";
+  const t = ctx?.t || ((key, fallback) => fallback ?? key);
   const display = opts.event_display === "text" ? "text" : "bars";
   const maxPerDay = Math.max(1, Number(opts.max_events_per_day) || 3);
   // Heat-tint on by default; cell option flips it off for users who
@@ -105,13 +134,23 @@ export default function render(shadow, ctx) {
   }
 
   const days = Array.isArray(data.days) ? data.days : [];
-  const dowNames = (data.week_start === "sunday") ? DOW_SUN : DOW;
-  const monthName = (data.month_name || "").toUpperCase();
+  const weekdayDates = WEEK_ANCHOR_DAYS.map((day) => new Date(2026, 0, day)); // Mon..Sun
+  const orderedDates = (data.week_start === "sunday")
+    ? [weekdayDates[6], ...weekdayDates.slice(0, 6)]
+    : weekdayDates;
+  const monthDate = new Date(data.year || 2026, (data.month || 1) - 1, 1);
+  const monthName = localizedFull(monthDate, "month", locale).toUpperCase();
   const year = data.year || "";
-  const weekStartLabel = (data.week_start === "sunday") ? "WEEK STARTS SUN" : "WEEK STARTS MON";
+  const weekStartLabel = (data.week_start === "sunday")
+    ? t("week_start_sunday", "Week starts Sun")
+    : t("week_start_monday", "Week starts Mon");
 
-  const dowHeader = dowNames
-    .map((name) => `<span>${escapeHtml(styleShortLabel(name, labelStyle, DOW_MINIMAL, DOW_FULL))}</span>`)
+  const dowMinimalMap = minimalMapFor("weekday", locale);
+  const dowHeader = orderedDates
+    .map((d) => {
+      const full = localizedFull(d, "weekday", locale);
+      return `<span>${escapeHtml(styleLabel(full, labelStyle, dowMinimalMap))}</span>`;
+    })
     .join("");
 
   const cells = days.map((d) => {

--- a/plugins/calendar_month/client.js
+++ b/plugins/calendar_month/client.js
@@ -38,14 +38,16 @@ const WEEKDAY_FULL = [
 // date_label_style cell option: "short" (default, current 3-letter
 // behaviour), "minimal" (1-2 chars, just enough to stay unambiguous), or
 // "full" (the whole word). Base label is always the *full* localised
-// name, short/minimal are derived from it.
+// name, short/minimal are derived from it. Labels keep their natural
+// casing here; display casing belongs to CSS (--label-transform), so
+// sentence-case styles like Editorial stay sentence-case.
 const DOW_MINIMAL = { Monday: "M", Tuesday: "Tu", Wednesday: "W", Thursday: "Th", Friday: "F", Saturday: "Sa", Sunday: "Su" };
 const MONTH_MINIMAL = { January: "Ja", February: "F", March: "Mr", April: "Ap", May: "My", June: "Jn", July: "Jl", August: "Au", September: "S", October: "O", November: "N", December: "D" };
 
 export function styleLabel(full, style, minimalMap) {
-  if (style === "minimal") return (minimalMap[full] || full.slice(0, 2)).toUpperCase();
-  if (style === "short") return full.slice(0, 3).toUpperCase();
-  return full.toUpperCase();
+  if (style === "minimal") return minimalMap[full] || full.slice(0, 2);
+  if (style === "short") return full.slice(0, 3);
+  return full;
 }
 
 // locales contract (docs/widgets.md#locales-strings): English keeps the

--- a/plugins/calendar_month/plugin.json
+++ b/plugins/calendar_month/plugin.json
@@ -5,6 +5,7 @@
   "kind": "widget",
   "description": "Month-grid view with tunable dashboard title/day-number/event text sizing, cell spacing, and a location toggle for text-display mode. Each feed's colour drives the bar / dot / stripe colour.",
   "icon": "ph-calendar",
+  "locales": ["en", "fr"],
   "supports": {
     "sizes": [
       "md",

--- a/plugins/calendar_month/strings/en.json
+++ b/plugins/calendar_month/strings/en.json
@@ -1,0 +1,4 @@
+{
+  "week_start_sunday": "Week starts Sun",
+  "week_start_monday": "Week starts Mon"
+}

--- a/plugins/calendar_month/strings/fr.json
+++ b/plugins/calendar_month/strings/fr.json
@@ -1,0 +1,4 @@
+{
+  "week_start_sunday": "Semaine débute dim.",
+  "week_start_monday": "Semaine débute lun."
+}

--- a/plugins/calendar_month/strings/fr.json
+++ b/plugins/calendar_month/strings/fr.json
@@ -1,4 +1,4 @@
 {
-  "week_start_sunday": "Semaine débute dim.",
-  "week_start_monday": "Semaine débute lun."
+  "week_start_sunday": "La semaine débute dim.",
+  "week_start_monday": "La semaine débute lun."
 }

--- a/plugins/calendar_month/tests/clamp_check.mjs
+++ b/plugins/calendar_month/tests/clamp_check.mjs
@@ -1,7 +1,7 @@
 // Plain-node self-check (no test framework in this repo).
 // Run: node tests/clamp_check.mjs
 import assert from "node:assert/strict";
-import { clampScale, styleShortLabel } from "../client.js";
+import { clampScale, localizedFull, minimalMapFor, styleLabel } from "../client.js";
 
 assert.equal(clampScale(undefined, 1.0, 0.1, 5.0), 1.0, "missing falls back to default");
 assert.equal(clampScale(null, 1.0, 0.1, 5.0), 1.0, "null falls back to default");
@@ -10,13 +10,27 @@ assert.equal(clampScale(2.5, 1.0, 0.1, 5.0), 2.5, "in-range value passes through
 assert.equal(clampScale(9, 1.0, 0.1, 5.0), 5.0, "above max clamps down");
 assert.equal(clampScale(0.0, 1.0, 0.1, 5.0), 0.1, "below min clamps up");
 
-// date_label_style: short (current) / minimal (1-2 chars) / full (whole word).
-const DOW_MINIMAL = { Tue: "Tu", Thu: "Th" };
-const DOW_FULL = { Tue: "Tuesday" };
-assert.equal(styleShortLabel("Tue", "short", DOW_MINIMAL), "Tue", "short passes the existing label through unchanged");
-assert.equal(styleShortLabel("Tue", "minimal", DOW_MINIMAL), "Tu", "minimal uses the disambiguation map");
-assert.equal(styleShortLabel("Zzz", "minimal", {}), "Zz", "unmapped label falls back to first 2 chars");
-assert.equal(styleShortLabel("Tue", "full", DOW_MINIMAL, DOW_FULL), "Tuesday", "full looks up the whole word");
-assert.equal(styleShortLabel("Zzz", "full", {}, {}), "Zzz", "unmapped full falls back to the short label as-is");
+// date_label_style: full (default) / short (3-letter) / minimal (1-2
+// chars, disambiguated). Base label is always the full name.
+const DOW_MINIMAL = { Tuesday: "Tu", Thursday: "Th" };
+assert.equal(styleLabel("Monday", "full", {}), "MONDAY", "full keeps the whole word, upper-cased");
+assert.equal(styleLabel("Tuesday", "short", {}), "TUE", "short is a 3-letter abbreviation");
+assert.equal(styleLabel("Tuesday", "minimal", DOW_MINIMAL), "TU", "minimal uses the disambiguation map");
+assert.equal(styleLabel("Thursday", "minimal", DOW_MINIMAL), "TH", "Tue/Thu don't collide at 1 char");
+assert.equal(styleLabel("Zzyzx", "minimal", {}), "ZZ", "unmapped label falls back to first 2 chars");
+
+// locales contract (docs/widgets.md#locales-strings): localizedFull() /
+// minimalMapFor() are what feed a locale-aware name into styleLabel above.
+// A Monday, so weekday indices are unambiguous either way.
+const monday = new Date(2026, 0, 5);
+assert.equal(localizedFull(monday, "weekday", "en"), "Monday", "English reads the hardcoded array, not Intl");
+assert.equal(localizedFull(monday, "month", "en-US"), "January", "English variants (en-US) still count as English");
+assert.equal(localizedFull(monday, "weekday", "fr"), "lundi", "non-English asks Intl for the real localised name");
+assert.equal(localizedFull(monday, "month", "fr"), "janvier", "same for months");
+assert.equal(localizedFull(monday, "weekday", ""), "Monday", "no locale at all defaults to English");
+
+assert.equal(minimalMapFor("weekday", "en").Tuesday, "Tu", "English gets the real disambiguation map");
+assert.deepEqual(minimalMapFor("weekday", "fr"), {}, "non-English gets {} -- styleLabel's generic slice, not English abbreviations");
+assert.deepEqual(minimalMapFor("month", "de"), {}, "same for months");
 
 console.log("clamp_check.mjs: all assertions passed");

--- a/plugins/calendar_month/tests/clamp_check.mjs
+++ b/plugins/calendar_month/tests/clamp_check.mjs
@@ -11,13 +11,14 @@ assert.equal(clampScale(9, 1.0, 0.1, 5.0), 5.0, "above max clamps down");
 assert.equal(clampScale(0.0, 1.0, 0.1, 5.0), 0.1, "below min clamps up");
 
 // date_label_style: full (default) / short (3-letter) / minimal (1-2
-// chars, disambiguated). Base label is always the full name.
+// chars, disambiguated). Base label is always the full name; display
+// casing is CSS's job (--label-transform), not styleLabel's.
 const DOW_MINIMAL = { Tuesday: "Tu", Thursday: "Th" };
-assert.equal(styleLabel("Monday", "full", {}), "MONDAY", "full keeps the whole word, upper-cased");
-assert.equal(styleLabel("Tuesday", "short", {}), "TUE", "short is a 3-letter abbreviation");
-assert.equal(styleLabel("Tuesday", "minimal", DOW_MINIMAL), "TU", "minimal uses the disambiguation map");
-assert.equal(styleLabel("Thursday", "minimal", DOW_MINIMAL), "TH", "Tue/Thu don't collide at 1 char");
-assert.equal(styleLabel("Zzyzx", "minimal", {}), "ZZ", "unmapped label falls back to first 2 chars");
+assert.equal(styleLabel("Monday", "full", {}), "Monday", "full keeps the whole word, natural casing");
+assert.equal(styleLabel("Tuesday", "short", {}), "Tue", "short is a 3-letter abbreviation");
+assert.equal(styleLabel("Tuesday", "minimal", DOW_MINIMAL), "Tu", "minimal uses the disambiguation map");
+assert.equal(styleLabel("Thursday", "minimal", DOW_MINIMAL), "Th", "Tue/Thu don't collide at 1 char");
+assert.equal(styleLabel("Zzyzx", "minimal", {}), "Zz", "unmapped label falls back to first 2 chars");
 
 // locales contract (docs/widgets.md#locales-strings): localizedFull() /
 // minimalMapFor() are what feed a locale-aware name into styleLabel above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.369.0"
+version = "0.370.0"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/static/style/spectra-widgets.css
+++ b/static/style/spectra-widgets.css
@@ -535,6 +535,7 @@
   font-size: var(--fs-caption); font-weight: var(--fw-black);
   letter-spacing: var(--ls-label); color: var(--text-muted);
   text-align: center;
+  text-transform: var(--label-transform, uppercase);
 }
 .mc-grid{
   flex: 1 1 auto;

--- a/uv.lock
+++ b/uv.lock
@@ -1934,7 +1934,7 @@ wheels = [
 
 [[package]]
 name = "tesserae"
-version = "0.369.0"
+version = "0.370.0"
 source = { editable = "." }
 dependencies = [
     { name = "amqtt" },


### PR DESCRIPTION
## What this changes

Translates the calendar_month widget to french

<img width="983" height="481" alt="image" src="https://github.com/user-attachments/assets/988e3f25-32ac-457b-aecd-d10b6ba6e7a6" />

## Why

Make the widget accessible to french speaking users

## Test plan

<!-- The commands you ran and what you verified. Reviewers should be
able to repeat this. Skip the obvious (don't say "ran the tests") and
call out what's *not* covered by automated tests, UI, hardware,
manual flows. -->

- [ ] `pytest -q` -> still unable to run the tests under 1.5h without crashing
- [x] `ruff check . && ruff format --check .`
- [x] `mypy app`
- [x] Manually verified: every part of the widget is correctly translated to french

## Checklist

- [x] Tests added for new behaviour (or note why none made sense)
- [x] `ruff` + `mypy` clean
- [ ] User-facing changes documented (README, `docs/`, or both)
- [x] CHANGELOG entry added under `## [Unreleased]` if user-facing
- [x] `pyproject.toml` version bumped if this is going to be tagged
