### PR TITLE
docs(devices): explain ghosting after a pushed update (#274)

### DIFF
--- a/docs/install/devices.md
+++ b/docs/install/devices.md
@@ -44,6 +44,26 @@ renderer, so two panels driven by the same renderer can differ. For TRMNL /
 1-bit panels the dither dropdown carries the full set: Floyd-Steinberg,
 Atkinson, Jarvis-Judice-Ninke, Stucki, Bayer 8×8, halftone, crosshatch, or none.
 
+### Ghosting after a pushed update
+
+A panel that repaints cleanly on its timed wake but leaves a faint ghost of
+the previous frame after a push — a webhook, a manual Send, a button action —
+is showing you the difference between the two delivery paths, not a fault.
+
+**Update delivery** on the device card defaults to *Auto*, which sends a small
+change as a partial-refresh patch on firmware that supports it. A partial
+refresh does not run the panel's full clearing waveform, so a high-contrast
+change can leave the old content faintly behind. A device that was asleep
+cannot apply a patch at all, so its next poll is served a whole frame and a
+full repaint — which is why the timed wake looks right and the pushed update
+does not.
+
+Set **Update delivery → Always full refresh** on that device. Every change
+then repaints the whole panel: slower and a visible flash, but no ghost.
+
+The setting is per device, so a panel used for high-contrast content can be
+pinned to full refresh while the rest stay on Auto.
+
 ## Compose a dashboard
 
 The page editor models a dashboard as **one page → one layout preset → one

--- a/docs/install/devices.md
+++ b/docs/install/devices.md
@@ -44,25 +44,24 @@ renderer, so two panels driven by the same renderer can differ. For TRMNL /
 1-bit panels the dither dropdown carries the full set: Floyd-Steinberg,
 Atkinson, Jarvis-Judice-Ninke, Stucki, Bayer 8×8, halftone, crosshatch, or none.
 
-### Ghosting after a pushed update
+### Update delivery
 
-A panel that repaints cleanly on its timed wake but leaves a faint ghost of
-the previous frame after a push — a webhook, a manual Send, a button action —
-is showing you the difference between the two delivery paths, not a fault.
+**Update delivery** on the device card decides how a change reaches a panel
+that is already showing the same page. *Auto*, the default, sends a small
+change (a clock tick, a toggled switch) as a partial-refresh patch on firmware
+that supports it, so the panel repaints only the changed area with no full
+flash. A change too large to patch, or a device that was asleep when the patch
+was staged, gets a whole frame and a full repaint on its next poll instead.
 
-**Update delivery** on the device card defaults to *Auto*, which sends a small
-change as a partial-refresh patch on firmware that supports it. A partial
-refresh does not run the panel's full clearing waveform, so a high-contrast
-change can leave the old content faintly behind. A device that was asleep
-cannot apply a patch at all, so its next poll is served a whole frame and a
-full repaint — which is why the timed wake looks right and the pushed update
-does not.
+*Always full refresh* turns the patch path off for that device: every change
+mints a new frame and repaints the whole panel. It is slower and flashes, but
+it is the setting to reach for when small pushed updates look incomplete or
+ghosted. Ghosting that also shows up on timed refreshes, or that follows a
+touch, has a different cause: report it against the firmware rather than
+changing this setting.
 
-Set **Update delivery → Always full refresh** on that device. Every change
-then repaints the whole panel: slower and a visible flash, but no ghost.
-
-The setting is per device, so a panel used for high-contrast content can be
-pinned to full refresh while the rest stay on Auto.
+The setting is per device, so one panel can be pinned to full refresh while
+the rest stay on Auto.
 
 ## Compose a dashboard
 


### PR DESCRIPTION
## What this changes

A **Ghosting after a pushed update** section under *Per-device settings*, connecting the symptom to the control that fixes it.

Refs #274. Docs only — no behaviour change.

## Why, and what I found

The reporter's observation is the diagnostic: *"This does not happen on normal (timed wakeup) refreshes."*

**Update delivery** defaults to *Auto*, which sends a small change as a partial-refresh patch (`_divert_to_patches_locked` in `app/push.py`). A partial refresh does not run the panel's clearing waveform, so a high-contrast change leaves the old content faintly behind. A device that was asleep cannot apply a patch at all, so its next poll is served a whole frame and a full repaint — which is exactly why the timed wake looks right and the button-triggered push does not.

`refresh_mode: "full"` disables the patch divert per device, and the control already says *"use it if updates look incomplete or ghosted"*.

**So the remedy exists and the control is honest.** What was missing is anything connecting the symptom to that control for someone who has not already found it: a search of `docs/` for "ghost" turns up only widget-design guidance about avoiding pure `#000`/`#fff`, nothing about delivery mode. Someone hitting this reaches for the tracker, which is what happened.

## What this does not do

It does not stop the ghosting. Whether *Auto* should decline to patch a high-contrast or large-area change on its own is a real question — the reporter's buttons are exactly that shape — but it is a heuristic with a cost on every push and a call for you rather than something to fold into a docs fix.

I have not closed the issue in the commit for that reason; if you would rather it stay open for the heuristic, this just makes the workaround findable in the meantime.

## Test plan

- [x] `pytest -q -k "docs or markdown or mkdocs or nav"` — 32 passed