### PR TITLE
fix(rail): thin dense schedules instead of truncating them (#166)

### DIFF
--- a/app/deck_routes.py
+++ b/app/deck_routes.py
@@ -249,6 +249,43 @@ def _cycle_fires_on(rotation: Any, day_start: datetime) -> list[datetime]:
     return fires
 
 
+#: Ticks the 24h rail draws. A rail is a few hundred pixels wide, so past
+#: this the marks stop being separable and only cost DOM.
+MAX_RAIL_MARKS = 48
+
+
+def _thin_marks(marks: list[float]) -> list[float]:
+    """Reduce *marks* to at most :data:`MAX_RAIL_MARKS`, spread across the day.
+
+    The rail used to draw ``marks[:48]``. A 3-minute schedule projects ~480
+    fires, so the ticks ran out about two hours in and the lane read as "the
+    schedule stopped firing" -- while the ``refreshes today`` label beside it
+    still showed the full count, so the two disagreed (#166).
+
+    Taking every *n*th mark instead keeps the lane spanning the window it
+    covers, which is what the rail is for: the reader is judging *when* the
+    schedule fires and roughly how densely, not counting ticks. The count
+    label remains the honest total, and it is now consistent with a lane that
+    reaches the end of the day.
+
+    The first and last marks are always kept, so the lane starts and ends
+    where the schedule does.
+    """
+    if len(marks) <= MAX_RAIL_MARKS:
+        return marks
+    step = (len(marks) - 1) / (MAX_RAIL_MARKS - 1)
+    thinned = [marks[round(i * step)] for i in range(MAX_RAIL_MARKS)]
+    # ``round`` can land twice on the same index at the tail; de-duplicate
+    # while keeping order so two ticks never stack on one pixel.
+    seen: set[float] = set()
+    out: list[float] = []
+    for mark in thinned:
+        if mark not in seen:
+            seen.add(mark)
+            out.append(mark)
+    return out
+
+
 def _design_cards(
     *,
     nav_decks: list[Deck],
@@ -476,7 +513,7 @@ def _design_cards(
                 + (f" · last sent {_ago(last, now_ts)}" if _ago(last, now_ts) else ""),
                 "screens": [screen(s.page_id, None, showing, bool(s.conditions))],
                 "live_name": page_names.get(s.page_id) if showing else None,
-                "marks": marks[:48],
+                "marks": _thin_marks(marks),
                 "now_pct": round(now_pct, 2),
                 "fires_label": (
                     f"fires {s.fires_at.strftime('%H:%M')}"

--- a/tests/test_deck_rail_thinning.py
+++ b/tests/test_deck_rail_thinning.py
@@ -1,0 +1,72 @@
+"""The 24h rail thins dense schedules instead of truncating them (#166).
+
+The rail drew ``marks[:48]``. A 3-minute schedule projects ~480 fires a day,
+so the ticks ran out about two hours in and the lane read as "the schedule
+stopped firing" -- while the ``refreshes today`` label beside it still showed
+the full count, so the label and the ticks disagreed.
+
+The issue reports this against ``_build_timeline`` in ``app/schedule_routes.py``
+(a ``fires[:200]`` cap). That function has no production caller: only a test
+imports it. The rail an operator actually sees is built in
+``app/deck_routes.py``, where the cap is 48 -- so the truncation bites four
+times sooner than the issue estimates.
+"""
+
+from __future__ import annotations
+
+from app.deck_routes import MAX_RAIL_MARKS, _thin_marks
+
+
+def _even_marks(count: int) -> list[float]:
+    """``count`` fires spread evenly across the day, as percentages."""
+    return [i * 100.0 / max(1, count - 1) for i in range(count)]
+
+
+def test_a_sparse_schedule_is_untouched() -> None:
+    """A daily or hourly schedule draws every fire, exactly as before."""
+    marks = _even_marks(24)
+    assert _thin_marks(marks) == marks
+
+
+def test_a_rail_at_the_cap_is_untouched() -> None:
+    marks = _even_marks(MAX_RAIL_MARKS)
+    assert _thin_marks(marks) == marks
+
+
+def test_a_dense_schedule_still_reaches_the_end_of_the_day() -> None:
+    """The defect, in one assertion.
+
+    480 fires truncated to the first 48 stopped at 9.8% of the window --
+    about two hours in on a 24h rail.
+    """
+    thinned = _thin_marks(_even_marks(480))
+    assert thinned[-1] > 99.0, f"the lane stops at {thinned[-1]:.1f}% of the day"
+
+
+def test_a_dense_schedule_starts_where_the_schedule_starts() -> None:
+    thinned = _thin_marks(_even_marks(480))
+    assert thinned[0] == 0.0
+
+
+def test_thinning_is_bounded_at_every_density() -> None:
+    """The cap is what keeps the DOM small; thinning must not lift it."""
+    for count in (49, 100, 480, 1440):
+        assert len(_thin_marks(_even_marks(count))) <= MAX_RAIL_MARKS
+
+
+def test_marks_stay_in_order_and_never_stack() -> None:
+    """Two ticks on one pixel read as one tick, which understates density."""
+    thinned = _thin_marks(_even_marks(1440))
+    assert thinned == sorted(thinned)
+    assert len(set(thinned)) == len(thinned)
+
+
+def test_the_lane_is_spread_not_bunched_at_the_start() -> None:
+    """Head-truncation put every tick in the first tenth of the rail.
+
+    A thinned lane should have marks in every quarter of the day, which is
+    the property that makes it readable as a cadence.
+    """
+    thinned = _thin_marks(_even_marks(480))
+    for lo, hi in ((0.0, 25.0), (25.0, 50.0), (50.0, 75.0), (75.0, 100.1)):
+        assert any(lo <= m < hi for m in thinned), f"no ticks between {lo}% and {hi}%"


### PR DESCRIPTION
## What this changes

The 24h rail thins a dense schedule across the whole day instead of drawing only its first few dozen fires.

Closes #166

## Why

The rail drew `marks[:48]`. A 3-minute schedule projects ~480 fires a day, so the ticks ran out about two hours in and the lane read as "the schedule stopped firing" — while the `refreshes today` label beside it still showed the full 480, so the label and the ticks disagreed.

Taking every *n*th mark keeps the lane spanning the window it covers, which is what a rail is for: the reader is judging *when* a schedule fires and roughly how densely, not counting ticks. The count label stays the honest total and is now consistent with a lane that reaches the end of the day.

First and last marks are always kept, so the lane starts and ends where the schedule does, and duplicates are dropped so two ticks never stack on one pixel and understate density.

## One correction to the issue

The issue reports this against `_build_timeline` in `app/schedule_routes.py`, with its `fires[:200]` cap. **That function has no production caller** — a repo-wide search finds only `tests/test_schedule_routes.py` importing it.

The rail an operator actually sees is built in `app/deck_routes.py:479`, and its cap is **48**, not 200. So the truncation bites about four times sooner than the issue estimates: for the 3-minute case in #164, the ticks stop at 9.8% of the rail — roughly 02:20 on a day that runs to 24:00.

I fixed the live one. `_build_timeline` is left alone; if it is dead it wants deleting rather than patching, and that is your call rather than something to fold into a bug fix.

## Test plan

- [x] `pytest tests/test_deck_rail_thinning.py -q` — 7 passed
- [x] `pytest -q -k "deck or schedule or rotation or rail"` — 422 passed, 5 failed
- [x] `ruff check . && ruff format --check .` on the changed files — clean

**On those 5 failures:** they are all in `tests/test_rotation_scheduler.py` and they fail identically on `main` with my change stashed. Not caused by this PR, and I have not touched them.

The tests assert the properties rather than a mark count: that a sparse schedule is untouched, that a dense lane still reaches >99% of the day, that the cap is never exceeded at any density, that marks stay ordered and unique, and that ticks appear in every quarter of the day — the last one being what head-truncation could never satisfy.