### PR TITLE
fix(calendar_day): open the day window at local midnight, not at now

### DIFF
--- a/plugins/calendar_day/plugin.json
+++ b/plugins/calendar_day/plugin.json
@@ -18,7 +18,7 @@
     {
       "name": "hours_ahead",
       "type": "number",
-      "label": "Hours of agenda to show",
+      "label": "Hours ahead to include (within today)",
       "default": 24
     },
     {

--- a/plugins/calendar_day/server.py
+++ b/plugins/calendar_day/server.py
@@ -34,12 +34,23 @@ def fetch(
 
     zone = app_timezone()
     now_local = datetime.now(zone)
-    now = now_local.astimezone(UTC)
-    end = now + timedelta(hours=hours_ahead)
+    # Start at LOCAL MIDNIGHT, not at `now`.
+    #
+    # This widget draws a single day on a 0-24 axis and filters everything to that day
+    # (see below), so it is a day view. Starting the fetch at `now` meant it quietly lost
+    # the morning as the day went on: at 14:00 a 10:00-11:00 meeting was not in the
+    # payload at all, and the auto-fitted range then shrank around whatever was left. On
+    # a widget that draws a day's timeline that reads as missing data rather than as an
+    # agenda (#252).
+    day_start_local = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    start = day_start_local.astimezone(UTC)
+    # `hours_ahead` keeps its meaning: a FORWARD bound, measured from now. It no longer
+    # decides where the window begins, only how far past this moment to look.
+    end = now_local.astimezone(UTC) + timedelta(hours=hours_ahead)
     try:
         events = core.server_module.load_events(
             feeds_filter,
-            now,
+            start,
             end,
             data_dir=Path(core.data_dir),
         )
@@ -47,7 +58,7 @@ def fetch(
         return {"error": f"{type(err).__name__}: {err}", "events": []}
 
     # Both kinds are filtered to the day being drawn (#248). ``hours_ahead``
-    # is a rolling window from now, so a 24 h default reaches into tomorrow;
+    # bounds how far PAST NOW to look, so a 24 h default reaches into tomorrow;
     # a timed event living entirely on tomorrow used to survive into today's
     # list. The client then drew it against today's 0-24 axis, where neither
     # edge is today, and clampToDay's multi-day rule painted it across the

--- a/plugins/calendar_day/tests/test_smoke.py
+++ b/plugins/calendar_day/tests/test_smoke.py
@@ -186,3 +186,57 @@ def test_a_multi_day_event_spanning_today_is_kept() -> None:
 def test_todays_date_is_reported() -> None:
     out = _fetch_with_events([])
     assert out["date"] == "2026-08-21"
+
+
+def _fetch_capturing_window(**options: Any) -> tuple[datetime, datetime]:
+    """The (start, end) `fetch` asks calendar_core for.
+
+    Asserted here rather than through the returned events, because the stub returns
+    whatever it is given regardless of the window - so a test reading the output cannot
+    see the bug at all. The window IS the bug (#252).
+    """
+    core = _stub_calendar_core([])
+    registry = MagicMock()
+    registry.get.return_value = core
+    app = MagicMock()
+    app.config = {"PLUGIN_REGISTRY": registry}
+    with (
+        patch.object(server, "current_app", app),
+        patch.object(server, "datetime", _FixedNow),
+        patch.object(server, "app_timezone", lambda: UTC),
+    ):
+        server.fetch(options=options, settings={}, ctx={})
+    args = core.server_module.load_events.call_args.args
+    return args[1], args[2]
+
+
+def test_the_window_starts_at_local_midnight_not_now() -> None:
+    """The day view must not lose the morning as the day goes on.
+
+    The window started at `now`, so at 09:00 an 07:00 meeting was never fetched: not
+    filtered out, absent from the payload. The auto-fitted range then shrank around
+    what was left, which on a widget drawing a day's timeline reads as missing data.
+    """
+    start, _end = _fetch_capturing_window()
+    assert start == datetime(2026, 8, 21, 0, 0, tzinfo=UTC)
+
+
+def test_hours_ahead_still_bounds_the_window_forward_from_now() -> None:
+    """It keeps its meaning; it just no longer decides where the day begins.
+
+    Measured from NOW rather than from midnight, so "hours ahead" stays the number of
+    hours ahead - at 09:00, 4 reaches 13:00, not 04:00.
+    """
+    _start, end = _fetch_capturing_window(hours_ahead=4)
+    assert end == datetime(2026, 8, 21, 13, 0, tzinfo=UTC)
+
+
+def test_a_small_hours_ahead_does_not_hide_the_morning() -> None:
+    """The two halves together: a narrow forward bound still shows the day so far.
+
+    This is the combination that made the old behaviour indefensible - a 2 h agenda at
+    09:00 showed 09:00-11:00 and called it a day view.
+    """
+    start, end = _fetch_capturing_window(hours_ahead=2)
+    assert start == datetime(2026, 8, 21, 0, 0, tzinfo=UTC)
+    assert end == datetime(2026, 8, 21, 11, 0, tzinfo=UTC)

--- a/tests/test_calendar_widget_timezone.py
+++ b/tests/test_calendar_widget_timezone.py
@@ -60,7 +60,12 @@ def test_calendar_day_uses_app_timezone_for_display_date(
         out = day.fetch({"hours_ahead": 24}, {}, ctx={})
 
     assert out["date"] == "2026-07-05"
-    assert captured["start"] == frozen
+    # The window now opens at LOCAL midnight rather than at `now` (#252), which makes this
+    # a stronger timezone assertion than it was: 18:30 UTC is 02:30 the next day in Hong
+    # Kong, so the day being drawn began at 16:00 UTC. Reading `now` back proved nothing
+    # about the zone, since `now` is the same instant everywhere.
+    assert captured["start"] == datetime(2026, 7, 4, 16, 0, tzinfo=UTC)
+    # `hours_ahead` is still measured forward from now.
     assert captured["end"] == datetime(2026, 7, 5, 18, 30, tzinfo=UTC)
 
 


### PR DESCRIPTION
## What

The day widget's fetch window now opens at local midnight. `hours_ahead` keeps its meaning as a forward bound.

Fixes #252, settling both halves.

## The decision the issue asks for

You framed it as one question — what does the window mean — and left it open.

**It is a day view.** The widget draws a single day on a 0-24 axis and, since #248, filters every event to that day. Nothing about it is an "agenda ahead" surface: the axis is the whole day whether or not there is anything in the morning.

So the window opens at local midnight, and `hours_ahead` becomes a purely forward bound measured from now.

## Part 2: the morning

```python
now = now_local.astimezone(UTC)
end = now + timedelta(hours=hours_ahead)
```

At 14:00 a 10:00-11:00 meeting was **not in the payload at all** — not filtered out downstream, never fetched. The auto-fitted range then shrank around what was left, so a day view drew an afternoon and gave no sign the morning existed.

The combination is what made it indefensible: a 2 h agenda at 09:00 showed 09:00-11:00 and called it a day. It now shows the day so far plus two hours.

## Part 1: the label

Nothing above 24 has a visible effect, because everything is filtered to the day being drawn. Rather than teach the widget to draw several days — which is a different widget, and out of scope here — the label now says what the option does:

> "Hours of agenda to show" → **"Hours ahead to include (within today)"**

If you would rather `calendar_day` grow a multi-day mode, that is worth its own issue and I am happy to take it; it changes the axis, the clamping rule and the auto-fit, so it did not belong in this fix.

## Tests

Four added, asserted through **the arguments passed to `calendar_core`**, not through the returned events. That matters: the test stub returns whatever it is given regardless of the window, so a test reading the output cannot see this bug at all. The window *is* the bug.

Two of the four are confirmed red before the change.

`test_calendar_day_uses_app_timezone_for_display_date` pinned `start == now` and is updated. Its intent is unchanged, and the assertion is now **stronger**: 18:30 UTC is 02:30 the next day in Hong Kong, so the day being drawn began at 16:00 UTC — while reading `now` back proved nothing about the zone, since `now` is the same instant everywhere.

## Gates

- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean (543 files)
- [x] `pytest -k calendar` — 62 passed
- [x] Full `pytest` run before this: 664 passed with only the timezone test above, which this PR updates