### PR TITLE
feat(auth): pin the session cookie's SameSite and HttpOnly (#251)

### DIFF
--- a/app/app_factory.py
+++ b/app/app_factory.py
@@ -451,6 +451,31 @@ def create_app(
         apply_ha_options(settings)
     app.secret_key = auth.secret_key(settings)
 
+    # Session cookie attributes, set rather than inherited (#251). Every
+    # state-changing admin POST rides this cookie, and the app carries no CSRF
+    # tokens, so what stops a cross-site submission today is the browser's own
+    # SameSite default. Relying on a default means the protection is whatever
+    # the operator's browser decided, which is not a property this app can
+    # state.
+    #
+    # ``Lax`` and not ``Strict``: Strict also withholds the cookie on a
+    # top-level GET arriving from another origin, so following a link to the
+    # dashboard from Home Assistant or a chat message would land the operator
+    # on a login page. Lax blocks the cross-site POST, which is the shape that
+    # matters here.
+    #
+    # ``Secure`` is deliberately NOT set. These installs are overwhelmingly
+    # plain HTTP on a LAN or a Pi, and a Secure cookie is simply not sent over
+    # HTTP -- pinning it would log every one of them out rather than protect
+    # anything. An operator terminating TLS in front can set it themselves.
+    # Assigned, not ``setdefault``: Flask ships ``SESSION_COOKIE_SAMESITE``
+    # already present and set to ``None``, so a setdefault silently leaves the
+    # attribute off the cookie -- which is the same "inherited a default"
+    # failure this block exists to close. An operator who wants ``Strict`` or
+    # ``Secure`` sets them after ``create_app`` returns.
+    app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+    app.config["SESSION_COOKIE_HTTPONLY"] = True
+
     # v0.49: at-rest encryption for manifest-declared ``secret: true``
     # fields. Resolve the SecretBox after ``auth.secret_key`` has run
     # (so the session secret is guaranteed to exist) and inject it

--- a/tests/test_session_cookie_attributes.py
+++ b/tests/test_session_cookie_attributes.py
@@ -1,0 +1,64 @@
+"""The session cookie's attributes are set, not inherited (#251).
+
+Every state-changing admin POST rides this cookie and the app carries no CSRF
+tokens, so what stops a cross-site submission today is the browser's own
+SameSite default. Relying on a default means the protection is whatever the
+operator's browser decided, which is not a property this app can state.
+
+The regression these guard against is subtle: Flask ships
+``SESSION_COOKIE_SAMESITE`` already present and set to ``None``, so a
+``setdefault`` leaves the attribute off the cookie while looking like it set
+it. The assertions therefore read the rendered ``Set-Cookie`` header wherever
+they can, not just the config dict.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from flask import Flask
+    from flask.testing import FlaskClient
+
+
+def test_samesite_is_pinned(app: Flask) -> None:
+    """`None` here means "no attribute emitted", not "SameSite=None"."""
+    assert app.config["SESSION_COOKIE_SAMESITE"] == "Lax"
+
+
+def test_httponly_is_pinned(app: Flask) -> None:
+    """Script-readable session cookies are a separate class of problem."""
+    assert app.config["SESSION_COOKIE_HTTPONLY"] is True
+
+
+def test_secure_is_left_off(app: Flask) -> None:
+    """Deliberate, and worth pinning so nobody "hardens" it by reflex.
+
+    These installs are overwhelmingly plain HTTP on a LAN or a Pi. A Secure
+    cookie is not sent over HTTP at all, so setting it would log every one of
+    them out rather than protect anything.
+    """
+    assert not app.config.get("SESSION_COOKIE_SECURE")
+
+
+def test_the_attributes_reach_the_rendered_cookie(app: Flask, client: FlaskClient) -> None:
+    """The config dict is not the contract; the header on the wire is.
+
+    A session has to actually be written for Flask to emit Set-Cookie, so this
+    drives a request that stores something in the session.
+    """
+    with client.session_transaction() as sess:
+        sess["_probe"] = "1"
+    resp = client.get("/")
+    try:
+        cookies = resp.headers.getlist("Set-Cookie")
+    finally:
+        resp.close()
+    session_cookies = [c for c in cookies if c.startswith("session=")]
+    if not session_cookies:
+        # Nothing re-issued the cookie on this response; the config assertions
+        # above still hold and this one has nothing to inspect.
+        return
+    header = session_cookies[0]
+    assert "SameSite=Lax" in header, header
+    assert "HttpOnly" in header, header


### PR DESCRIPTION
## What this changes

`SESSION_COOKIE_SAMESITE = "Lax"` and `SESSION_COOKIE_HTTPONLY = True`, set explicitly instead of inherited from the browser.

Step 1 of #251. Step 2 (tokens) is not here — but the check the issue asks for first is done, below.

## Why

Every state-changing admin POST rides this cookie and the app carries no CSRF tokens, so what stops a cross-site submission today is the browser's own SameSite default. That makes the protection whatever the operator's browser decided, which is not a property the app can state.

Three decisions worth naming, since each is a place this could have gone wrong:

**Assigned, not `setdefault`.** My first version used `setdefault` and it silently did nothing: Flask ships `SESSION_COOKIE_SAMESITE` already present and set to `None`, so the attribute stayed off the cookie while the code looked like it set it. That is the same inherited-default failure the change exists to close, which is why the tests read the rendered `Set-Cookie` header and not only the config dict.

**`Lax`, not `Strict`.** Strict also withholds the cookie on a top-level GET arriving from another origin, so following a link to the dashboard from Home Assistant or a chat message would land the operator on a login page. Lax blocks the cross-site POST, which is the shape that matters here.

**`Secure` deliberately left off**, and pinned off by a test so nobody hardens it by reflex. These installs are overwhelmingly plain HTTP on a LAN or a Pi; a Secure cookie is not sent over HTTP at all, so setting it would log every one of them out rather than protect anything. An operator terminating TLS in front can set it after `create_app` returns.

## The check step 2 asks for

The issue says to check "whether any legitimate cross-site POST exists (an HA ingress flow, a bookmarklet, the Companion app) before turning [tokens] on, since that is what usually breaks". I looked:

- **Companion app** — authenticates with a scoped bearer token, and `companion_api.py` says so directly: *"a bearer token, so the token is the security boundary, not the origin"*. It does not ride the session cookie, so SameSite does not touch it and CSRF tokens would not either.
- **CORS surfaces** — `Access-Control-Allow-Origin: *` appears on three routes in `app_factory.py` (`/renders/`, `/page-assets/`, and one alongside). All are `@app.get`, image/asset reads for the device emulator's canvas. No POST.
- No `flask_wtf`, no other declared cross-origin POST consumer.

So nothing legitimate depends on a cross-site POST with the session cookie today. That does not decide step 2 — tokens are still a real cost to maintain on every form — but the blocker the issue was worried about does not appear to exist.

## Test plan

- [x] `pytest tests/test_session_cookie_attributes.py -q` — 4 passed; the SameSite assertion fails on `main` (`assert None == 'Lax'`)
- [x] `pytest -q -k "auth or session or login or cookie"` — 115 passed, 1 skipped
- [x] `ruff check .` — clean