### PR TITLE
feat(mcp): summarise widget descriptions in /catalog, serve the full text per widget

### DIFF
--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -352,6 +352,38 @@ def _invalid_icons(layout: CanvasLayout) -> list[dict[str, Any]]:
 
 # -- catalog / widget options -------------------------------------------
 
+# Longest summary the catalog carries before it is cut at a word boundary.
+# Sized off the bundled set: most first sentences are well under this, and the
+# few that run past carry a second clause after a colon rather than being one
+# genuinely long sentence.
+_DESC_SUMMARY_MAX = 160
+
+# A sentence ends at . ! or ? followed by whitespace. Deliberately not a real
+# sentence tokenizer: these are hand-written single paragraphs, and the cost of
+# getting one slightly wrong is a slightly long summary, not a wrong answer.
+_SENTENCE_END = re.compile(r"(?<=[.!?])\s")
+
+
+def _desc_summary(desc: str) -> str:
+    """First sentence of a widget description, capped at a word boundary.
+
+    ``/catalog`` used to carry every widget's full ``desc``: 9,256 B across the
+    36 bundled widgets, 48% of the ``widgets`` block and the largest single
+    line item in an agent's context budget — paid on every build, for every
+    widget, whether or not it was placed (#257). Summarised it is 2,884 B.
+
+    The full text is not lost, it moves one call along: ``GET
+    /widgets/<key>/options`` now returns it, and that is the call an agent
+    already makes for the two or three widgets it actually places.
+    """
+    text = " ".join(desc.split())
+    if not text:
+        return ""
+    first = _SENTENCE_END.split(text, 1)[0]
+    if len(first) <= _DESC_SUMMARY_MAX:
+        return first
+    return first[:_DESC_SUMMARY_MAX].rsplit(" ", 1)[0] + "…"
+
 
 @bp.get("/catalog")
 def catalog() -> Response:
@@ -361,9 +393,20 @@ def catalog() -> Response:
 
     The per-widget ``sample`` payload is omitted here to keep the response small;
     fetch a widget's live data shape with ``POST /widgets/<key>/data`` instead.
-    The full icon name list is searched via ``GET /icons?q=`` rather than inlined."""
+    The full icon name list is searched via ``GET /icons?q=`` rather than inlined.
+    ``desc`` is the first sentence only; ``GET /widgets/<key>/options`` returns
+    the widget's full description alongside its options."""
     widgets = build_catalog(_pr._registry())
-    lean = [{k: v for k, v in w.items() if k != "sample"} for w in widgets]
+    lean = [
+        {
+            **{k: v for k, v in w.items() if k != "sample"},
+            # Summarised, not dropped: the descriptions are what let an agent
+            # pick the right widget, so the full text stays reachable on the
+            # per-widget call rather than riding along 36 times (#257).
+            "desc": _desc_summary(str(w.get("desc") or "")),
+        }
+        for w in widgets
+    ]
     return jsonify(
         {
             "widgets": lean,
@@ -470,7 +513,10 @@ def widget_options(key: str) -> Response:
     Big ``choices`` lists (HA entity pickers) are omitted by default to keep the
     response small: an option with a long list shows ``choices_count`` and a
     ``choices_endpoint`` instead. Pass ``?include_choices=true`` to inline them
-    anyway. Each option also carries a ``format`` hint for its type."""
+    anyway. Each option also carries a ``format`` hint for its type.
+
+    Also returns this widget's full ``desc``. ``/catalog`` carries only the
+    first sentence, so this is where the rest of it lives."""
     plugin = _pr._registry().get(key)
     if plugin is None:
         return _err(404, f"unknown widget {key!r}")
@@ -487,7 +533,13 @@ def widget_options(key: str) -> Response:
             o["choices_endpoint"] = f"/widgets/{key}/choices?option={o.get('name')}"
             o.pop("choices", None)
         opts.append(o)
-    return jsonify({"key": key, "options": opts})
+    return jsonify(
+        {
+            "key": key,
+            "desc": str(plugin.manifest.get("description") or ""),
+            "options": opts,
+        }
+    )
 
 
 @bp.get("/widgets/<key>/choices")

--- a/tests/test_mcp_api.py
+++ b/tests/test_mcp_api.py
@@ -7,6 +7,7 @@ roundtrip + 422 validation, the grid-page guardrail, and the preview/push paths
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -1728,3 +1729,89 @@ def test_render_report_lists_touch_primitives_and_who_draws_them(
     report = client.get(f"/api/mcp/pages/{pid}/render_report").get_json()
     # Only the protocol-v2 panel draws its own; "plain" gets a painted control.
     assert all(p["device_drawn"] == ["e1003"] for p in report["touch_primitives"])
+
+
+# -- catalog description budget (#257) ---------------------------------
+
+
+def test_catalog_carries_only_the_first_sentence_of_each_description(app: Flask) -> None:
+    """The catalog was 48% description by weight, paid on every build.
+
+    Every widget's full ``desc`` rode along in ``/catalog`` whether or not the
+    agent placed it. This pins the summary down to one sentence.
+    """
+    _enable(app)
+    resp = app.test_client().get("/api/mcp/catalog")
+    assert resp.status_code == 200
+    widgets = resp.get_json()["widgets"]
+    assert widgets, "no widgets in the catalog"
+
+    for w in widgets:
+        desc = w["desc"]
+        assert "\n" not in desc
+        # One sentence: no full stop followed by more prose.
+        assert not re.search(r"[.!?]\s+\S", desc), f"{w['key']} carries more than one sentence"
+
+
+def test_catalog_summary_is_materially_smaller_than_the_full_text(app: Flask) -> None:
+    """Guards the point of the change, not just its mechanism.
+
+    A summariser that returned the whole string would satisfy every other
+    assertion here; this fails if the saving quietly disappears.
+    """
+    _enable(app)
+    catalog = app.test_client().get("/api/mcp/catalog").get_json()["widgets"]
+    registry = app.config["PLUGIN_REGISTRY"]
+
+    summarised = sum(len(w["desc"].encode()) for w in catalog)
+    full = sum(
+        len(str(registry.get(w["key"]).manifest.get("description") or "").encode()) for w in catalog
+    )
+    assert summarised < full // 2, (
+        f"summarised {summarised} B vs full {full} B — the catalog is no longer paying off"
+    )
+
+
+def test_the_full_description_is_still_reachable_per_widget(app: Flask) -> None:
+    """The text moved, it was not dropped — the round trip has to hold.
+
+    Without this the change is indistinguishable from deleting information the
+    agent needs to pick a widget.
+    """
+    _enable(app)
+    client = app.test_client()
+    catalog = client.get("/api/mcp/catalog").get_json()["widgets"]
+    registry = app.config["PLUGIN_REGISTRY"]
+
+    # The widget with the longest description: the one the truncation matters for.
+    longest = max(
+        catalog,
+        key=lambda w: len(str(registry.get(w["key"]).manifest.get("description") or "")),
+    )
+    expected = str(registry.get(longest["key"]).manifest.get("description") or "")
+
+    resp = client.get(f"/api/mcp/widgets/{longest['key']}/options")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["desc"] == expected
+    assert len(body["desc"]) > len(longest["desc"])
+    # And the summary really is a prefix of the full text, not a rewrite.
+    assert expected.startswith(longest["desc"].rstrip("…"))
+
+
+def test_a_widget_with_no_description_summarises_to_empty(app: Flask) -> None:
+    _enable(app)
+    from app.mcp_api import _desc_summary
+
+    assert _desc_summary("") == ""
+    assert _desc_summary("   ") == ""
+
+
+def test_a_single_long_sentence_is_cut_at_a_word_boundary(app: Flask) -> None:
+    from app.mcp_api import _DESC_SUMMARY_MAX, _desc_summary
+
+    long_sentence = "word " * 100
+    out = _desc_summary(long_sentence)
+    assert len(out) <= _DESC_SUMMARY_MAX + 1  # +1 for the ellipsis
+    assert out.endswith("…")
+    assert "  " not in out


### PR DESCRIPTION
Refs #257 — option **1**, the one you rate best value.

## The change

`/api/mcp/catalog` carries the **first sentence** of each widget's description, capped at 160 characters on a word boundary. `GET /widgets/<key>/options` now returns the full `desc` alongside the options.

That matches the loop the tool docs already prescribe — list, then read options for the widget being placed — so the full text still reaches the agent for the two or three widgets it actually uses instead of all 36.

## Measured, not estimated

On the bundled set, the `desc` block goes **9,256 B → 2,884 B**: a **69% cut**, roughly **1,593 tokens** off every `list_widgets` call. Slightly under your ~2,000 estimate, since a few descriptions are already one short sentence and save nothing.

The summaries read as intended — they are the sentence the author wrote first, not a truncation mid-thought:

| widget | full | summary |
| --- | --- | --- |
| `webpage` | 821 B | *Embed an external URL in a cell.* (32 B) |
| `tesserae_status` | 495 B | *Dashboard status strip: identity on the left, ambient device telemetry on the right.* (84 B) |
| `ha_locks` | 415 B | *A security-focused overview of every `lock.*` entity plus door / window / garage / opening binary_sensors.* (104 B) |

## Two decisions worth checking

**At the MCP layer, not in `catalog_entry`.** The editor palette reads the same builder and wants the full text, so summarising upstream would have changed the UI to save an agent's tokens. The trim sits next to the existing `sample`-stripping in `mcp_api.py`.

**A first-sentence split, not a sentence tokenizer.** These are hand-written single paragraphs; the cost of getting one slightly wrong is a slightly long summary, not a wrong answer. Abbreviations like "e.g." would split early — none in the bundled set do, and the fallback is graceful.

I did **not** touch `appearance` (option 3). It is a separate 838-token question about when a restyle is happening, and worth its own change.

## On "measure build quality, not just tokens"

Fair, and I can't measure that from outside — I have no build corpus to run before/after. What I can do is make the failure mode cheap: the full text is one call away on a tool the agent already uses, so if a summary turns out to be too thin for picking, the recovery is a call it was going to make anyway. If you would rather see a `?full=true` escape hatch on `/catalog` while you evaluate, say so and I will add it.

## Tests

Five added to `tests/test_mcp_api.py`, all five red without the change:

- every catalog `desc` is one sentence, no embedded newlines
- **the summarised total is under half the full total** — this is the one that guards the *point*; a summariser that returned the whole string would pass every other assertion here
- the full text round-trips: for the longest-described widget, `/options` returns exactly the manifest text, it is longer than the catalog line, and the summary is a genuine **prefix** of it rather than a rewrite
- an empty or whitespace-only description summarises to `""`
- a single 500-character sentence is cut at a word boundary with an ellipsis, never mid-word

Verified: `test_mcp_api.py` + the other two MCP suites 118 passed; `-k "catalog or widget_options or panels_schema"` 47 passed; `ruff check` and `ruff format --check` clean across `app` and `tests`. `mypy app` reports two pre-existing errors in `send_routes.py` and `rest_api.py` from a local werkzeug version skew — neither is in a file this touches.
