### PR TITLE
test: run the widget clamp_check self-checks under pytest

### DIFF
--- a/tests/test_widget_clamp_checks.py
+++ b/tests/test_widget_clamp_checks.py
@@ -1,0 +1,70 @@
+"""Run each widget's ``clamp_check.mjs`` self-check under pytest.
+
+The calendar widgets ship plain-node assertion scripts covering the client-side
+clamping helpers — ``clampScale``, ``clampToDay``, ``computeRange`` and friends.
+Their own headers say ``Run: node tests/clamp_check.mjs``, and nothing did:
+no CI step, no pytest bridge, no ``package.json`` test script referenced them.
+
+That is a coverage hole with a history. ``calendar_day``'s header records it:
+the cases "previously covered by test_smoke.py's
+test_scale_sliders_clamp_to_bounds" moved out of pytest when the clamp moved
+from ``server.py`` to ``client.js``, and the assertions went with them. They
+have been unrun since — free to drift from ``client.js`` with nothing to
+notice (#214).
+
+This is the "fold them into the Python smoke test via a subprocess call" option
+from that issue: the scripts stay where they are, next to the code they assert
+on, and the existing pytest run executes them.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHECKS = sorted(REPO_ROOT.glob("plugins/*/tests/clamp_check.mjs"))
+
+
+def _node() -> str | None:
+    return shutil.which("node")
+
+
+def test_every_clamp_check_is_discovered() -> None:
+    """A widget that grows a self-check is picked up without editing this file.
+
+    Also guards the reverse: if the glob ever silently matches nothing, the
+    parametrised test below would vacuously "pass" by having no cases, which is
+    exactly the invisible-drift failure this file exists to close.
+    """
+    assert CHECKS, "no plugins/*/tests/clamp_check.mjs found — has the layout moved?"
+
+
+@pytest.mark.parametrize("script", CHECKS, ids=lambda p: p.parent.parent.name)
+def test_clamp_check_passes(script: Path) -> None:
+    node = _node()
+    if node is None:
+        # Skipping locally is fine — plenty of contributors work on the Python
+        # side without node. Skipping in CI is not: it would restore the exact
+        # silence this test removes, so fail there instead. GitHub's
+        # ubuntu-latest image ships node, so this only fires on a real
+        # regression in the runner image.
+        if os.environ.get("CI"):
+            pytest.fail("node is not on PATH in CI, so the widget self-checks did not run")
+        pytest.skip("node is not installed; widget self-checks skipped locally")
+
+    result = subprocess.run(
+        [node, str(script)],
+        capture_output=True,
+        text=True,
+        cwd=script.parent,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"{script.relative_to(REPO_ROOT)} failed:\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )


### PR DESCRIPTION
Refs #214 — the second half of it, applied to this repo rather than the marketplace one.

## What I found

#214 says `clamp_check.mjs` "isn't run by anything" in the calendar-schedule widget repo. The same is true here, three times over:

```
plugins/calendar_month/tests/clamp_check.mjs
plugins/calendar_day/tests/clamp_check.mjs
plugins/calendar_week/tests/clamp_check.mjs
```

Nothing references any of them — not `.github/workflows/`, not pytest, not a `package.json` script. They pass today; they have simply been free to drift from `client.js` with nothing to notice.

`calendar_day`'s own header records how the hole opened:

> Mirrors the cases previously covered by `test_smoke.py`'s `test_scale_sliders_clamp_to_bounds` before the clamp moved from `server.py` to `client.js`.

So these assertions used to run in CI, and stopped when the clamp moved to the client. That is a coverage regression with a paper trail rather than a gap that was never filled.

## The approach

The third option from your list — fold them into pytest via a subprocess call. The scripts stay next to the code they assert on, and the existing `pytest` job executes them; no new workflow, no `package.json`.

Two details worth a look:

- **Discovery is a glob**, so a widget that grows a self-check is picked up without editing the test. A separate case asserts the glob matched *something* — an empty glob would make the parametrised test vacuously green, which is the same invisible silence this is closing.
- **A missing `node` skips locally but fails under `CI`.** Plenty of work here is Python-only, so a hard requirement would be annoying; but skipping in CI would restore exactly the silence being removed. GitHub's `ubuntu-latest` image ships node, so the `CI` branch only fires on a real regression in the runner image. Happy to add `actions/setup-node` to the `pytest` job instead if you would rather pin it explicitly.

## Verification

- `pytest tests/test_widget_clamp_checks.py -v` — 4 passed (the discovery guard plus one case per widget).
- Mutation-checked: appending a deliberate `assert.equal(1, 2)` to `calendar_day/tests/clamp_check.mjs` turns it red with the node assertion text in the failure output, and reverting turns it green. The bridge reports real failures rather than swallowing the exit code.
- `ruff check` and `ruff format --check` clean. `mypy` runs on `app` only, so `tests/` is out of its scope.

The change is a single new test file, so it adds coverage without touching any existing behaviour.
