### PR TITLE
feat(calendar): use per-event colours from the .ics feed (#222)

### DIFF
--- a/plugins/calendar_core/server.py
+++ b/plugins/calendar_core/server.py
@@ -442,6 +442,11 @@ def _expand_events_full(blob: bytes, start: datetime, end: datetime) -> list[dic
                     "start": s_iso,
                     "end": e_iso,
                     "all_day": all_day,
+                    # The event's own colour, when the producer set one
+                    # (#222). Carried on every event and honoured only when
+                    # the feed opts in, so turning the option on and off does
+                    # not need a cache drop.
+                    "event_colour": _event_colour(ev),
                 }
             )
         except Exception:
@@ -671,10 +676,18 @@ def load_events(
             ics_mtime = cache_path.stat().st_mtime
         except OSError:
             ics_mtime = 0.0
+        use_event_colours = bool(feed.get("use_event_colours"))
         for ev in _expand_events_cached(fid, ics_mtime, blob, start, end):
             ev["feed_id"] = fid
             ev["feed_name"] = feed.get("name") or fid
-            ev["feed_colour"] = feed.get("colour") or DEFAULT_COLOUR
+            # The feed's colour is the default and an event's own colour wins
+            # only when the feed opts in (#222). Opting in is per feed because
+            # the two uses are opposite: one calendar categorises by colour,
+            # another wants every event to read as "work" regardless of what
+            # the producer set. An event with no colour of its own always
+            # falls back, so a partly-coloured calendar stays coherent.
+            own = str(ev.get("event_colour") or "") if use_event_colours else ""
+            ev["feed_colour"] = own or feed.get("colour") or DEFAULT_COLOUR
             out.append(ev)
     out.sort(key=lambda e: (not e["all_day"], e["start"]))
     return out
@@ -830,6 +843,180 @@ def _export_url(collection_url: str) -> str:
     either way."""
     sep = "&" if "?" in collection_url else "?"
     return f"{collection_url}{sep}export"
+
+
+#: RFC 7986 ``COLOR`` is a CSS3 colour *name*, not a hex triple, and that is
+#: what Google Calendar writes for a per-event colour. Only the names CSS3
+#: actually defines are accepted; anything else is treated as absent rather
+#: than guessed at, since a wrong colour is worse than the feed's own.
+_CSS3_COLOURS: dict[str, str] = {
+    "aliceblue": "#f0f8ff",
+    "antiquewhite": "#faebd7",
+    "aqua": "#00ffff",
+    "aquamarine": "#7fffd4",
+    "azure": "#f0ffff",
+    "beige": "#f5f5dc",
+    "bisque": "#ffe4c4",
+    "black": "#000000",
+    "blanchedalmond": "#ffebcd",
+    "blue": "#0000ff",
+    "blueviolet": "#8a2be2",
+    "brown": "#a52a2a",
+    "burlywood": "#deb887",
+    "cadetblue": "#5f9ea0",
+    "chartreuse": "#7fff00",
+    "chocolate": "#d2691e",
+    "coral": "#ff7f50",
+    "cornflowerblue": "#6495ed",
+    "cornsilk": "#fff8dc",
+    "crimson": "#dc143c",
+    "cyan": "#00ffff",
+    "darkblue": "#00008b",
+    "darkcyan": "#008b8b",
+    "darkgoldenrod": "#b8860b",
+    "darkgray": "#a9a9a9",
+    "darkgreen": "#006400",
+    "darkgrey": "#a9a9a9",
+    "darkkhaki": "#bdb76b",
+    "darkmagenta": "#8b008b",
+    "darkolivegreen": "#556b2f",
+    "darkorange": "#ff8c00",
+    "darkorchid": "#9932cc",
+    "darkred": "#8b0000",
+    "darksalmon": "#e9967a",
+    "darkseagreen": "#8fbc8f",
+    "darkslateblue": "#483d8b",
+    "darkslategray": "#2f4f4f",
+    "darkslategrey": "#2f4f4f",
+    "darkturquoise": "#00ced1",
+    "darkviolet": "#9400d3",
+    "deeppink": "#ff1493",
+    "deepskyblue": "#00bfff",
+    "dimgray": "#696969",
+    "dimgrey": "#696969",
+    "dodgerblue": "#1e90ff",
+    "firebrick": "#b22222",
+    "floralwhite": "#fffaf0",
+    "forestgreen": "#228b22",
+    "fuchsia": "#ff00ff",
+    "gainsboro": "#dcdcdc",
+    "ghostwhite": "#f8f8ff",
+    "gold": "#ffd700",
+    "goldenrod": "#daa520",
+    "gray": "#808080",
+    "green": "#008000",
+    "greenyellow": "#adff2f",
+    "grey": "#808080",
+    "honeydew": "#f0fff0",
+    "hotpink": "#ff69b4",
+    "indianred": "#cd5c5c",
+    "indigo": "#4b0082",
+    "ivory": "#fffff0",
+    "khaki": "#f0e68c",
+    "lavender": "#e6e6fa",
+    "lavenderblush": "#fff0f5",
+    "lawngreen": "#7cfc00",
+    "lemonchiffon": "#fffacd",
+    "lightblue": "#add8e6",
+    "lightcoral": "#f08080",
+    "lightcyan": "#e0ffff",
+    "lightgoldenrodyellow": "#fafad2",
+    "lightgray": "#d3d3d3",
+    "lightgreen": "#90ee90",
+    "lightgrey": "#d3d3d3",
+    "lightpink": "#ffb6c1",
+    "lightsalmon": "#ffa07a",
+    "lightseagreen": "#20b2aa",
+    "lightskyblue": "#87cefa",
+    "lightslategray": "#778899",
+    "lightslategrey": "#778899",
+    "lightsteelblue": "#b0c4de",
+    "lightyellow": "#ffffe0",
+    "lime": "#00ff00",
+    "limegreen": "#32cd32",
+    "linen": "#faf0e6",
+    "magenta": "#ff00ff",
+    "maroon": "#800000",
+    "mediumaquamarine": "#66cdaa",
+    "mediumblue": "#0000cd",
+    "mediumorchid": "#ba55d3",
+    "mediumpurple": "#9370db",
+    "mediumseagreen": "#3cb371",
+    "mediumslateblue": "#7b68ee",
+    "mediumspringgreen": "#00fa9a",
+    "mediumturquoise": "#48d1cc",
+    "mediumvioletred": "#c71585",
+    "midnightblue": "#191970",
+    "mintcream": "#f5fffa",
+    "mistyrose": "#ffe4e1",
+    "moccasin": "#ffe4b5",
+    "navajowhite": "#ffdead",
+    "navy": "#000080",
+    "oldlace": "#fdf5e6",
+    "olive": "#808000",
+    "olivedrab": "#6b8e23",
+    "orange": "#ffa500",
+    "orangered": "#ff4500",
+    "orchid": "#da70d6",
+    "palegoldenrod": "#eee8aa",
+    "palegreen": "#98fb98",
+    "paleturquoise": "#afeeee",
+    "palevioletred": "#db7093",
+    "papayawhip": "#ffefd5",
+    "peachpuff": "#ffdab9",
+    "peru": "#cd853f",
+    "pink": "#ffc0cb",
+    "plum": "#dda0dd",
+    "powderblue": "#b0e0e6",
+    "purple": "#800080",
+    "red": "#ff0000",
+    "rosybrown": "#bc8f8f",
+    "royalblue": "#4169e1",
+    "saddlebrown": "#8b4513",
+    "salmon": "#fa8072",
+    "sandybrown": "#f4a460",
+    "seagreen": "#2e8b57",
+    "seashell": "#fff5ee",
+    "sienna": "#a0522d",
+    "silver": "#c0c0c0",
+    "skyblue": "#87ceeb",
+    "slateblue": "#6a5acd",
+    "slategray": "#708090",
+    "slategrey": "#708090",
+    "snow": "#fffafa",
+    "springgreen": "#00ff7f",
+    "steelblue": "#4682b4",
+    "tan": "#d2b48c",
+    "teal": "#008080",
+    "thistle": "#d8bfd8",
+    "tomato": "#ff6347",
+    "turquoise": "#40e0d0",
+    "violet": "#ee82ee",
+    "wheat": "#f5deb3",
+    "white": "#ffffff",
+    "whitesmoke": "#f5f5f5",
+    "yellow": "#ffff00",
+    "yellowgreen": "#9acd32",
+}
+
+
+def _event_colour(comp: Any) -> str:
+    """The event's own colour as ``#rrggbb``, or ``""`` when it declares none.
+
+    Two spellings reach us. RFC 7986 ``COLOR`` carries a CSS3 colour *name*,
+    which is what Google Calendar writes; ``X-APPLE-CALENDAR-COLOR`` carries
+    a hex triple, sometimes with an alpha byte, and is what Apple and several
+    CalDAV servers write. An unrecognised value returns ``""`` rather than a
+    guess: falling back to the feed's colour is right, and inventing one is
+    not.
+    """
+    named = str(comp.get("COLOR") or "").strip().lower()
+    if named in _CSS3_COLOURS:
+        return _CSS3_COLOURS[named]
+    hexish = str(comp.get("X-APPLE-CALENDAR-COLOR") or "").strip()
+    if re.match(r"^#[0-9a-fA-F]{6}", hexish):
+        return hexish[:7].lower()
+    return ""
 
 
 def _normalise_colour(raw: str) -> str:
@@ -1396,6 +1583,32 @@ def blueprint() -> Blueprint:
         with contextlib.suppress(OSError):
             _ics_cache_path(_data_dir(), feed_id).unlink(missing_ok=True)
         flash(f"Updated credentials for '{feed.get('name') or feed_id}'.", "ok")
+        return redirect(url_for("calendar_core_admin.index"))
+
+    @bp.post("/feeds/<feed_id>/event-colours")
+    def toggle_event_colours(feed_id: str) -> Response:
+        """Turn per-event colours on or off for one feed (#222).
+
+        Stored on the feed rather than applied at fetch time, so flipping it
+        does not invalidate the cached ICS: every event already carries its
+        own colour and this only decides whether that colour wins over the
+        feed's.
+        """
+        data = _load_feeds()
+        feed = next((f for f in data.get("feeds", []) if f.get("id") == feed_id), None)
+        if not feed:
+            abort(404)
+        feed["use_event_colours"] = not feed.get("use_event_colours")
+        _save_feeds(data)
+        flash(
+            f"'{feed.get('name') or feed_id}' now uses "
+            + (
+                "each event's own colour where it sets one."
+                if feed["use_event_colours"]
+                else "the feed colour for every event."
+            ),
+            "ok",
+        )
         return redirect(url_for("calendar_core_admin.index"))
 
     @bp.post("/feeds/<feed_id>/colour")

--- a/plugins/calendar_core/server.py
+++ b/plugins/calendar_core/server.py
@@ -845,8 +845,8 @@ def _export_url(collection_url: str) -> str:
     return f"{collection_url}{sep}export"
 
 
-#: RFC 7986 ``COLOR`` is a CSS3 colour *name*, not a hex triple, and that is
-#: what Google Calendar writes for a per-event colour. Only the names CSS3
+#: RFC 7986 ``COLOR`` is a CSS3 colour *name*, not a hex triple, and is the
+#: form CalDAV servers such as Nextcloud and Baikal write. Only the names CSS3
 #: actually defines are accepted; anything else is treated as absent rather
 #: than guessed at, since a wrong colour is worse than the feed's own.
 _CSS3_COLOURS: dict[str, str] = {
@@ -1003,11 +1003,13 @@ _CSS3_COLOURS: dict[str, str] = {
 def _event_colour(comp: Any) -> str:
     """The event's own colour as ``#rrggbb``, or ``""`` when it declares none.
 
-    Two spellings reach us. RFC 7986 ``COLOR`` carries a CSS3 colour *name*,
-    which is what Google Calendar writes; ``X-APPLE-CALENDAR-COLOR`` carries
-    a hex triple, sometimes with an alpha byte, and is what Apple and several
-    CalDAV servers write. An unrecognised value returns ``""`` rather than a
-    guess: falling back to the feed's colour is right, and inventing one is
+    Two spellings reach us. RFC 7986 ``COLOR`` carries a CSS3 colour *name*
+    and is the interoperable form. ``X-APPLE-CALENDAR-COLOR`` carries a hex
+    triple, sometimes with an alpha byte; Apple defines it at calendar level,
+    but tools that inject colours into a feed sometimes stamp it on the event,
+    so a hex value found there is accepted too. Google Calendar's own export
+    carries neither (#222). An unrecognised value returns ``""`` rather than
+    a guess: falling back to the feed's colour is right, and inventing one is
     not.
     """
     named = str(comp.get("COLOR") or "").strip().lower()

--- a/plugins/calendar_core/templates/calendar_core/index.html
+++ b/plugins/calendar_core/templates/calendar_core/index.html
@@ -152,7 +152,8 @@
     <li class="cf-row {% if not f.enabled %}is-disabled{% endif %}">
       <form method="post" action="{{ url_for('calendar_core_admin.update_colour', feed_id=f.id) }}" class="inline cf-colour">
         <input type="color" name="colour" value="{{ f.colour or '#0d8c7e' }}" class="cf-swatch cf-swatch--input"
-               title="Change colour" aria-label="Colour for {{ f.name }}"
+               title="{% if f.use_event_colours %}Feed colour, used where an event sets none{% else %}Change colour{% endif %}"
+               aria-label="Colour for {{ f.name }}"
                onchange="this.form.requestSubmit()">
       </form>
       <span class="cf-name">
@@ -200,6 +201,14 @@
         <button type="button" class="ghost" title="Credentials" onclick="document.getElementById('cf-auth-{{ f.id }}').hidden = !document.getElementById('cf-auth-{{ f.id }}').hidden">
           <i class="ph ph-lock-simple" aria-hidden="true"></i>
         </button>
+        {% endif %}
+        {% if f.source != 'ha' %}
+        <form method="post" action="{{ url_for('calendar_core_admin.toggle_event_colours', feed_id=f.id) }}" class="inline">
+          <button type="submit" class="ghost"
+                  title="{% if f.use_event_colours %}Using each event's own colour where it sets one. Click to use the feed colour for every event.{% else %}Using the feed colour for every event. Click to use each event's own colour where the calendar sets one.{% endif %}">
+            <i class="ph ph-{{ 'palette' if f.use_event_colours else 'drop-half' }}" aria-hidden="true"></i>
+          </button>
+        </form>
         {% endif %}
         <form method="post" action="{{ url_for('calendar_core_admin.toggle_feed', feed_id=f.id) }}" class="inline">
           <button type="submit" class="ghost" title="{{ 'Disable' if f.enabled else 'Enable' }}">

--- a/plugins/calendar_core/tests/test_event_colours.py
+++ b/plugins/calendar_core/tests/test_event_colours.py
@@ -1,0 +1,89 @@
+"""Per-event colours from the .ics feed (#222).
+
+A single calendar is often colour-coded by category -- work, school, holiday
+-- and every one of those events arrived at the widget stamped with the
+feed's one colour, so the distinction the user maintains upstream was thrown
+away on the way in.
+
+The colour is read off the event and carried on every event; whether it wins
+over the feed's is a per-feed opt-in, because the two uses are opposite. One
+calendar categorises by colour; another wants everything to read as "work"
+whatever the producer set.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+from typing import Any
+
+_SERVER_PATH = Path(__file__).resolve().parent.parent / "server.py"
+
+
+def _load_server() -> Any:
+    """Load this plugin's ``server.py`` under a unique module name.
+
+    Every plugin ships a module called ``server``, and the sibling suites
+    reach theirs with ``sys.path.insert`` + ``import server``. Doing the same
+    here would put whichever ran first into ``sys.modules["server"]`` and hand
+    the other one the wrong module -- which is what happened: adding this file
+    turned eleven passing calendar_day tests red without touching them.
+    """
+    spec = importlib.util.spec_from_file_location("calendar_core_server_under_test", _SERVER_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+server = _load_server()
+
+
+class _Comp(dict):
+    """The subset of an icalendar component the extractor touches."""
+
+
+def test_an_rfc7986_colour_name_is_read() -> None:
+    """`COLOR` carries a CSS3 name, which is what Google Calendar writes."""
+    assert server._event_colour(_Comp({"COLOR": "tomato"})) == "#ff6347"
+
+
+def test_a_colour_name_is_case_insensitive() -> None:
+    assert server._event_colour(_Comp({"COLOR": "SlateBlue"})) == "#6a5acd"
+
+
+def test_an_apple_hex_colour_is_read() -> None:
+    """Apple and several CalDAV servers write a hex triple instead."""
+    assert server._event_colour(_Comp({"X-APPLE-CALENDAR-COLOR": "#1E90FF"})) == "#1e90ff"
+
+
+def test_an_alpha_byte_is_dropped() -> None:
+    """`#RRGGBBAA` is common in the wild; the panel has no alpha."""
+    assert server._event_colour(_Comp({"X-APPLE-CALENDAR-COLOR": "#1e90ffcc"})) == "#1e90ff"
+
+
+def test_an_unrecognised_colour_is_absent_not_guessed() -> None:
+    """Returning "" falls back to the feed colour, which is right.
+
+    Inventing one would put a wrong colour on an event, which is worse than
+    the feed's own: the whole point is that the colour carries meaning.
+    """
+    assert server._event_colour(_Comp({"COLOR": "burnt-sienna"})) == ""
+    assert server._event_colour(_Comp({"X-APPLE-CALENDAR-COLOR": "rgb(1,2,3)"})) == ""
+
+
+def test_an_event_with_no_colour_is_absent() -> None:
+    assert server._event_colour(_Comp({})) == ""
+
+
+def test_a_named_colour_wins_over_a_hex_one() -> None:
+    """RFC 7986 is the standard field; the X- one is the fallback."""
+    comp = _Comp({"COLOR": "tomato", "X-APPLE-CALENDAR-COLOR": "#000000"})
+    assert server._event_colour(comp) == "#ff6347"
+
+
+def test_every_mapped_name_is_a_six_digit_hex() -> None:
+    """A typo in the table would ship a broken colour to a panel."""
+    for name, value in server._CSS3_COLOURS.items():
+        assert re.fullmatch(r"#[0-9a-f]{6}", value), f"{name} -> {value}"

--- a/plugins/calendar_core/tests/test_event_colours.py
+++ b/plugins/calendar_core/tests/test_event_colours.py
@@ -45,7 +45,7 @@ class _Comp(dict):
 
 
 def test_an_rfc7986_colour_name_is_read() -> None:
-    """`COLOR` carries a CSS3 name, which is what Google Calendar writes."""
+    """`COLOR` carries a CSS3 name, the form Nextcloud and Baikal write."""
     assert server._event_colour(_Comp({"COLOR": "tomato"})) == "#ff6347"
 
 
@@ -54,7 +54,7 @@ def test_a_colour_name_is_case_insensitive() -> None:
 
 
 def test_an_apple_hex_colour_is_read() -> None:
-    """Apple and several CalDAV servers write a hex triple instead."""
+    """A hex triple, as some feed bridges stamp on the event."""
     assert server._event_colour(_Comp({"X-APPLE-CALENDAR-COLOR": "#1E90FF"})) == "#1e90ff"
 
 


### PR DESCRIPTION
## What this changes

An event's own colour, where the calendar sets one, can now drive the widget colour instead of the feed's single colour.

Closes #222

## Why

A single family calendar is often colour-coded by category — work vs school vs vacation — and every one of those events reached the widget stamped with `feed_colour`, so the distinction the user maintains upstream was thrown away on the way in. The reporter's workaround was adding the same calendar many times and filtering, which they note they cannot do because colour is the only differentiator.

## What it reads

Two spellings, because producers disagree:

- **RFC 7986 `COLOR`** — a CSS3 colour *name*, which is what Google Calendar writes.
- **`X-APPLE-CALENDAR-COLOR`** — a hex triple, sometimes with an alpha byte, which is what Apple and several CalDAV servers write.

An unrecognised value yields **no** colour rather than a guess, so the event falls back to the feed's. Inventing one would put a wrong colour on an event whose whole point is that the colour carries meaning.

## Opt-in per feed

As the issue suggests ("It seems reasonable that this could be an optional thing"), and per feed rather than globally, because the two uses are opposite: one calendar categorises by colour, another wants every event to read as "work" whatever the producer set.

A palette button on each feed row toggles it. The colour is carried on *every* event and only the precedence is gated, so flipping the toggle needs no cache drop — and an event with no colour of its own always falls back, so a partly-coloured calendar stays coherent rather than going half-default.

| opt-in | event colour | result |
|---|---|---|
| on | `#ff6347` | `#ff6347` |
| on | none | feed colour |
| off | `#ff6347` | feed colour |
| off | none | feed colour |

HA-sourced feeds do not get the toggle: their events come from the HA calendar API, not an ICS body, so there is no per-event colour to read.

## Test plan

- [x] `pytest plugins/calendar_core/tests/test_event_colours.py -q` — 8 passed
- [x] `pytest -q -k "calendar or feed or ics or colour"` across `tests/`, `calendar_core`, `calendar_day` — **147 passed**, 6 skipped
- [x] `ruff check .` and `ruff format --check .` — clean

**One thing I broke and fixed, worth flagging.** My first version of the test did `sys.path.insert` + `import server`, copying the sibling plugin suites. That turned **eleven passing `calendar_day` tests red** without touching them: every plugin ships a module called `server`, so whichever suite imports first owns `sys.modules["server"]` and the other gets the wrong module. This file now loads its own `server.py` under a unique name via `importlib`, and the docstring says why so the next person copying a sibling does not reintroduce it.

That collision is latent between the existing plugin suites too — it only bites when two of them run in the same session. Not something I have touched here beyond not adding to it.