### PR TITLE
feat(calendar_month): the "Week starts" label is optional, off by default (#283)

### DIFF
--- a/plugins/calendar_month/client.js
+++ b/plugins/calendar_month/client.js
@@ -143,6 +143,12 @@ export default function render(shadow, ctx) {
   const monthDate = new Date(data.year || 2026, (data.month || 1) - 1, 1);
   const monthName = localizedFull(monthDate, "month", locale).toUpperCase();
   const year = data.year || "";
+  // Off by default (#283): the weekday column headers already say which day
+  // the week starts on, so the label restated it and cost a line of header on
+  // a panel where space is the scarce thing. Kept as an option rather than
+  // deleted, because a minimal or single-letter weekday style makes it much
+  // less obvious at a glance.
+  const showWeekStart = opts.show_week_start === true;
   const weekStartLabel = (data.week_start === "sunday")
     ? t("week_start_sunday", "Week starts Sun")
     : t("week_start_monday", "Week starts Mon");
@@ -269,7 +275,7 @@ export default function render(shadow, ctx) {
         <div class="cal-head">
           <div class="cal-head-row">
             <span class="cal-head-title">${escapeHtml(monthName)} <span class="num">${escapeHtml(String(year))}</span></span>
-            <span class="cal-head-meta">${escapeHtml(weekStartLabel)}</span>
+            ${showWeekStart ? `<span class="cal-head-meta">${escapeHtml(weekStartLabel)}</span>` : ""}
           </div>
           <div class="cal-head-rule"></div>
         </div>

--- a/plugins/calendar_month/plugin.json
+++ b/plugins/calendar_month/plugin.json
@@ -70,6 +70,13 @@
       ]
     },
     {
+      "name": "show_week_start",
+      "type": "boolean",
+      "label": "Show \"Week starts\" label",
+      "default": false,
+      "help": "Off by default: the weekday column headers already show which day the week starts on. Worth turning on with a minimal or single-letter weekday style, where it is less obvious."
+    },
+    {
       "name": "title_scale",
       "type": "slider",
       "label": "Dashboard title size",

--- a/plugins/calendar_month/tests/clamp_check.mjs
+++ b/plugins/calendar_month/tests/clamp_check.mjs
@@ -1,6 +1,7 @@
 // Plain-node self-check (no test framework in this repo).
 // Run: node tests/clamp_check.mjs
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { clampScale, localizedFull, minimalMapFor, styleLabel } from "../client.js";
 
 assert.equal(clampScale(undefined, 1.0, 0.1, 5.0), 1.0, "missing falls back to default");
@@ -33,5 +34,22 @@ assert.equal(localizedFull(monday, "weekday", ""), "Monday", "no locale at all d
 assert.equal(minimalMapFor("weekday", "en").Tuesday, "Tu", "English gets the real disambiguation map");
 assert.deepEqual(minimalMapFor("weekday", "fr"), {}, "non-English gets {} -- styleLabel's generic slice, not English abbreviations");
 assert.deepEqual(minimalMapFor("month", "de"), {}, "same for months");
+
+// The "Week starts" label is opt-in (#283): the weekday column headers
+// already say which day the week starts on. Asserted against the source
+// because the label lives inside the render template literal, and the
+// property that matters is that it is gated at all -- an ungated one
+// reappears the moment someone edits that block.
+const clientSource = readFileSync(new URL("../client.js", import.meta.url), "utf8");
+assert.match(
+  clientSource,
+  /opts\.show_week_start === true/,
+  "the week-start label must read the show_week_start option",
+);
+assert.match(
+  clientSource,
+  /showWeekStart \? /,
+  "the week-start label must be gated on that option, not always rendered",
+);
 
 console.log("clamp_check.mjs: all assertions passed");


### PR DESCRIPTION
## What this changes

The month widget's `Week starts Sun/Mon` header label is now a `show_week_start` option, off by default.

Closes #283

## Why

The reporter's point holds: the weekday column headers directly beneath already say which day the week starts on, so the label restated it and cost a line of header on a panel where space is the scarce thing.

**Made optional rather than removed, and defaulting off.** The widget has a `date_label_style` option with `minimal` (1–2 characters, `M Tu W Th…`) and `short` settings — with those the first column is much less self-evident, so there is a real case for the label. Just not the default one, which is what the issue is about.

## Test plan

- [x] `node plugins/calendar_month/tests/clamp_check.mjs` — passes
- [x] `pytest tests/test_widget_clamp_checks.py -q` — 4 passed
- [x] `pytest -q -k "calendar or clamp or manifest"` — 159 passed
- [x] Verified the new assertion actually fails: with `client.js` reverted, the self-check throws

The assertion goes in the widget's own `clamp_check.mjs`, which `test_widget_clamp_checks.py` already runs under pytest, so it is covered by the normal suite rather than needing a new harness.

It asserts against the source rather than a rendered DOM, because the label lives inside the render template literal and the property worth pinning is that it is *gated at all* — an ungated one reappears the moment someone edits that block.

## One note on the diff

My first commit rewrote `plugin.json` through `json.dumps`, which expanded every compact array in the file and turned a one-option addition into a 77-line diff. Re-done as a text insertion, so the manifest change is the 7 lines it should be and the file's existing formatting is untouched.