### PR TITLE
fix(lineups): keep deleted-display lineups visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Fixed
 
+- **Lineups remain visible after their displays are deleted.** Lineups whose
+  targets are all unavailable now appear in an **Unavailable displays** group
+  on the web, where they can still be edited or deleted. Existing Lineups are
+  preserved, including when device deletion also clears associated data.
+
 - **A touch action no longer repaints a different lineup page over the
   one on glass.** The post-action reconcile resolved "the page the
   device is showing" from the lineup's nav record before the live frame,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,9 +43,11 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 ### Fixed
 
 - **Lineups remain visible after their displays are deleted.** Lineups whose
-  targets are all unavailable now appear in an **Unavailable displays** group
-  on the web, where they can still be edited or deleted. Existing Lineups are
-  preserved, including when device deletion also clears associated data.
+  targets are all gone now appear in an **Unavailable displays** group on the
+  Lineups page instead of disappearing, so they can still be edited, rebound
+  or deleted. The editors keep the stale display (and a wiped dashboard)
+  selected, so saving no longer silently unbinds the lineup or re-points it at
+  the first dashboard in the list.
 
 - **A touch action no longer repaints a different lineup page over the
   one on glass.** The post-action reconcile resolved "the page the

--- a/app/deck_routes.py
+++ b/app/deck_routes.py
@@ -500,8 +500,9 @@ def _design_cards(
 
     # One section per display, in registry order; a card targeting several
     # displays appears under each. Displays with nothing lined up are
-    # omitted entirely. Cards with no resolvable display land in a trailing
-    # "not on a display yet" group.
+    # omitted entirely. Empty bindings and bindings to missing displays
+    # get separate trailing groups, so retained Lineups remain manageable
+    # after their last display is deleted.
     groups: list[dict[str, Any]] = []
 
     def refresh_total(group_cards: list[dict[str, Any]]) -> int | None:
@@ -536,6 +537,23 @@ def _design_cards(
                 "thumb": "",
                 "refreshes_today": None,
                 "cards": unbound,
+            }
+        )
+    unavailable = [
+        c
+        for c in cards
+        if c["device_ids"] and not any(did in device_names for did in c["device_ids"])
+    ]
+    if unavailable:
+        groups.append(
+            {
+                "id": "",
+                "name": "Unavailable displays",
+                "icon": "warning-circle",
+                "showing": None,
+                "thumb": "",
+                "refreshes_today": None,
+                "cards": unavailable,
             }
         )
     return {"cards": cards, "groups": groups, "now_hhmm": now_tz.strftime("%H:%M")}

--- a/app/deck_routes.py
+++ b/app/deck_routes.py
@@ -928,6 +928,17 @@ def editor(deck_id: str | None = None) -> str | Response:
             device_meta.append({"id": d.id, "name": d.display_name})
             if deck is not None and d.id in deck.device_ids and d.manifest.get("touch") is True:
                 touch_bound = True
+    # A binding to a display that has since been deleted still needs an
+    # option, or the select falls back to "Choose a display" and a plain
+    # save would silently unbind the deck. It stays selected (and labelled)
+    # until the user picks a live display.
+    if deck is not None:
+        known = {d["id"] for d in device_meta}
+        device_meta.extend(
+            {"id": did, "name": f"{did} (unavailable)"}
+            for did in deck.device_ids
+            if did not in known
+        )
 
     from app.deck_suggest import suggest_decks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.389.1"
+version = "0.389.2"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/templates/_schedules_section.html
+++ b/templates/_schedules_section.html
@@ -33,6 +33,12 @@
         {% for p in pages %}
         <option value="{{ p.id }}" {% if p.id == s.page_id %}selected{% endif %}>{{ p.name }}</option>
         {% endfor %}
+        {# A dashboard that was deleted out from under the schedule keeps its
+           option, otherwise the browser preselects the first dashboard and a
+           save silently re-points the schedule. #}
+        {% if s.page_id and s.page_id not in (pages | map(attribute='id') | list) %}
+        <option value="{{ s.page_id }}" selected>{{ s.page_id }} (missing dashboard)</option>
+        {% endif %}
       </select>
     </div>
     <div class="field">

--- a/tests/test_unified_deck_cards.py
+++ b/tests/test_unified_deck_cards.py
@@ -4,6 +4,7 @@ noun: deck; kinds surface as By hand / Rotation / Schedule."""
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -308,6 +309,104 @@ def _register_display(app: Flask, client, device_id: str) -> None:
         data=_json.dumps({"device_id": device_id, "kind": "esp32_client"}),
     )
     assert resp.status_code == 201
+
+
+@pytest.mark.parametrize("intent", ["manual", "cycle", "daily", "interval"])
+@pytest.mark.parametrize("wipe_orphan", [False, True])
+def test_deleted_display_lineup_remains_manageable(
+    app: Flask, intent: str, wipe_orphan: bool
+) -> None:
+    """Deleting a display must not hide its retained Lineups from the web UI."""
+    from app.lineup_authoring import build_lineup
+
+    client = app.test_client()
+    _sign_in(client)
+    _register_display(app, client, "kobo")
+    pages = app.config["PAGE_STORE"]
+    pages.save(pages.get("kitchen").model_copy(update={"device_ids": ["kobo"]}))
+    deck = build_lineup(
+        intent=intent,
+        lineup_id="kobo-lineup",
+        name="Kobo lineup",
+        page_ids=["kitchen"],
+        device_ids=["kobo"],
+        fires_at="08:00",
+    ).model_copy(update={"enabled": False})
+    app.config["DECK_STORE"].upsert(deck)
+    before = client.get("/decks").get_data(as_text=True)
+    assert 'id="display-kobo"' in before
+    assert 'id="udeck-kobo-lineup"' in before
+
+    deleted = client.post(
+        "/settings/devices/kobo/delete", data={"wipe_orphan": "1"} if wipe_orphan else {}
+    )
+    assert deleted.status_code == 302
+    assert app.config["DEVICE_REGISTRY"].get("kobo") is None
+    body = client.get("/decks").get_data(as_text=True)
+    assert "Unavailable displays" in body
+    assert 'id="display-kobo"' not in body
+    assert body.count('id="udeck-kobo-lineup"') == 1
+    assert app.config["DECK_STORE"].get(deck.id) == deck
+
+    edit_url = (
+        "/decks/kobo-lineup/edit"
+        if intent in ("manual", "cycle")
+        else "/decks?sedit=kobo-lineup#schedule-form-card"
+    )
+    assert f'href="{edit_url}"' in body
+    editor = client.get(edit_url)
+    assert editor.status_code == 200
+    assert "Kobo lineup" in editor.get_data(as_text=True)
+    delete_kind = {"manual": "decks", "cycle": "rotations"}.get(intent, "schedules")
+    delete_url = f"/{delete_kind}/kobo-lineup/delete"
+    assert f'action="{delete_url}"' in body
+    assert client.post(delete_url).status_code == 302
+    assert app.config["DECK_STORE"].get(deck.id) is None
+    assert 'id="udeck-kobo-lineup"' not in client.get("/decks").get_data(as_text=True)
+
+
+def test_unavailable_group_preserves_shared_and_unassigned_lineups(app: Flask) -> None:
+    """Only Lineups with targets but no surviving display need the fallback."""
+    from app.lineup_authoring import build_lineup
+
+    client = app.test_client()
+    _sign_in(client)
+    _register_display(app, client, "panel_a")
+    _register_display(app, client, "panel_b")
+    pages = app.config["PAGE_STORE"]
+    pages.save(pages.get("kitchen").model_copy(update={"device_ids": ["deleted"]}))
+    specs = [
+        ("missing", "manual", ["deleted", "also-deleted"], "hall"),
+        ("partial", "cycle", ["panel_a", "deleted"], "hall"),
+        ("shared", "manual", ["panel_a", "panel_b"], "hall"),
+        ("inherited", "daily", [], "kitchen"),
+        ("unassigned", "manual", [], "hall"),
+    ]
+    for lineup_id, intent, device_ids, page_id in specs:
+        app.config["DECK_STORE"].upsert(
+            build_lineup(
+                intent=intent,
+                lineup_id=lineup_id,
+                name=lineup_id,
+                page_ids=[page_id],
+                device_ids=device_ids,
+                fires_at="08:00",
+            ).model_copy(update={"enabled": False})
+        )
+
+    body = client.get("/decks").get_data(as_text=True)
+    groups = re.findall(r'<section class="dk-group"[^>]*>.*?</section>', body, re.S)
+    unavailable = next(g for g in groups if "Unavailable displays" in g)
+    unassigned = next(g for g in groups if "Not on a display yet" in g)
+    panel_a = next(g for g in groups if 'id="display-panel_a"' in g)
+    panel_b = next(g for g in groups if 'id="display-panel_b"' in g)
+    assert set(re.findall(r'id="udeck-([^"]+)"', unavailable)) == {"missing", "inherited"}
+    assert set(re.findall(r'id="udeck-([^"]+)"', unassigned)) == {"unassigned"}
+    assert 'id="udeck-partial"' in panel_a
+    assert '<span class="dk-name">shared</span>' in panel_a
+    assert '<span class="dk-name">shared</span>' in panel_b
+    assert body.count('id="udeck-shared"') == 1
+    assert app.config["DECK_STORE"].get("partial").device_ids == ["panel_a", "deleted"]
 
 
 def test_unbound_rotation_spanning_displays_warns(app: Flask) -> None:

--- a/tests/test_unified_deck_cards.py
+++ b/tests/test_unified_deck_cards.py
@@ -356,7 +356,45 @@ def test_deleted_display_lineup_remains_manageable(
     assert f'href="{edit_url}"' in body
     editor = client.get(edit_url)
     assert editor.status_code == 200
-    assert "Kobo lineup" in editor.get_data(as_text=True)
+    editor_html = editor.get_data(as_text=True)
+    assert "Kobo lineup" in editor_html
+    # The editors must keep the stale binding selectable: the deck editor's
+    # display select would otherwise fall back to "Choose a display" and a
+    # plain save would unbind the deck; the schedule form would preselect
+    # the first dashboard once the wiped page vanished from the list.
+    if intent in ("manual", "cycle"):
+        assert '<option value="kobo" selected>kobo (unavailable)</option>' in editor_html
+        saved = client.post(
+            "/decks/editor-save",
+            data={
+                "deck_id": "kobo-lineup",
+                "name": "Kobo lineup renamed",
+                "pages": "kitchen",
+                "device_ids": "kobo",
+                # Keep a cycle lineup on its timer so it stays a rotation.
+                "advance": "timer" if intent == "cycle" else "manual",
+            },
+        )
+    else:
+        if wipe_orphan:
+            assert (
+                '<option value="kitchen" selected>kitchen (missing dashboard)</option>'
+                in editor_html
+            )
+        saved = client.post(
+            "/schedules/kobo-lineup/update",
+            data={
+                "name": "Kobo lineup renamed",
+                "page_id": "kitchen",
+                "type": "daily",
+                "fires_at": "08:00",
+            },
+        )
+    assert saved.status_code == 302
+    after_save = app.config["DECK_STORE"].get(deck.id)
+    assert after_save.name == "Kobo lineup renamed"
+    assert after_save.device_ids == ["kobo"]
+    assert [dp.page_id for dp in after_save.pages] == ["kitchen"]
     delete_kind = {"manual": "decks", "cycle": "rotations"}.get(intent, "schedules")
     delete_url = f"/{delete_kind}/kobo-lineup/delete"
     assert f'action="{delete_url}"' in body

--- a/uv.lock
+++ b/uv.lock
@@ -1934,7 +1934,7 @@ wheels = [
 
 [[package]]
 name = "tesserae"
-version = "0.389.1"
+version = "0.389.2"
 source = { editable = "." }
 dependencies = [
     { name = "amqtt" },


### PR DESCRIPTION
## What this changes

Keep Lineups whose targets are all missing visible in an **Unavailable displays** group, with their existing Edit and Delete actions. Lineups with a surviving target stay under that display; unassigned Lineups retain their existing group.

## Why

Deleting a display preserves its Lineups, even with associated-data cleanup enabled. The web list grouped records under registered displays or empty target lists, so a non-empty binding to a deleted display fell into neither group. Companion still received the same record from the API and showed it as unavailable, making this look like an app caching issue.

Reproduction: create a Lineup bound to a display, delete that display in Settings, then open Lineups. The retained record now stays accessible on the web.

## Test plan

- [x] Python 3.11: `pytest -n 4 -q` — 4,293 passed in 310.31s.
- [x] `ruff check . && ruff format --check .`
- [x] `mypy app` — 203 source files.
- [x] Nine regression cases cover all four intents with and without associated-data cleanup, edit-page access, deletion, inherited targets, and shared/unassigned grouping.

## Checklist

- [x] Regression tests added.
- [x] Changelog entry added under Unreleased.
- [x] Stored bindings and device-deletion policy preserved.

