### PR TITLE
feat(companion): support configurable personal-data retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Added
 
+- Companion publishers can choose snapshot retention up to 365 days or explicitly
+  retain the latest snapshot until replacement or deletion. The optional
+  `personal_data_retention` capability enables Never; freshness stays independent
+  of expiry, and existing clients retain their chosen finite deadlines.
+
 - Home Assistant MQTT discovery now exposes lineups and device
   operations. The hub device gains an *Automation* switch (pause every
   scheduled push), a *Quiet hours* switch, a switch per lineup with

--- a/app/companion_api.py
+++ b/app/companion_api.py
@@ -135,7 +135,7 @@ IDEMPOTENCY_RETENTION_SECONDS = 86_400
 # how far a client may set expires_at past generated_at. Server-advertised so
 # the app does not hard-code them.
 PERSONAL_DATA_STALE_SECONDS = 86_400  # 24 h
-PERSONAL_DATA_MAX_TTL_SECONDS = 172_800  # 48 h
+PERSONAL_DATA_MAX_TTL_SECONDS = 31_536_000  # 365 days; null explicitly opts out
 PERSONAL_DATA_SOURCES = ("reminders", "reminders.fridge", HEALTH_SUMMARY_SOURCE_ID)
 PERSONAL_DATA_SNAPSHOT_VERSION = "personal_data_bridge_v1"
 PERSONAL_DATA_REMINDERS_MAX_LISTS = 20
@@ -156,6 +156,7 @@ FEATURES = (
     "image_framing",
     "personal_data_reminders",
     "personal_data_health",
+    "personal_data_retention",
     # Read + control for Lineups (#205). Authoring is a separate capability
     # so a client can offer the controls without implying it can edit, which
     # it can't until the write path behind #204 exists.
@@ -641,8 +642,8 @@ def _is_iso_date(value: Any) -> bool:
         return False
 
 
-def _personal_data_state(generated_epoch: float, expires_epoch: float, now: float) -> str:
-    if now >= expires_epoch:
+def _personal_data_state(generated_epoch: float, expires_epoch: float | None, now: float) -> str:
+    if expires_epoch is not None and now >= expires_epoch:
         return "expired"
     if now >= generated_epoch + PERSONAL_DATA_STALE_SECONDS:
         return "stale"
@@ -650,20 +651,20 @@ def _personal_data_state(generated_epoch: float, expires_epoch: float, now: floa
 
 
 def _source_status(
-    source_id: str, generated_epoch: float, expires_epoch: float, now: float
+    source_id: str, generated_epoch: float, expires_epoch: float | None, now: float
 ) -> dict[str, Any]:
     return {
         "source_id": source_id,
         "state": _personal_data_state(generated_epoch, expires_epoch, now),
         "generated_at": _iso(generated_epoch),
         "stale_at": _iso(generated_epoch + PERSONAL_DATA_STALE_SECONDS),
-        "expires_at": _iso(expires_epoch),
+        "expires_at": _iso(expires_epoch) if expires_epoch is not None else None,
     }
 
 
 def _validate_reminders_fridge(
     source_id: str, body: Any
-) -> tuple[tuple[dict[str, Any], float, float] | None, tuple[Response, int] | None]:
+) -> tuple[tuple[dict[str, Any], float, float | None] | None, tuple[Response, int] | None]:
     """Validate a ``reminders.fridge`` snapshot. Returns ``((snapshot, gen, exp),
     None)`` or ``(None, error)``. Strict: unknown fields are rejected, so the
     endpoint can never become arbitrary JSON storage."""
@@ -681,11 +682,11 @@ def _validate_reminders_fridge(
         return bad("source_id does not match the path")
     gen = _parse_iso(body.get("generated_at"))
     exp = _parse_iso(body.get("expires_at"))
-    if gen is None or exp is None:
-        return bad("generated_at and expires_at must be ISO 8601")
-    if exp <= gen:
+    if gen is None or "expires_at" not in body or (body["expires_at"] is not None and exp is None):
+        return bad("generated_at must be ISO 8601; expires_at must be ISO 8601 or null")
+    if exp is not None and exp <= gen:
         return bad("expires_at must be after generated_at")
-    if exp - gen > PERSONAL_DATA_MAX_TTL_SECONDS:
+    if exp is not None and exp - gen > PERSONAL_DATA_MAX_TTL_SECONDS:
         return bad("expires_at exceeds the maximum retention window")
     data = body.get("data")
     if not isinstance(data, dict) or set(data) - {"items"}:
@@ -719,7 +720,7 @@ def _validate_reminders_fridge(
 
 def _validate_reminders(
     source_id: str, body: Any
-) -> tuple[tuple[dict[str, Any], float, float] | None, tuple[Response, int] | None]:
+) -> tuple[tuple[dict[str, Any], float, float | None] | None, tuple[Response, int] | None]:
     """Validate the generic, grouped Apple Reminders snapshot.
 
     The schema stays deliberately bounded and source-specific: list ids are
@@ -740,11 +741,11 @@ def _validate_reminders(
         return bad("source_id does not match the path")
     gen = _parse_iso(body.get("generated_at"))
     exp = _parse_iso(body.get("expires_at"))
-    if gen is None or exp is None:
-        return bad("generated_at and expires_at must be ISO 8601")
-    if exp <= gen:
+    if gen is None or "expires_at" not in body or (body["expires_at"] is not None and exp is None):
+        return bad("generated_at must be ISO 8601; expires_at must be ISO 8601 or null")
+    if exp is not None and exp <= gen:
         return bad("expires_at must be after generated_at")
-    if exp - gen > PERSONAL_DATA_MAX_TTL_SECONDS:
+    if exp is not None and exp - gen > PERSONAL_DATA_MAX_TTL_SECONDS:
         return bad("expires_at exceeds the maximum retention window")
 
     data = body.get("data")
@@ -815,7 +816,7 @@ def put_personal_data(source_id: str) -> Any:
         if len(request.get_data(cache=True)) > HEALTH_SUMMARY_MAX_BYTES:
             return _error("invalid_snapshot", "health.summary exceeds the 256 KiB limit", 400)
     body = request.get_json(silent=True)
-    result: tuple[dict[str, Any], float, float] | None
+    result: tuple[dict[str, Any], float, float | None] | None
     err: tuple[Response, int] | None
     if source_id == HEALTH_SUMMARY_SOURCE_ID:
         try:
@@ -879,8 +880,12 @@ def personal_data_status() -> Any:
     sources = []
     for source_id, rec in sorted(store.all(publisher_id=publisher_id).items()):
         gen, exp = rec.get("generated_epoch"), rec.get("expires_epoch")
-        if isinstance(gen, (int, float)) and isinstance(exp, (int, float)):
-            sources.append(_source_status(source_id, float(gen), float(exp), now))
+        if isinstance(gen, (int, float)) and (
+            isinstance(exp, (int, float)) or ("expires_epoch" in rec and exp is None)
+        ):
+            sources.append(
+                _source_status(source_id, float(gen), float(exp) if exp is not None else None, now)
+            )
     return jsonify({"sources": sources})
 
 

--- a/app/health_summary.py
+++ b/app/health_summary.py
@@ -481,7 +481,7 @@ def validate_health_summary(
     active_timezone: str,
     snapshot_version: str,
     maximum_ttl_seconds: int,
-) -> tuple[dict[str, Any], float, float]:
+) -> tuple[dict[str, Any], float, float | None]:
     """Validate and return ``(snapshot, generated_epoch, expires_epoch)``."""
 
     snapshot = _object(body, _ENVELOPE_FIELDS, "snapshot")
@@ -491,10 +491,15 @@ def validate_health_summary(
         raise InvalidHealthSummary("source_id does not match the health.summary path")
 
     generated = _utc_instant(snapshot["generated_at"], "generated_at")
-    expires = _utc_instant(snapshot["expires_at"], "expires_at")
-    ttl_seconds = (expires - generated).total_seconds()
-    if not (0 < ttl_seconds <= maximum_ttl_seconds):
-        raise InvalidHealthSummary("expires_at exceeds the maximum retention window")
+    expires = (
+        _utc_instant(snapshot["expires_at"], "expires_at")
+        if snapshot["expires_at"] is not None
+        else None
+    )
+    if expires is not None:
+        ttl_seconds = (expires - generated).total_seconds()
+        if not (0 < ttl_seconds <= maximum_ttl_seconds):
+            raise InvalidHealthSummary("expires_at exceeds the maximum retention window")
 
     data = _object(snapshot["data"], _DATA_FIELDS, "data")
     time_zone = data["time_zone"]
@@ -537,4 +542,4 @@ def validate_health_summary(
     if data["workouts"] is not None:
         _validate_workouts(data["workouts"], expected_dates=expected_date_set, timezone=timezone)
 
-    return snapshot, generated.timestamp(), expires.timestamp()
+    return snapshot, generated.timestamp(), expires.timestamp() if expires is not None else None

--- a/app/state/personal_data_store.py
+++ b/app/state/personal_data_store.py
@@ -1,11 +1,12 @@
 """Latest-only personal-data snapshots for the Companion bridge (#176).
 
-The iOS Companion publishes minimal, expiring Apple Reminders and Health
+The iOS Companion publishes minimal Apple Reminders and Health
 summaries; the server keeps only the *latest* snapshot per paired publisher and
 source, then renders it in a widget. No history: exactly one snapshot per
 ``(publisher_id, source_id)``, replaced on each accepted PUT and deleted on
 disable or expiry. The server never connects to iCloud or HealthKit, it only
-stores what each phone explicitly publishes, and drops it once expired.
+stores what each phone explicitly publishes, and drops it once expired. An
+explicit null deadline retains the latest snapshot until replaced or deleted.
 Contract: ``tests/companion/contract/app-v1.openapi.yaml``.
 
 Each stored record wraps the raw snapshot with the two epochs the API needs for
@@ -14,7 +15,7 @@ ordering and freshness, so this store never parses ISO timestamps itself::
     { "_format": 2, "publishers": {
         "companion_<digest>": { "name": "Kitchen iPhone", "sources": {
           "reminders": { "snapshot": {...}, "generated_epoch": float,
-            "expires_epoch": float, "stored_at": float }
+            "expires_epoch": float | None, "stored_at": float }
         }}
     }}
 
@@ -185,7 +186,7 @@ class PersonalDataSnapshotStore:
         *,
         snapshot: dict[str, Any],
         generated_epoch: float,
-        expires_epoch: float,
+        expires_epoch: float | None,
         publisher_id: str,
         publisher_name: str | None = None,
     ) -> None:

--- a/docs/integrations/companion-data-retention.md
+++ b/docs/integrations/companion-data-retention.md
@@ -1,0 +1,26 @@
+# Companion snapshot retention
+
+Companion's Reminders and Health settings independently choose how long this
+phone's latest snapshot is kept on the selected Tesserae server. The default is
+48 hours; the app also offers 1, 7, 30, and 90 days, or Never. Apply a changed
+period by syncing. It applies to all widgets using that publisher and source,
+not to the due dates of individual reminders or the seven-day Health window.
+
+Updated servers advertise `personal_data_retention` and a finite
+`personal_data_max_ttl_seconds` limit of 365 days. A publisher opts into Never
+with a required, explicit `expires_at: null`; omission or malformed dates are
+rejected. Existing clients continue publishing their usual 48-hour deadline.
+Upgrade the server before selecting longer retention or Never in Companion.
+
+The server always replaces the previous snapshot. Finite deadlines still remove
+raw values and retain only non-sensitive expiry metadata. Never retains values
+until a new snapshot replaces them or the user stops sync and deletes them.
+Changing Never to a finite period takes effect on the next accepted sync.
+Already expired values require a new sync and cannot be recovered by changing
+settings. Disabling the source still deletes the latest snapshot.
+
+Freshness is separate: after 24 hours without a new snapshot, widgets can report
+stale data but keep using it until its chosen expiry. Widgets should treat a null
+deadline as no expiry and keep tracking freshness separately. E-ink frames and
+rendered History images can remain until replaced; snapshot deletion does not
+remotely erase an already displayed image.

--- a/tests/companion/contract/Fixtures/capabilities-personal-data-retention.json
+++ b/tests/companion/contract/Fixtures/capabilities-personal-data-retention.json
@@ -1,0 +1,59 @@
+{
+  "product": "tesserae",
+  "server_version": "0.226.0+personal-data-fixture",
+  "api": {
+    "name": "companion",
+    "version": 1
+  },
+  "pairing": {
+    "supported": true,
+    "code_length": 6,
+    "ttl_seconds": 600
+  },
+  "features": [
+    "devices",
+    "dashboards",
+    "dashboard_push",
+    "image_push",
+    "jobs",
+    "previews",
+    "history",
+    "image_url_push",
+    "webpage_push",
+    "image_framing",
+    "personal_data_reminders",
+    "personal_data_health",
+    "personal_data_retention"
+  ],
+  "personal_data": {
+    "sources": [
+      "reminders",
+      "reminders.fridge",
+      "health.summary"
+    ]
+  },
+  "limits": {
+    "image_upload_bytes": 26214400,
+    "image_max_edge": 8192,
+    "image_content_types": [
+      "image/jpeg",
+      "image/png",
+      "image/heic",
+      "image/heif",
+      "image/webp"
+    ],
+    "image_fit_modes": [
+      "fit",
+      "fill",
+      "blur",
+      "stretch",
+      "center"
+    ],
+    "image_framing_max_zoom": 4,
+    "personal_data_stale_after_seconds": 86400,
+    "personal_data_max_ttl_seconds": 31536000,
+    "job_retention_seconds": 86400,
+    "idempotency_retention_seconds": 86400
+  },
+  "web_url": "/"
+}

--- a/tests/companion/contract/Fixtures/personal-data-reminders-never.json
+++ b/tests/companion/contract/Fixtures/personal-data-reminders-never.json
@@ -1,0 +1,9 @@
+{
+  "version": "personal_data_bridge_v1",
+  "source_id": "reminders",
+  "generated_at": "2026-08-03T09:00:00Z",
+  "expires_at": null,
+  "data": {
+    "lists": []
+  }
+}

--- a/tests/companion/contract/Fixtures/personal-data-status-never.json
+++ b/tests/companion/contract/Fixtures/personal-data-status-never.json
@@ -1,0 +1,7 @@
+{
+  "source_id": "health.summary",
+  "state": "fresh",
+  "generated_at": "2026-08-14T12:30:00Z",
+  "stale_at": "2026-08-15T12:30:00Z",
+  "expires_at": null
+}

--- a/tests/companion/contract/app-v1.openapi.yaml
+++ b/tests/companion/contract/app-v1.openapi.yaml
@@ -1313,6 +1313,7 @@ components:
               - offline_albums
               - personal_data_reminders
               - personal_data_health
+              - personal_data_retention
               - lineups
               - lineup_control
               - lineup_authoring
@@ -1400,7 +1401,9 @@ components:
           minimum: 60
         personal_data_max_ttl_seconds:
           description: >-
-            Maximum allowed difference between generated_at and expires_at.
+            Maximum finite difference between generated_at and expires_at (up to
+            365 days). Servers advertising personal_data_retention also accept
+            explicit null expires_at for user-selected indefinite retention.
             Required whenever any personal-data capability is advertised.
           type: integer
           minimum: 60
@@ -1575,9 +1578,14 @@ components:
           type: string
           format: date-time
         expires_at:
-          description: Required deletion deadline for raw snapshot values
+          description: >-
+            Deletion deadline, or explicit null to retain until replaced or
+            deleted. Null requires the personal_data_retention capability and
+            explicit user selection. Finite deadlines must be after generated_at
+            and within personal_data_max_ttl_seconds. Staleness remains independent.
           type: string
           format: date-time
+          nullable: true
         data:
           $ref: "#/components/schemas/RemindersData"
     RemindersData:
@@ -1644,10 +1652,13 @@ components:
           format: date-time
         expires_at:
           description: >-
-            Required deletion deadline for raw snapshot values. It must be later
-            than generated_at and conform to the server retention policy.
+            Deletion deadline, or explicit null to retain until replaced or
+            deleted. Null requires the personal_data_retention capability and
+            explicit user selection. Finite deadlines must be after generated_at
+            and within personal_data_max_ttl_seconds. Staleness remains independent.
           type: string
           format: date-time
+          nullable: true
         data:
           $ref: "#/components/schemas/RemindersFridgeData"
     RemindersFridgeData:
@@ -1711,10 +1722,13 @@ components:
           format: date-time
         expires_at:
           description: >-
-            Required deletion deadline. The server's advertised maximum remains
-            48 hours even though the content covers seven calendar dates.
+            Deletion deadline, or explicit null to retain until replaced or
+            deleted. Null requires the personal_data_retention capability and
+            explicit user selection. Finite deadlines must be after generated_at
+            and within personal_data_max_ttl_seconds. Staleness remains independent.
           type: string
           format: date-time
+          nullable: true
         data:
           $ref: "#/components/schemas/HealthSummaryData"
     HealthSummaryData:
@@ -2213,8 +2227,14 @@ components:
           type: string
           format: date-time
         expires_at:
+          description: >-
+            Deletion deadline, or explicit null to retain until replaced or
+            deleted. Null requires the personal_data_retention capability and
+            explicit user selection. Finite deadlines must be after generated_at
+            and within personal_data_max_ttl_seconds. Staleness remains independent.
           type: string
           format: date-time
+          nullable: true
     PersonalDataStatusResponse:
       type: object
       additionalProperties: false

--- a/tests/companion/test_companion_api.py
+++ b/tests/companion/test_companion_api.py
@@ -130,6 +130,7 @@ def test_capabilities_probe_is_unauthenticated_and_valid(app: Flask) -> None:
         "image_framing",
         "personal_data_reminders",
         "personal_data_health",
+        "personal_data_retention",
         "lineups",
         "lineup_control",
         "lineup_authoring",

--- a/tests/companion/test_companion_personal_data.py
+++ b/tests/companion/test_companion_personal_data.py
@@ -196,13 +196,14 @@ def test_capabilities_advertise_personal_data(app: Flask) -> None:
     jsonschema.validate(body, schema_for("Capabilities"), format_checker=_FMT)
     assert "personal_data_reminders" in body["features"]
     assert "personal_data_health" in body["features"]
+    assert "personal_data_retention" in body["features"]
     assert body["personal_data"]["sources"] == [
         "reminders",
         "reminders.fridge",
         "health.summary",
     ]
     assert body["limits"]["personal_data_stale_after_seconds"] == 86400
-    assert body["limits"]["personal_data_max_ttl_seconds"] == 172800
+    assert body["limits"]["personal_data_max_ttl_seconds"] == 31_536_000
 
 
 def test_put_then_status_round_trip(app: Flask) -> None:
@@ -381,7 +382,7 @@ def test_health_validation_enforces_ttl_window_and_request_size(app: Flask) -> N
     token = _token(app)
     now = datetime.now(UTC).replace(microsecond=0)
 
-    too_long = _put_health(app, token, _health_snapshot(now, ttl_hours=49))
+    too_long = _put_health(app, token, _health_snapshot(now, ttl_hours=365 * 24 + 1))
     assert too_long.status_code == 400
     assert too_long.get_json()["error"]["code"] == "invalid_snapshot"
 
@@ -625,8 +626,8 @@ def test_validation_and_unknown_source(app: Flask) -> None:
     assert r.status_code == 400
     assert r.get_json()["error"]["message"] == "item due_date is required"
 
-    # ttl beyond the 48h max.
-    r = _put(app, token, _snapshot(now, ttl_hours=72))
+    # TTL beyond the advertised 365-day maximum.
+    r = _put(app, token, _snapshot(now, ttl_hours=366 * 24))
     assert r.status_code == 400 and r.get_json()["error"]["code"] == "invalid_snapshot"
 
     # unknown source id.
@@ -765,3 +766,68 @@ def test_delete_is_idempotent(app: Flask) -> None:
 def test_unauthenticated_is_rejected(app: Flask) -> None:
     r = app.test_client().get("/api/app/v1/personal-data/status")
     assert r.status_code == 401
+
+
+@pytest.mark.parametrize("source", ["reminders", "reminders.fridge", "health.summary"])
+@pytest.mark.parametrize("days", [7, 30, 90, 365, None])
+def test_configurable_retention_survives_two_days_and_deletes(
+    app: Flask, source: str, days: int | None
+) -> None:
+    token = _token(app)
+    now = datetime.now(UTC).replace(microsecond=0)
+    generated = now - timedelta(days=3)
+    factories = {
+        "reminders": _multi_list_snapshot,
+        "reminders.fridge": _snapshot,
+        "health.summary": _health_snapshot,
+    }
+    snapshot = factories[source](generated)
+    snapshot["expires_at"] = _iso(generated + timedelta(days=days)) if days else None
+    client = app.test_client()
+    url = f"/api/app/v1/personal-data/{source}"
+    response = client.put(url, json=snapshot, headers=_auth(token))
+    assert response.status_code == 200, response.get_data(as_text=True)
+    status = response.get_json()
+    jsonschema.validate(status, schema_for("PersonalDataSourceStatus"), format_checker=_FMT)
+    assert status["state"] == "stale"  # age is honest, values remain usable
+    assert status["expires_at"] == snapshot["expires_at"]
+    store = app.config["PERSONAL_DATA_STORE"]
+    assert store.get(source)["snapshot"] == snapshot
+    listing = client.get("/api/app/v1/personal-data/status", headers=_auth(token)).get_json()
+    assert listing["sources"] == [status]
+    # Restart/reload retains the selected policy; finite snapshots still redact.
+    from app.state.personal_data_store import PersonalDataSnapshotStore
+
+    reloaded = PersonalDataSnapshotStore(store._path)
+    assert reloaded.get(source)["snapshot"] == snapshot
+    reloaded.redact_expired((generated + timedelta(days=366)).timestamp())
+    assert ("snapshot" in reloaded.get(source)) is (days is None)
+    assert client.delete(url, headers=_auth(token)).status_code == 204
+    assert store.get(source) is None
+
+
+@pytest.mark.parametrize("source", ["reminders", "reminders.fridge", "health.summary"])
+def test_retention_can_be_shortened_and_missing_deadline_is_rejected(
+    app: Flask, source: str
+) -> None:
+    token = _token(app)
+    now = datetime.now(UTC).replace(microsecond=0)
+    factories = {
+        "reminders": _multi_list_snapshot,
+        "reminders.fridge": _snapshot,
+        "health.summary": _health_snapshot,
+    }
+    client = app.test_client()
+    url = f"/api/app/v1/personal-data/{source}"
+    snapshot = factories[source](now)
+    del snapshot["expires_at"]
+    assert client.put(url, json=snapshot, headers=_auth(token)).status_code == 400
+    snapshot["expires_at"] = None
+    assert client.put(url, json=snapshot, headers=_auth(token)).status_code == 200
+    replacement = factories[source](now + timedelta(seconds=1), ttl_hours=24)
+    response = client.put(url, json=replacement, headers=_auth(token))
+    assert response.status_code == 200
+    assert response.get_json()["expires_at"] == replacement["expires_at"]
+    store = app.config["PERSONAL_DATA_STORE"]
+    store.redact_expired((now + timedelta(days=2)).timestamp())
+    assert "snapshot" not in store.get(source)

--- a/tests/companion/test_contract_fixtures.py
+++ b/tests/companion/test_contract_fixtures.py
@@ -18,6 +18,9 @@ import pytest
 from ._schema import FIXTURES_DIR, SPEC, schema_for
 
 CASES = {
+    "capabilities-personal-data-retention.json": "Capabilities",
+    "personal-data-reminders-never.json": "PersonalDataSnapshot",
+    "personal-data-status-never.json": "PersonalDataSourceStatus",
     "capabilities.json": "Capabilities",
     "capabilities-previews.json": "Capabilities",
     "capabilities-extended.json": "Capabilities",


### PR DESCRIPTION
## What this changes

Companion publishers can retain their latest Reminders, Reminders Fridge, and Health Summary snapshots for up to 365 days, or explicitly use `expires_at: null` to keep them until replaced or deleted. Servers advertise `personal_data_retention`; the deadline field remains required, and existing finite deadlines continue to work.

## Why

The current 48-hour maximum can remove a useful reminder or health summary between phone syncs. This supports the [Companion app's per-server retention controls](https://github.com/charmmmz/tesserae-companion-ios/commit/808f9ef) while keeping freshness separate: data becomes stale after 24 hours, and finite expiry still removes raw values. Storage remains latest-only and scoped to each paired publisher and source.

## Test plan

- [x] `.venv/bin/python -m pytest -n 6 -q` — 4,316 passed on Python 3.12.
- [x] `.venv/bin/ruff check . && .venv/bin/ruff format --check .`
- [x] `.venv/bin/python -m mypy app`
- [x] Regression coverage for 7/30/90/365-day and indefinite retention across all three sources, status responses, persistence after reload, explicit deletion, missing-deadline rejection, and changing Never back to finite expiry.
- Manual validation against a deployed server is not included in this PR's validation.

## Checklist

- [x] Tests and OpenAPI fixtures added for the new behavior.
- [x] Ruff and mypy clean.
- [x] Retention and widget behavior documented in `docs/integrations/companion-data-retention.md`.
- [x] User-facing entry added under `CHANGELOG.md`'s Unreleased section.
- No version bump or release tag; this PR only adds the API capability.
