### PR TITLE
feat(secrets): warn while running on the derived encryption key (#259)

### DIFF
--- a/app/secret_box.py
+++ b/app/secret_box.py
@@ -70,6 +70,16 @@ class SecretBoxError(ValueError):
     so the user can fix it instead of getting empty secrets)."""
 
 
+def suggested_env_key() -> str:
+    """A fresh key in the exact form :data:`ENV_KEY` expects.
+
+    Generated per call rather than derived from anything: an operator pasting
+    this is choosing a new key, and one derived from the session secret would
+    reproduce the very coupling the warning is telling them to break.
+    """
+    return secrets.token_hex(KEY_BYTES)
+
+
 class SecretBox:
     """Holds a 32-byte AES-GCM key plus the wrap / unwrap helpers.
 
@@ -139,16 +149,34 @@ class SecretBox:
     @classmethod
     def resolve(cls, session_secret: bytes) -> SecretBox:
         """Apply the documented precedence: env first, session-secret
-        derivation second. Logs the fallback at info on first use so
-        the operator can promote to an explicit env key later."""
+        derivation second.
+
+        The fallback is warned about, not merely noted (#259). It survives an
+        ordinary restart and does not survive a recreated container or a
+        restored data folder with a regenerated session secret; when it does
+        not, every stored secret decrypts to an empty string while the
+        non-secret settings beside it are intact. The install then looks
+        configured and is not, so an operator who never pinned a key is one
+        container recreation away from re-entering every credential they
+        have.
+
+        The warning carries a ready-to-paste key so acting on it is one copy
+        rather than a trip to the docs to find out how to generate one.
+        """
         from_env = cls.from_env()
         if from_env is not None:
             logger.info("SecretBox using %s", ENV_KEY)
             return from_env
-        logger.info(
-            "SecretBox using key derived from session secret; set %s for a stable, "
-            "operator-owned key",
+        logger.warning(
+            "%s is not set, so secrets are encrypted with a key derived from the "
+            "session secret. That key does not survive a recreated container or a "
+            "restored data folder, and stored secrets then read back empty while "
+            "the rest of the settings stay intact. Pin one now — add to your "
+            "compose environment:\n"
+            "    %s=%s",
             ENV_KEY,
+            ENV_KEY,
+            suggested_env_key(),
         )
         return cls.from_session_secret(session_secret)
 

--- a/docs/install/configuration.md
+++ b/docs/install/configuration.md
@@ -48,7 +48,7 @@ tesserae [--dev] [--host HOST] [--port PORT] [--log-level LEVEL] [--reset-passwo
 | Variable | Default | What it does |
 | --- | --- | --- |
 | `TESSERAE_DATA_ROOT` | `<repo>/data` | Data directory: settings, pages, schedules, event log, render cache, backups. The Docker image keeps the default and expects a volume at `/app/data`. |
-| `TESSERAE_SECRET_KEY` | derived | 64 hex chars (32 bytes) used to encrypt stored secrets (API keys, broker passwords) at rest. Unset, a key is derived from the persisted session secret, which works fine; pin it explicitly if you rotate or template `settings.json`. |
+| `TESSERAE_SECRET_KEY` | derived | 64 hex chars (32 bytes) used to encrypt stored secrets (API keys, broker passwords) at rest. Unset, the key is derived from the persisted session secret: that survives a restart but **not** a recreated container or a restored data folder with a regenerated session secret, and stored secrets then read back empty while the rest of the settings stay intact. Pin it — see [Pin the secret key](docker.md#pin-the-secret-key-before-you-store-any-credentials). |
 
 ### Logging and behaviour
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -27,6 +27,47 @@ That's it. Open `http://<host-ip>:8765` (or
 `http://tesserae.local:8765` once mDNS comes up), the first request
 walks through password setup and the onboarding wizard.
 
+## Pin the secret key before you store any credentials
+
+Stored secrets — API keys, broker passwords, the Home Assistant token —
+are encrypted at rest. Without `TESSERAE_SECRET_KEY` the key is derived
+from the persisted session secret, which survives an ordinary restart and
+**does not survive a recreated container or a data folder restored
+alongside a regenerated session secret**.
+
+When it does not survive, the secrets decrypt to an empty string while
+every non-secret setting beside them is intact. The install looks
+configured and is not: the Home Assistant URL is still right, and every
+widget that needs the token reports the install as unconfigured. Nothing
+warns you at the moment the credentials go, only the next time something
+tries to use one.
+
+Generate a key once and put it in the compose file before you enter
+anything worth keeping:
+
+```sh
+python3 -c "import secrets; print(secrets.token_hex(32))"
+```
+
+```yaml
+services:
+  tesserae:
+    image: ghcr.io/dmellok/tesserae:latest
+    environment:
+      TESSERAE_SECRET_KEY: "<the 64 hex chars from above>"
+    volumes:
+      - ./data:/app/data
+```
+
+Tesserae warns at startup while it is running on the derived key, and the
+warning carries a ready-to-paste line. Adding the key later is fine — any
+secret entered *after* it is pinned is safe; ones entered before are still
+tied to the session secret and want re-entering once.
+
+Treat it like any other secret: it decrypts the credentials in your data
+folder, so it does not belong in the same backup as them, and it does not
+belong in a public repo alongside your compose file.
+
 The default `docker-compose.yml` uses **host networking**, which is
 the right choice for a self-hosted Pi / mini-PC / NAS appliance:
 

--- a/tests/test_secret_key_warning.py
+++ b/tests/test_secret_key_warning.py
@@ -1,0 +1,89 @@
+"""The derived encryption key is warned about, not merely noted (#259).
+
+The fallback key survives an ordinary restart and does not survive a
+recreated container or a data folder restored alongside a regenerated
+session secret. When it does not, every stored secret decrypts to an empty
+string while the non-secret settings beside it are intact -- so the install
+looks configured and is not, and nothing says so until the next time
+something tries to use a credential.
+
+An operator who never pinned a key is one container recreation away from
+re-entering everything. That is worth a warning with the line to fix it, not
+an info line most deployments never render.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+
+from app.secret_box import ENV_KEY, KEY_BYTES, SecretBox, suggested_env_key
+
+
+def test_the_derived_key_warns(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """At warning, so it reaches an operator running at default log level."""
+    monkeypatch.delenv(ENV_KEY, raising=False)
+    with caplog.at_level(logging.INFO):
+        SecretBox.resolve(b"0" * 32)
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings, "running on the derived key produced no warning"
+
+
+def test_the_warning_carries_a_pasteable_line(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Acting on it should be a copy, not a trip to the docs.
+
+    The issue asks for "the exact line to add to the compose file".
+    """
+    monkeypatch.delenv(ENV_KEY, raising=False)
+    with caplog.at_level(logging.WARNING):
+        SecretBox.resolve(b"0" * 32)
+    text = "\n".join(r.getMessage() for r in caplog.records)
+    match = re.search(rf"{ENV_KEY}=([0-9a-f]+)", text)
+    assert match, f"no `{ENV_KEY}=<key>` line in the warning:\n{text}"
+    assert len(match.group(1)) == KEY_BYTES * 2
+
+
+def test_the_warning_names_the_failure_not_just_the_setting(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ "Set this variable" is advice; "you will lose your credentials" is a
+    reason. The operator is deciding whether to act now or later."""
+    monkeypatch.delenv(ENV_KEY, raising=False)
+    with caplog.at_level(logging.WARNING):
+        SecretBox.resolve(b"0" * 32)
+    text = " ".join(r.getMessage() for r in caplog.records).lower()
+    assert "container" in text
+    assert "empty" in text
+
+
+def test_a_pinned_key_does_not_warn(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An operator who already acted must not be nagged on every boot."""
+    monkeypatch.setenv(ENV_KEY, "ab" * KEY_BYTES)
+    with caplog.at_level(logging.INFO):
+        SecretBox.resolve(b"0" * 32)
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+def test_the_suggested_key_is_fresh_each_time() -> None:
+    """A key derived from the session secret would reproduce the coupling
+    the warning exists to break."""
+    first, second = suggested_env_key(), suggested_env_key()
+    assert first != second
+    assert len(first) == KEY_BYTES * 2
+    assert re.fullmatch(r"[0-9a-f]+", first)
+
+
+def test_the_suggested_key_is_accepted_by_the_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The line the warning prints has to actually work when pasted."""
+    monkeypatch.setenv(ENV_KEY, suggested_env_key())
+    box = SecretBox.from_env()
+    assert box is not None
+    assert box.unwrap(box.wrap("hunter2")) == "hunter2"


### PR DESCRIPTION
## What this changes

Tesserae warns at startup while it is encrypting secrets with the derived fallback key, and the warning carries the exact line to fix it.

Part of #259 — items **2** and **3**, which the issue calls the minimum.

## Why

`resolve()` already noted the fallback, at `info`, which most deployments never render. The failure it is warning about is not a small one: the derived key survives an ordinary restart and **does not** survive a recreated container or a data folder restored alongside a regenerated session secret. When it does not, every stored secret decrypts to an empty string while every non-secret setting beside it is intact — so the install looks configured and is not, and nothing says so until the next time something tries to use a credential.

What comes out now:

```
WARNING TESSERAE_SECRET_KEY is not set, so secrets are encrypted with a key derived from
the session secret. That key does not survive a recreated container or a restored data
folder, and stored secrets then read back empty while the rest of the settings stay
intact. Pin one now — add to your compose environment:
    TESSERAE_SECRET_KEY=280e6c015a205aff1a7e277370e0c7666a7cf2d8feb00be5a8061e165e22731d
```

The issue asks for "the exact line to add to the compose file", so the warning generates one rather than telling the operator to go and find out how. The suggestion is fresh per call and not derived from anything — a derived suggestion would reproduce the coupling the warning exists to break.

`resolve()` runs once per boot from `app_factory`, so this is a startup warning by construction rather than by adding a second hook.

## Docs (item 3)

The Docker page gains **Pin the secret key before you store any credentials**, placed immediately after first-run and before anything that would store one — the advice is only useful before the secrets go in. It covers generating a key, where it goes, that adding it later protects everything entered after, and that the key does not belong in the same backup as the data it decrypts.

The configuration table described the derived key as one that "works fine; pin it explicitly if you rotate or template `settings.json`". That understated it, and is the sentence an operator would have read before losing a token. It now names the failure and links the new section.

## Not in this PR

Item 1 — generating and persisting a key beside `settings.json` — is left alone. The issue says it "deserves a decision on the trade-off before anyone writes it", and a key sitting next to the ciphertext it protects is exactly the kind of call that should be yours.

## Test plan

- [x] `pytest tests/test_secret_box.py tests/test_secret_key_warning.py -q` — 18 passed
- [x] `pytest -q -k "secret or settings or config"` — 226 passed
- [x] `ruff check . && ruff format --check .` — clean

The tests pin the properties rather than the wording: it warns at `>= WARNING`, the message contains a `TESSERAE_SECRET_KEY=<64 hex>` line, it names the *failure* and not just the setting (an operator is deciding whether to act now or later), a pinned key does **not** warn so nobody is nagged after acting, and the suggested key actually round-trips through `from_env` when pasted.