### PR TITLE
fix(rail): the now-marker ticks in the configured timezone (#165)

### DIFF
--- a/app/deck_routes.py
+++ b/app/deck_routes.py
@@ -538,7 +538,17 @@ def _design_cards(
                 "cards": unbound,
             }
         )
-    return {"cards": cards, "groups": groups, "now_hhmm": now_tz.strftime("%H:%M")}
+    # The IANA name, not just the rendered time: the rail's now-marker ticks
+    # client-side, and a browser in a different zone from the configured one
+    # would otherwise recompute the mark against its own clock and jump by the
+    # offset a minute after load (#165, same class as #143 / #164 / #170).
+    tz_name = getattr(tz, "key", "") or ""
+    return {
+        "cards": cards,
+        "groups": groups,
+        "now_hhmm": now_tz.strftime("%H:%M"),
+        "now_tz_name": tz_name,
+    }
 
 
 @bp.get("")
@@ -628,6 +638,7 @@ def index() -> str:
         cards=design["cards"],
         groups=design["groups"],
         now_hhmm=design["now_hhmm"],
+        now_tz_name=design.get("now_tz_name", ""),
         # -- schedules forms ----------------------------------------------
         schedules=schedules,
         status=schedule_status,

--- a/templates/decks.html
+++ b/templates/decks.html
@@ -191,14 +191,33 @@
         .forEach((wash) => wash.classList.add('do-push'));
     }
     // Tick the now marks each minute so the rails stay honest.
-    const tick = () => {
+    //
+    // In the configured timezone, not the browser's. The server anchors
+    // now_pct to settings.app.timezone; a browser somewhere else recomputing
+    // from its own clock made the marker jump by the offset a minute after
+    // load, which is the bug #143 / #164 / #170 fixed server-side arriving
+    // again from the client (#165). An empty name means the server could not
+    // resolve one, and the browser's clock is then the best guess available.
+    const tzName = {{ now_tz_name | tojson }};
+    const hhmmParts = () => {
       const now = new Date();
-      const pct = ((now.getHours() * 60 + now.getMinutes()) / 1440) * 100;
+      if (!tzName) return [now.getHours(), now.getMinutes()];
+      const parts = new Intl.DateTimeFormat('en-GB', {
+        timeZone: tzName, hour: '2-digit', minute: '2-digit', hour12: false,
+      }).formatToParts(now);
+      const get = (t) => Number(parts.find((p) => p.type === t)?.value ?? 0);
+      return [get('hour') % 24, get('minute')];
+    };
+    const tick = () => {
+      const [hh, mm] = hhmmParts();
+      const pct = ((hh * 60 + mm) / 1440) * 100;
       document.querySelectorAll('[data-now-mark]').forEach((m) => { m.style.left = pct + '%'; });
-      const label = String(now.getHours()).padStart(2, '0') + ':' + String(now.getMinutes()).padStart(2, '0');
+      const label = String(hh).padStart(2, '0') + ':' + String(mm).padStart(2, '0');
       document.querySelectorAll('[data-now-label]').forEach((l) => { l.textContent = label; });
     };
-    setInterval(tick, 60000);
+    // Land on the minute rather than 60s after load, so the marker moves when
+    // the clock does instead of on an offset of whenever the page opened.
+    setTimeout(() => { tick(); setInterval(tick, 60000); }, (60 - new Date().getSeconds()) * 1000);
     // A click anywhere outside an open ⋯ menu closes it.
     document.addEventListener('click', (e) => {
       document.querySelectorAll('details.dk-more[open]').forEach((d) => {

--- a/tests/test_deck_rail_now_timezone.py
+++ b/tests/test_deck_rail_now_timezone.py
@@ -1,0 +1,82 @@
+"""The rail's now-marker ticks in the configured timezone (#165).
+
+The marker is drawn server-side from ``settings.app.timezone`` and then
+advanced client-side each minute. The client recomputed it from the browser's
+own clock, so an operator whose browser sits in a different zone from the one
+they configured saw the marker jump by the offset a minute after the page
+loaded -- the bug #143 / #164 / #170 fixed server-side, arriving again from
+the other side.
+
+The page therefore has to carry the zone, not just the rendered time. These
+tests pin that contract: the name reaches the template, and the marker the
+server draws is anchored to it.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
+
+if TYPE_CHECKING:
+    from flask import Flask
+
+
+def _design(app: Flask) -> dict:
+    from app.deck_routes import _design_cards
+
+    with app.test_request_context("/decks"):
+        return _design_cards(
+            nav_decks=[],
+            rotations=[],
+            schedules=[],
+            current_step={},
+            schedule_status={},
+            pages=[],
+            devices=[],
+        )
+
+
+def test_the_design_carries_the_timezone_name(app: Flask) -> None:
+    """Without the name the client has nothing but its own clock to use."""
+    design = _design(app)
+    assert "now_tz_name" in design
+
+
+def test_the_timezone_name_is_resolvable_when_present(app: Flask) -> None:
+    """An unresolvable name is worse than none: the client would fall back
+    to the browser clock anyway, but only after ``Intl`` threw."""
+    name = _design(app)["now_tz_name"]
+    if name:
+        assert ZoneInfo(name) is not None
+
+
+def test_the_rendered_clock_matches_the_zone_it_reports(app: Flask) -> None:
+    """The label and the zone must describe the same moment.
+
+    If they disagree, the client tick will correct the marker to something
+    the server-rendered label contradicts.
+    """
+    design = _design(app)
+    name = design["now_tz_name"]
+    if not name:
+        return
+    expected = datetime.now(ZoneInfo(name)).strftime("%H:%M")
+    # A minute may tick over between the two reads; allow the adjacent value.
+    assert (
+        design["now_hhmm"][:2] == expected[:2]
+        or abs(int(design["now_hhmm"][3:]) - int(expected[3:])) <= 1
+    )
+
+
+def test_the_page_ships_the_zone_to_the_client(app: Flask) -> None:
+    """End to end: the template has to be able to read it."""
+    client = app.test_client()
+    resp = client.get("/decks")
+    try:
+        assert resp.status_code in (200, 302)
+        if resp.status_code == 200:
+            body = resp.get_data(as_text=True)
+            assert "tzName" in body, "the rail tick no longer carries a timezone"
+    finally:
+        resp.close()


### PR DESCRIPTION
## What this changes

The rail's now-marker advances in `settings.app.timezone`, not in whatever zone the operator's browser happens to be in.

Closes #165

## Why — and a correction to the issue

#165 reports the marker as a static snapshot that never advances, against `_build_timeline` in `app/schedule_routes.py`.

That function has no production caller (only a test imports it), and the rail an operator actually sees — built in `deck_routes.py`, drawn by `decks.html` — has ticked client-side since the Lineups redesign:

```js
const tick = () => {
  const now = new Date();
  const pct = ((now.getHours() * 60 + now.getMinutes()) / 1440) * 100;
  ...
setInterval(tick, 60000);
```

So the liveness half is already done. **What is left is that the tick reads the wrong clock.**

The server anchors `now_pct` to `datetime.now(app_timezone())` — deliberately, with a comment citing #164 / #170 / #143 about not inheriting the container's UTC. The client then recomputes from `new Date().getHours()`, the *browser's* zone. On load the marker is right; a minute later it jumps by the offset between the two. That is the same bug those issues fixed server-side, arriving again from the other side, and it is invisible to anyone whose browser and server share a zone.

## The fix

The page carries the IANA name, and the tick formats through `Intl.DateTimeFormat` with `timeZone` — so DST is the platform's problem rather than offset arithmetic I would have to get right. An unresolvable name falls back to the browser clock, which is the best guess available and exactly what happened before.

The interval is also aligned to the minute boundary rather than firing 60s after page load, so the marker moves when the clock does instead of on an offset of whenever the page opened.

## Test plan

- [x] `pytest tests/test_deck_rail_now_timezone.py -q` — 4 passed; all fail on `main` (`KeyError: 'now_tz_name'`)
- [x] `pytest -q -k "deck or decks or rail"` — 206 passed
- [x] `ruff check .` — clean

The tests pin the contract rather than the implementation: the zone name reaches the design dict, it is resolvable when present, the rendered `now_hhmm` describes the same moment as the zone it reports (so the label and the corrected marker cannot contradict each other), and the rendered page actually ships the zone to the client.

## Note

I have not touched `_build_timeline`. Between this and #286 it is the second live bug the tracker attributes to it; if it is dead it wants deleting rather than maintaining, but that is your call rather than something to fold into a fix.