### PR TITLE
fix(quantizer): LAB matching sees the diffused error (#202)

### DIFF
--- a/app/quantizer.py
+++ b/app/quantizer.py
@@ -1211,6 +1211,45 @@ def _native_colour_mask(
     return flat
 
 
+#: sRGB transfer curve for the 256 integer channel values, precomputed.
+#: :func:`_srgb_to_lab` quantises to ``uint8`` before converting, so a table
+#: indexed by the rounded channel is exact rather than an approximation of it.
+_SRGB_LINEAR_8: tuple[float, ...] = tuple(
+    (v / 12.92) if (v := i / 255.0) <= 0.04045 else ((v + 0.055) / 1.055) ** 2.4 for i in range(256)
+)
+
+#: D65 reference white, and the CIELAB toe constants, unpacked once so the
+#: per-pixel path does no attribute lookups.
+_LAB_REF_X = 0.95047
+_LAB_REF_Y = 1.00000
+_LAB_REF_Z = 1.08883
+_LAB_DELTA = 6.0 / 29.0
+_LAB_DELTA_CUBED = _LAB_DELTA**3
+_LAB_TOE_SCALE = 1.0 / (3 * _LAB_DELTA**2)
+_LAB_TOE_OFFSET = 4.0 / 29.0
+
+
+def _lab_of_rgb8(r8: int, g8: int, b8: int) -> tuple[float, float, float]:
+    """Scalar sRGB (0-255 ints) -> CIE L*a*b*, matching :func:`_srgb_to_lab`.
+
+    The vectorised version is the right tool for a whole image and the wrong
+    one for a single pixel: error diffusion has to re-read a pixel *after* its
+    neighbours have written into it, so the conversion has to happen inside
+    the sequential loop. Same constants and same piecewise curve, so a pixel
+    that never received any error converts to the identical triple.
+    """
+    lr = _SRGB_LINEAR_8[r8]
+    lg = _SRGB_LINEAR_8[g8]
+    lb = _SRGB_LINEAR_8[b8]
+    xn = (0.4124564 * lr + 0.3575761 * lg + 0.1804375 * lb) / _LAB_REF_X
+    yn = (0.2126729 * lr + 0.7151522 * lg + 0.0721750 * lb) / _LAB_REF_Y
+    zn = (0.0193339 * lr + 0.1191920 * lg + 0.9503041 * lb) / _LAB_REF_Z
+    fx = xn ** (1 / 3) if xn > _LAB_DELTA_CUBED else xn * _LAB_TOE_SCALE + _LAB_TOE_OFFSET
+    fy = yn ** (1 / 3) if yn > _LAB_DELTA_CUBED else yn * _LAB_TOE_SCALE + _LAB_TOE_OFFSET
+    fz = zn ** (1 / 3) if zn > _LAB_DELTA_CUBED else zn * _LAB_TOE_SCALE + _LAB_TOE_OFFSET
+    return (116.0 * fy - 16.0, 500.0 * (fx - fy), 200.0 * (fy - fz))
+
+
 def _error_diffusion(
     rgb: Image.Image,
     palette: np.ndarray,
@@ -1279,18 +1318,19 @@ def _error_diffusion(
     # Declare LAB buffers up-front so mypy sees one type per name;
     # the LAB branch guards indexing behind ``use_lab`` so the empty
     # placeholders are never touched at runtime.
-    buf_l = _array.array("f")
-    buf_a = _array.array("f")
-    buf_b_lab = _array.array("f")
     pal_L: list[float] = []
     pal_a: list[float] = []
     pal_b_lab: list[float] = []
+    # LAB of the pixel as it stands *now* is computed in the loop, not
+    # pre-computed per pixel here. A pre-pass reads the pristine image, and
+    # the whole point of error diffusion is that a pixel's value has moved by
+    # the time it is matched: judging it against its original coordinates
+    # ignores every neighbour's error and degrades to plain nearest-colour
+    # quantisation, which is issue #202. Only the palette is fixed, so only
+    # the palette is converted up front.
+    lab_cache: dict[int, tuple[float, float, float]] = {}
     if use_lab:
         pal_lab = _srgb_to_lab(np.asarray(palette, dtype=np.uint8))
-        src_lab = _srgb_to_lab(arr.astype(np.uint8))
-        buf_l = _array.array("f", src_lab[:, :, 0].ravel().tolist())
-        buf_a = _array.array("f", src_lab[:, :, 1].ravel().tolist())
-        buf_b_lab = _array.array("f", src_lab[:, :, 2].ravel().tolist())
         pal_L = [float(pal_lab[i, 0]) for i in range(pal_lab.shape[0])]
         pal_a = [float(pal_lab[i, 1]) for i in range(pal_lab.shape[0])]
         pal_b_lab = [float(pal_lab[i, 2]) for i in range(pal_lab.shape[0])]
@@ -1324,9 +1364,19 @@ def _error_diffusion(
                 # aware, 1.0 for plain LAB) biases towards preserving
                 # hue over lightness, so blues stay blue even at the
                 # cost of a lightness match.
-                L0 = buf_l[idx]
-                A0 = buf_a[idx]
-                B0 = buf_b_lab[idx]
+                # Clamp-and-round to the 0-255 grid `_srgb_to_lab` quantises
+                # to, then memoise: a dashboard frame is mostly flat colour,
+                # so the cache turns most pixels into a dict hit instead of a
+                # conversion.
+                r8 = 0 if r < 0.0 else (255 if r > 255.0 else int(r + 0.5))
+                g8 = 0 if g < 0.0 else (255 if g > 255.0 else int(g + 0.5))
+                b8 = 0 if b < 0.0 else (255 if b > 255.0 else int(b + 0.5))
+                key = (r8 << 16) | (g8 << 8) | b8
+                cached = lab_cache.get(key)
+                if cached is None:
+                    cached = _lab_of_rgb8(r8, g8, b8)
+                    lab_cache[key] = cached
+                L0, A0, B0 = cached
                 best_i = 0
                 dL = L0 - pal_L[0]
                 dA = A0 - pal_a[0]

--- a/tests/test_bwry_calibration.py
+++ b/tests/test_bwry_calibration.py
@@ -7,6 +7,8 @@ had. Every assertion about another gamut here exists to prove the change
 is inert outside ``bwry_4``.
 """
 
+from itertools import pairwise
+
 import pytest
 from PIL import Image
 
@@ -214,22 +216,23 @@ def test_no_bundled_profile_selects_lab_matching():
         assert p.dither.color_match == "rgb", f"{p.slug} selects {p.dither.color_match}"
 
 
-def test_lab_matching_still_loses_dither_feedback():
-    """Regression guard documenting a PRE-EXISTING upstream bug, not a
-    BWRY one: ``_error_diffusion`` builds its LAB buffers once from the
-    original image and never writes diffused error back into them, while
-    the LAB branch reads those stale buffers to pick the nearest ink.
-    Every pixel is judged against its pristine value, so error diffusion
-    is ignored and the result is plain nearest-colour quantisation.
+def test_lab_matching_keeps_dither_feedback():
+    """The inverted tripwire (#202). It used to assert the bug.
 
-    ``_error_diffusion`` never sees a gamut and is shared by atkinson /
-    jarvis / stucki (floyd-steinberg detours into it when LAB is
-    selected), so this affects every gamut and every error-diffusion
-    dither, under both ``lab`` and ``chroma-aware``.
+    ``_error_diffusion`` built its LAB buffers once from the original image
+    and never wrote diffused error back into them, while the LAB branch read
+    those stale buffers to pick the nearest ink. Every pixel was judged
+    against its pristine value, so error diffusion was ignored and the result
+    was plain nearest-colour quantisation: a flat patch came back as a single
+    ink, on every gamut and every error-diffusion dither.
 
-    Signature: a flat patch must dither into a MIX of inks. Under LAB it
-    collapses to a single ink. If this test starts failing, the upstream
-    bug was fixed and a LAB preset becomes worth reconsidering."""
+    The LAB coordinates are now derived from the pixel as it stands when it is
+    matched, so a flat patch dithers under ``lab`` and ``chroma-aware`` the
+    way it always did under ``rgb``.
+
+    Signature: a flat patch must dither into a MIX of inks under every
+    combination. One ink means the feedback has been lost again.
+    """
     from collections import Counter
 
     palette = ((36, 37, 34), (236, 233, 223), (222, 180, 40), (188, 66, 72))
@@ -251,14 +254,40 @@ def test_lab_matching_still_loses_dither_feedback():
         return len(Counter(idx))
 
     # Every error-diffusion dither routes through the same function, so
-    # every one of them loses the feedback.
+    # fixing it there fixes every one of them.
     for dither in ("floyd-steinberg", "atkinson", "jarvis", "stucki"):
         assert ink_count("rgb", dither) > 1, f"{dither}+rgb should mix inks"
         for match in ("lab", "chroma-aware"):
-            assert ink_count(match, dither) == 1, (
-                f"{dither}+{match} no longer collapses — upstream bug may be fixed, "
-                "in which case a LAB preset is worth reconsidering"
+            assert ink_count(match, dither) > 1, (
+                f"{dither}+{match} collapsed to one ink: the LAB match is reading "
+                "a pixel value that predates its neighbours' diffused error again"
             )
+
+
+def test_lab_matching_produces_an_alternating_pattern_not_just_two_inks():
+    """Counting inks alone would pass on a frame split into two solid halves.
+
+    A flat patch under a working error diffusion alternates, so consecutive
+    pixels differ far more often than not. This is what separates "the dither
+    ran" from "two inks appear somewhere in the frame".
+    """
+    palette = ((36, 37, 34), (236, 233, 223), (222, 180, 40), (188, 66, 72))
+    flat = Image.new("RGB", (40, 40), (128, 128, 128))
+    payload = pack_to_panel_bin(
+        flat,
+        width=40,
+        height=40,
+        gamut="bwry_4",
+        dither="floyd-steinberg",
+        color_match="lab",
+        palette_override=palette,
+    )
+    idx = []
+    for byte in payload:
+        idx += [(byte >> 6) & 3, (byte >> 4) & 3, (byte >> 2) & 3, byte & 3]
+    row = idx[:40]
+    transitions = sum(1 for a, b in pairwise(row) if a != b)
+    assert transitions > 20, f"only {transitions} ink changes across a 40px flat row"
 
 
 def test_bwry_profile_palette_slices_to_the_four_inks():


### PR DESCRIPTION
## What this changes

`_error_diffusion` now derives each pixel's LAB coordinates from the pixel **as it stands when it is matched**, instead of from a pre-pass over the original image.

Closes #202

## Why

The LAB buffers were built once from the pristine image (`quantizer.py:1132`) and never received the diffused error — only `buf_r/g/b` did (`:1200`). The LAB branch then read those stale buffers to pick the nearest ink (`:1165`), so every pixel was judged against its original value, the diffusion was ignored, and the result was plain nearest-colour quantisation.

The source-LAB pre-pass is gone. Only the palette is converted up front, because only the palette is fixed.

## The cost, measured

The issue asks for this before committing to an approach. sRGB→linear is a 256-entry table — exact rather than approximate, since `_srgb_to_lab` quantises to `uint8` before converting — and the conversion is memoised on the rounded RGB triple.

800×480, floyd-steinberg:

| input | before | after | |
|---|---|---|---|
| flat dashboard | 0.74s | 0.76s | **+3%** |
| photo noise | 0.73s | 0.96s | +32% |
| `rgb` match (control) | 0.65s | 0.66s | unchanged |

The memo pays off exactly where the workload is: a dashboard frame is mostly flat colour, so most pixels are a dict hit. Pure noise is the worst case and is not what these panels render. The `rgb` path is untouched.

I also checked the scalar conversion against `_srgb_to_lab` directly — same constants, same piecewise curve, max delta < 1e-3 across black, white, mid-grey, primaries and the toe region — so a pixel that received no error converts to the identical triple it did before.

## Test plan

- [x] `pytest -q` on the affected areas: `-k "quant or dither or palette or calibrat or render or panel or bin"` — **724 passed**, 10 skipped (Playwright not installed)
- [x] `pytest tests/test_bwry_calibration.py` — 40 passed
- [x] `ruff check . && ruff format --check .` on the changed files — clean

**The tripwire fired, as designed.** `test_lab_matching_still_loses_dither_feedback` said "if this test starts failing, the upstream bug was fixed", and it did. It is inverted to `test_lab_matching_keeps_dither_feedback`.

I added a second test with it, because counting inks is not enough on its own — a frame split into two solid halves would pass an ink count. `test_lab_matching_produces_an_alternating_pattern_not_just_two_inks` asserts a flat row actually alternates. On unfixed code it reports `only 0 ink changes across a 40px flat row`.

The measured signature, flat 40×40 mid-grey, distinct inks:

| gamut | rgb | lab / chroma-aware (before) | lab / chroma-aware (after) |
|---|---|---|---|
| `bwry_4` | 3 | 1 | 2 |
| `waveshare_e6` | 2 | 1 | 2 |
| `inky_7colour` | 5–7 | 1 | 2 |

Worth saying plainly: LAB lands on fewer inks than `rgb` here, and I believe that is correct rather than a residual bug. For a neutral grey, a perceptual match picks the two nearest *neutral* inks; `rgb`'s euclidean match wanders into chromatic ones. The output is a clean checkerboard (`1010101…`) where before it was a solid block. On a gradient both matchers use the same number of inks.

## Not in this PR

`test_no_bundled_profile_selects_lab_matching` is left alone, so no shipped preset steers users onto LAB. The issue says a LAB preset "becomes worth reconsidering" once this is fixed — that is a palette decision with visual consequences, and it seemed better to leave it to you than to bundle it in a correctness fix.