### PR TITLE
fix(calendar_month): spread multi-day timed events across every day they cover

### DIFF
--- a/plugins/calendar_month/client.js
+++ b/plugins/calendar_month/client.js
@@ -176,7 +176,14 @@ export default function render(shadow, ctx) {
           const colour = ev.colour || "var(--accent-4)";
           const location = showLocations && ev.location ? ev.location : "";
           const text = location ? `${ev.summary || ""} · ${location}` : (ev.summary || "");
-          return `<span class="mc-text" style="border-left-color:${colour}" title="${escapeHtml(text)}">${escapeHtml(text)}</span>`;
+          // A multi-day event occupies every cell it runs through. A month
+          // grid has far less room per cell than a week column, so repeating
+          // the full title in each is mostly noise: mark the pass-through
+          // days with a leading arrow. The untouched title stays in the
+          // tooltip, so the cell is still identifiable.
+          const label = ev.continued ? `↳ ${text}` : text;
+          const cls = ev.continued ? "mc-text is-continued" : "mc-text";
+          return `<span class="${cls}" style="border-left-color:${colour}" title="${escapeHtml(text)}">${escapeHtml(label)}</span>`;
         }).join("")}
         ${remainder > 0 ? `<span class="mc-more">+${remainder}</span>` : ""}`;
     } else {
@@ -244,6 +251,11 @@ export default function render(shadow, ctx) {
        title_scale: the "MONTH YYYY" dashboard title. */
     .mc-num { font-size: calc(var(--fs-body) * var(--mc-header-scale, 1)); }
     .mc-text { font-size: calc(var(--fs-caption) * var(--mc-event-scale, 1)); }
+    /* Pass-through day of a multi-day event: present, but visually
+       subordinate to the cell where it actually starts. Opacity rather
+       than a lighter colour so it survives the 1-bit and greyscale
+       panels the same way the rest of the grid does. */
+    .mc-text.is-continued { opacity: 0.72; }
     .mc-cell { padding: calc(var(--space-1) + var(--mc-row-pad, 0em)) var(--space-2); }
     .cal-head-title { font-size: calc(1em * var(--mc-dash-title-scale, 1)); }
     .cal-head-meta { font-size: calc(1em * var(--mc-dash-title-scale, 1)); }

--- a/plugins/calendar_month/server.py
+++ b/plugins/calendar_month/server.py
@@ -13,6 +13,7 @@ from app.calendar_time import (
     all_day_event_date_keys,
     event_local_date_key,
     local_midnight_utc,
+    timed_event_date_keys,
 )
 from app.tz_resolve import app_timezone
 
@@ -59,16 +60,26 @@ def fetch(
     except Exception as err:
         return {"error": f"{type(err).__name__}: {err}", "days": []}
 
-    # Bucket timed events by their local start date. All-day event DTEND values
-    # are exclusive, so expand them across each covered visible date.
+    # Expand both kinds of event across every visible date they cover: all-day
+    # DTEND values are exclusive, and a multi-day *timed* span (a trip that
+    # starts Friday 16:00 and ends Monday 10:00) occupies each day it runs
+    # through. Bucketing a timed event on its start day alone made it vanish
+    # from every later cell while the week view spanned it correctly.
+    #
+    # Days after the event's own start day are flagged as continuations, so
+    # the cell can mark them instead of repeating the title four times in a
+    # grid that has far less room per cell than a week column.
     buckets: dict[str, list[dict[str, Any]]] = {}
     for ev in events:
         if ev.get("all_day"):
             day_keys = all_day_event_date_keys(ev, grid_start, grid_end)
         else:
-            day_keys = [event_local_date_key(ev, zone)]
+            day_keys = timed_event_date_keys(ev, zone, grid_start, grid_end)
+        # The event's own first day, which may fall before the visible grid -
+        # then every visible day of it is a continuation.
+        first_key = event_local_date_key(ev, zone)
         for day_key in day_keys:
-            buckets.setdefault(day_key, []).append(ev)
+            buckets.setdefault(day_key, []).append({"event": ev, "continued": day_key != first_key})
 
     days = []
     cur = grid_start
@@ -77,8 +88,8 @@ def fetch(
         all_evs = buckets.get(key, [])
         # All-day events first, then timed; cap to max_per_day for the
         # cell, but keep total for the "+N more" badge.
-        all_day = [e for e in all_evs if e.get("all_day")]
-        timed = [e for e in all_evs if not e.get("all_day")]
+        all_day = [e for e in all_evs if e["event"].get("all_day")]
+        timed = [e for e in all_evs if not e["event"].get("all_day")]
         visible = (all_day + timed)[:max_per_day]
         days.append(
             {
@@ -89,18 +100,22 @@ def fetch(
                 "is_today": cur == today,
                 "events": [
                     {
-                        "summary": e["summary"],
-                        "start": e["start"],
+                        "summary": e["event"]["summary"],
+                        "start": e["event"]["start"],
                         # Forward end so a future client variant that wants
                         # to time-slot events in the day cell can; the
                         # current month grid only shows summaries but
                         # keeping the field consistent across calendar_*
                         # avoids drift if/when the month cell grows a
                         # mini-timeline.
-                        "end": e.get("end"),
-                        "all_day": e.get("all_day", False),
-                        "colour": e.get("feed_colour"),
-                        "location": e.get("location") or "",
+                        "end": e["event"].get("end"),
+                        "all_day": e["event"].get("all_day", False),
+                        "colour": e["event"].get("feed_colour"),
+                        "location": e["event"].get("location") or "",
+                        # True on every day of a multi-day event except the
+                        # one it starts on, so the cell can mark it as
+                        # running through rather than starting here.
+                        "continued": e["continued"],
                     }
                     for e in visible
                 ],

--- a/tests/test_calendar_widget_timezone.py
+++ b/tests/test_calendar_widget_timezone.py
@@ -229,3 +229,98 @@ def test_calendar_month_expands_all_day_events_across_visible_dates(
     assert events_by_date["2026-07-05"] == ["Long weekend"]
     assert events_by_date["2026-07-06"] == ["Long weekend"]
     assert events_by_date["2026-07-07"] == []
+
+
+def test_calendar_month_spreads_multi_day_timed_events_across_covered_dates(
+    app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A timed span occupies every day it runs through, not just its start.
+
+    The week view already spreads these (#210); bucketing them on the start
+    day alone made a trip vanish from every later month cell.
+    """
+    month = _plugin(app, "calendar_month")
+    core = _core_plugin(app)
+    app.config["SETTINGS_STORE"].update_section("app", {"timezone": "Asia/Hong_Kong"})
+    frozen = datetime(2026, 7, 5, 10, 0, tzinfo=UTC)
+
+    def load_events(
+        _feeds_filter: list[str] | None,
+        _start: datetime,
+        _end: datetime,
+        *,
+        data_dir: Any,
+    ) -> list[dict[str, Any]]:
+        del data_dir
+        return [
+            {
+                # Friday 16:00 -> Monday 10:00, Hong Kong local.
+                "summary": "Trip",
+                "start": "2026-07-03T08:00:00+00:00",
+                "end": "2026-07-06T02:00:00+00:00",
+                "all_day": False,
+                "feed_colour": "#0d8c7e",
+            }
+        ]
+
+    monkeypatch.setattr(month, "datetime", _freeze_datetime(frozen))
+    monkeypatch.setattr(core.server_module, "load_events", load_events)
+
+    with app.app_context():
+        out = month.fetch({}, {}, ctx={})
+
+    by_date = {day["date"]: [e["summary"] for e in day["events"]] for day in out["days"]}
+    # The bug: only 07-03 carried the trip, every later cell of the span
+    # was empty while the week view spanned all four columns.
+    assert by_date["2026-07-03"] == ["Trip"]
+    assert by_date["2026-07-04"] == ["Trip"]
+    assert by_date["2026-07-05"] == ["Trip"]
+    assert by_date["2026-07-06"] == ["Trip"]
+    assert by_date["2026-07-07"] == []
+
+    # Only the start day is a fresh occurrence; the rest are pass-throughs,
+    # so the cell can mark them instead of repeating the title.
+    continued = {day["date"]: [e["continued"] for e in day["events"]] for day in out["days"]}
+    assert continued["2026-07-03"] == [False]
+    assert continued["2026-07-04"] == [True]
+    assert continued["2026-07-05"] == [True]
+    assert continued["2026-07-06"] == [True]
+
+
+def test_calendar_month_timed_event_ending_at_midnight_does_not_spill(
+    app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End is exclusive: a block ending at local midnight stops the day before."""
+    month = _plugin(app, "calendar_month")
+    core = _core_plugin(app)
+    app.config["SETTINGS_STORE"].update_section("app", {"timezone": "Asia/Hong_Kong"})
+    frozen = datetime(2026, 7, 5, 10, 0, tzinfo=UTC)
+
+    def load_events(
+        _feeds_filter: list[str] | None,
+        _start: datetime,
+        _end: datetime,
+        *,
+        data_dir: Any,
+    ) -> list[dict[str, Any]]:
+        del data_dir
+        return [
+            {
+                # 22:00 Friday -> 00:00 Saturday, Hong Kong local.
+                "summary": "Night shift",
+                "start": "2026-07-03T14:00:00+00:00",
+                "end": "2026-07-03T16:00:00+00:00",
+                "all_day": False,
+                "feed_colour": "#0d8c7e",
+            }
+        ]
+
+    monkeypatch.setattr(month, "datetime", _freeze_datetime(frozen))
+    monkeypatch.setattr(core.server_module, "load_events", load_events)
+
+    with app.app_context():
+        out = month.fetch({}, {}, ctx={})
+
+    by_date = {day["date"]: [e["summary"] for e in day["events"]] for day in out["days"]}
+    assert by_date["2026-07-03"] == ["Night shift"]
+    assert by_date["2026-07-04"] == []


### PR DESCRIPTION
Fixes #213.

## The change

`calendar_month` bucketed timed events on their start day only:

```python
day_keys = [event_local_date_key(ev, zone)]
```

so a trip starting Friday 16:00 and ending Monday 10:00 showed in Friday's cell and nowhere else, while the same event correctly spanned four columns in the week view. This switches it to the shared `timed_event_date_keys` helper `calendar_week` already uses, which also brings the exclusive-end convention with it — a block ending exactly at local midnight stops on the previous day rather than spilling.

## On the rendering question

You flagged that this is a visible behaviour change and that a month cell has far less room than a week column, so a spanning event probably wants a continuation marker rather than a repeated title. Agreed, so that is included rather than left for later:

- The server now attaches `continued` to each per-day copy — true on every day of the span except the one the event starts on. It is computed against the event's **own** start date, not the first visible key, so a span entering from the previous month is correctly marked as a continuation rather than looking like it starts at the grid edge.
- The `text` cell renders a pass-through with a leading `↳` and `opacity: 0.72`, keeping the untouched title in the `title` tooltip so the cell stays identifiable. Opacity rather than a lighter colour, so it degrades the same way as the rest of the grid on 1-bit and greyscale panels.
- The default **bars** mode is unchanged: a colour strip already reads as presence rather than as a fresh occurrence, so it needed nothing.

All-day events also carry the flag, since they were already spread and had the same repeated-title problem in the text cell — it would have been odd for the two kinds to render differently on a pass-through day.

## Tests

Two added to `tests/test_calendar_widget_timezone.py`:

- `..._spreads_multi_day_timed_events_across_covered_dates` — the reported case. Fails on `main` with `assert [] == ['Trip']` on the second day, passes with the fix, and pins the `continued` flags.
- `..._timed_event_ending_at_midnight_does_not_spill` — guards the exclusive-end edge the helper brings in.

Verified: `pytest -k calendar` 49 passed (one unrelated collection error in `test_plugin_route_auth.py` from a missing `paho` MQTT dep locally), `node plugins/calendar_month/tests/clamp_check.mjs` passes, and `ruff check .` + `ruff format --check .` are clean repo-wide on ruff 0.15.22.