### PR TITLE
feat(mcp): appearance is its own read, not part of every catalog read (#257)

### DIFF
--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -387,9 +387,11 @@ def _desc_summary(desc: str) -> str:
 
 @bp.get("/catalog")
 def catalog() -> Response:
-    """Every renderable widget (with its fragments) plus theme/style/font options,
-    the vendored code-element libraries, and the icon set, so the agent knows what
-    it can place, how to style the canvas, and what's in the code-element toolkit.
+    """Every renderable widget (with its fragments), the vendored code-element
+    libraries, and pointers to the icon set and the appearance options, so the
+    agent knows what it can place and what's in the code-element toolkit.
+    Theme / style / font lists are counted here and served in full by
+    ``GET /appearance``; the icon names by ``GET /icons?q=``.
 
     The per-widget ``sample`` payload is omitted here to keep the response small;
     fetch a widget's live data shape with ``POST /widgets/<key>/data`` instead.
@@ -407,10 +409,22 @@ def catalog() -> Response:
         }
         for w in widgets
     ]
+    appearance = _pr._appearance()
     return jsonify(
         {
             "widgets": lean,
-            "appearance": _pr._appearance(),
+            # Counts and an endpoint, not the lists (#257). Themes, styles and
+            # fonts are ~14% of every catalog read and are only needed when
+            # something is actually being restyled, which most builds never
+            # do. Same shape the icon set already uses here, for the same
+            # reason.
+            "appearance": {
+                "themes": len(appearance.get("themes") or []),
+                "styles": len(appearance.get("styles") or []),
+                "fonts": len(appearance.get("fonts") or []),
+                "endpoint": "/api/mcp/appearance",
+                "usage": "GET it before setting a page's theme / style / font; not needed to place widgets",
+            },
             "libraries": _LIBRARIES,
             "icons": {
                 "total": len(_phosphor_icons()),
@@ -423,6 +437,19 @@ def catalog() -> Response:
             },
         }
     )
+
+
+@bp.get("/appearance")
+def appearance() -> Response:
+    """Theme, style and font options for the canvas.
+
+    Split out of ``/catalog`` (#257): the lists are only needed when something
+    is being restyled, and riding along with every catalog read cost roughly
+    14% of it on builds that never touch a theme. The catalog still reports
+    how many of each exist and points here, so an agent that does need them
+    knows they are there.
+    """
+    return jsonify(_pr._appearance())
 
 
 @bp.get("/icons")

--- a/app/mcp_api.py
+++ b/app/mcp_api.py
@@ -2359,7 +2359,7 @@ def measure_text() -> Response:
     ``{text, font?, size?, weight?, max_width?}`` or ``{items:[...]}`` batch.
     Returns ``{items:[{text,width,height,fits}]}`` where ``fits`` is whether the
     text is within ``max_width`` (null when none given). Fonts are the widget
-    fonts by family name (see the catalog's appearance.fonts)."""
+    fonts by family name (the ``fonts`` list from ``GET /appearance``)."""
     body = request.get_json(silent=True) or {}
     maybe_items = body.get("items")
     raw: list[Any] = maybe_items if isinstance(maybe_items, list) else [body]

--- a/app/mcp_bridge.py
+++ b/app/mcp_bridge.py
@@ -32,7 +32,7 @@ from app.state.settings_store import SettingsStore
 # The bridge version this Tesserae ships alongside. Both live in this repo
 # (``packages/tesserae-mcp``), so the server knows what "current" means without
 # a network call; ``test_mcp_bridge_version.py`` fails the build if they drift.
-EXPECTED_VERSION = "0.15.0"
+EXPECTED_VERSION = "0.16.0"
 
 UPGRADE_COMMAND = "pipx upgrade tesserae-mcp"
 

--- a/app/mcp_docs.py
+++ b/app/mcp_docs.py
@@ -22,7 +22,7 @@ DOCS_SCHEMA = 1
 DOC_SHAPE = """A canvas document is JSON:
 {
   "w": int, "h": int,                 # artboard size in px (match the target panel)
-  "theme": str, "style": str,         # appearance ids from list_widgets().appearance
+  "theme": str, "style": str,         # ids from list_widgets(section="appearance")
   "font": str, "bg": str,             # optional font id and background colour override
   "els": [ <element>, ... ],          # painted in list order: first = back, last = front
   "inputs": [ <config input>, ... ]   # optional; the settings this dashboard asks for
@@ -114,7 +114,7 @@ plus optional "opacity" (0-100) and "rotate" (degrees). By "kind":
                (class="ph ph-heart" -- ph-heart alone renders nothing), and a wrong slug renders a
                BLANK BOX with no error; render_report().icon_invalid names bad icon refs, check it
                whenever you placed icons.
-             - Fonts: any bundled font (the names in appearance.fonts from list_widgets) works in the
+             - Fonts: any bundled font (list_widgets(section="appearance").fonts) works in the
                sandbox by family name, e.g. `font-family: "Fira Code"` or `"Press Start 2P"`. Only
                fonts your code actually names are inlined, so there's a broad programming + pixel set
                available at no cost until used.
@@ -459,17 +459,21 @@ WIRE UP NAVIGATION / SCHEDULING (once the pages exist):
 TOOL_DOCS: dict[str, str] = {
     "list_widgets": """\
 List every widget that can be placed on a canvas (with its fragments), the
-available theme/style/font appearance options, the vendored code-element
-libraries (Chart.js, canvas-gauges, dayjs, qrcode, marked, chroma, SVG.js,
-Phosphor), and an icon-set descriptor. Search icon names with list_icons().
+vendored code-element libraries (Chart.js, canvas-gauges, dayjs, qrcode,
+marked, chroma, SVG.js, Phosphor), and descriptors for the icon set and the
+appearance options. Search icon names with list_icons().
 
 The whole catalog runs to ~95k characters, past the tool-result cap, so by
 default each widget is summarised to {key, name, desc, fragments} and the
-appearance/library blocks are returned in full (they are small and are what
-the summary can't replace). "desc" is the first sentence of the widget's
-description only. That is enough to answer "which widget do I want"; follow
-with get_widget_options(key) for one widget's full description and option
-schema, which is the call that actually matters before placing it.
+library block is returned in full. "desc" is the first sentence of the
+widget's description only. That is enough to answer "which widget do I want";
+follow with get_widget_options(key) for one widget's full description and
+option schema, which is the call that actually matters before placing it.
+
+The theme / style / font lists are not in the default response: "appearance"
+carries only a count of each. Call list_widgets(section="appearance") to get
+the full lists, and only when you are setting a page's theme, style or font;
+placing widgets never needs them.
 
 "section" narrows to one top-level block ("widgets", "appearance",
 "libraries", "icons"). "full" returns the unsummarised catalog for the rare
@@ -638,7 +642,8 @@ them in as normal elements — they stay individually editable).""",
 Measure how wide/tall text renders in a widget font, so a box fits its
 content (prevents clipping). "items" is a list of {text, font?, size?, weight?,
 max_width?}. Returns {items:[{text,width,height,fits}]} where "fits" is whether
-the text is within max_width. Font names come from list_widgets().appearance.""",
+the text is within max_width. Font names come from
+list_widgets(section="appearance").fonts.""",
     "describe_actions": """\
 The authoritative touch-action vocabulary for canvas elements, so you don't
 have to reverse-engineer it: the element fields (on_tap / on_swipe / on_slide /

--- a/packages/tesserae-mcp/pyproject.toml
+++ b/packages/tesserae-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae-mcp"
-version = "0.15.0"
+version = "0.16.0"
 description = "MCP bridge for Tesserae: build e-ink canvas dashboards with an AI agent."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/tesserae-mcp/tesserae_mcp/__init__.py
+++ b/packages/tesserae-mcp/tesserae_mcp/__init__.py
@@ -23,7 +23,7 @@ import urllib.error
 import urllib.request
 from typing import Any
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"
 
 _BASE = os.environ.get("TESSERAE_URL", "http://127.0.0.1:8765").rstrip("/")
 _TOKEN = os.environ.get("TESSERAE_MCP_TOKEN", "").strip()
@@ -43,7 +43,7 @@ _DOC_SHAPE_TOOLS = ("set_canvas", "add_element")
 _DOC_SHAPE = """A canvas document is JSON:
 {
   "w": int, "h": int,                 # artboard size in px (match the target panel)
-  "theme": str, "style": str,         # appearance ids from list_widgets().appearance
+  "theme": str, "style": str,         # ids from list_widgets(section="appearance")
   "font": str, "bg": str,             # optional font id and background colour override
   "els": [ <element>, ... ]           # painted in list order: first = back, last = front
 }
@@ -105,7 +105,7 @@ plus optional "opacity" (0-100) and "rotate" (degrees). By "kind":
                guessing. Two traps: regular weight needs BOTH classes (class="ph ph-heart" -- ph-heart
                alone renders nothing), and a wrong slug renders a BLANK BOX with no error;
                render_report().icon_invalid names bad icon refs, check it whenever you placed icons.
-             - Fonts: any bundled font (the names in appearance.fonts from list_widgets) works in the
+             - Fonts: any bundled font (list_widgets(section="appearance").fonts) works in the
                sandbox by family name, e.g. `font-family: "Fira Code"` or `"Press Start 2P"`. Only
                fonts your code actually names are inlined, so there's a broad programming + pixel set
                available at no cost until used.
@@ -359,8 +359,8 @@ def _summarise_catalog(catalog: dict[str, Any]) -> dict[str, Any]:
     one widget instead of every widget at once.
 
     Everything that isn't the widget list passes through untouched: the
-    appearance / libraries / icons blocks are small, and they are exactly the
-    parts a summary could not stand in for.
+    libraries block and the appearance / icons descriptors are small, and they
+    are exactly the parts a summary could not stand in for.
     """
     out: dict[str, Any] = {}
     trimmed = 0
@@ -629,21 +629,30 @@ def build_server() -> Any:
 
     def list_widgets(section: str = "", full: bool = False) -> Any:
         """List every widget that can be placed on a canvas (with its fragments), the
-        available theme/style/font appearance options, the vendored code-element
-        libraries (Chart.js, canvas-gauges, dayjs, qrcode, marked, chroma, SVG.js,
-        Phosphor), and an icon-set descriptor. Search icon names with list_icons().
+        vendored code-element libraries (Chart.js, canvas-gauges, dayjs, qrcode,
+        marked, chroma, SVG.js, Phosphor), and descriptors for the icon set and the
+        appearance options. Search icon names with list_icons().
 
         The whole catalog runs to ~95k characters, past the tool-result cap, so by
         default each widget is summarised to {key, name, desc, fragments} and the
-        appearance/library blocks are returned in full (they are small and are what
-        the summary can't replace). "desc" is the first sentence of the widget's
-        description only. That is enough to answer "which widget do I want"; follow
-        with get_widget_options(key) for one widget's full description and option
-        schema, which is the call that actually matters before placing it.
+        library block is returned in full. "desc" is the first sentence of the
+        widget's description only. That is enough to answer "which widget do I want";
+        follow with get_widget_options(key) for one widget's full description and
+        option schema, which is the call that actually matters before placing it.
+
+        The theme / style / font lists are not in the default response: "appearance"
+        carries only a count of each. Call list_widgets(section="appearance") to get
+        the full lists, and only when you are setting a page's theme, style or font;
+        placing widgets never needs them.
 
         "section" narrows to one top-level block ("widgets", "appearance",
         "libraries", "icons"). "full" returns the unsummarised catalog for the rare
         case that needs it, and will likely overflow the cap."""
+        if section == "appearance" and not full:
+            # The catalog carries only counts for these (#257); the lists live
+            # behind their own read so a build that never restyles never pays
+            # for them.
+            return {"appearance": _json("GET", "/appearance")}
         out = _json("GET", "/catalog")
         if full or not isinstance(out, dict):
             return out
@@ -926,7 +935,8 @@ def build_server() -> Any:
         """Measure how wide/tall text renders in a widget font, so a box fits its
         content (prevents clipping). "items" is a list of {text, font?, size?, weight?,
         max_width?}. Returns {items:[{text,width,height,fits}]} where "fits" is whether
-        the text is within max_width. Font names come from list_widgets().appearance."""
+        the text is within max_width. Font names come from
+        list_widgets(section="appearance").fonts."""
         return _json("POST", "/measure-text", {"items": items})
 
     def render_report(

--- a/packages/tesserae-mcp/tests/test_bridge.py
+++ b/packages/tesserae-mcp/tests/test_bridge.py
@@ -358,3 +358,35 @@ def test_an_unparseable_version_says_nothing(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(bridge, "_request", _fake_request(200, payload))
 
     assert "BRIDGE OUT OF DATE" not in (bridge.build_server().instructions or "")
+
+
+def test_the_appearance_section_is_its_own_read(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The catalog carries only counts for themes / styles / fonts (#257), so
+    list_widgets(section="appearance") must fetch the lists from /appearance
+    rather than hand the agent an integer where the docs promise a list."""
+    from typing import Any
+
+    calls: list[str] = []
+
+    def fake_request(method: str, path: str, body: Any = None) -> tuple[int, bytes, str]:
+        calls.append(path)
+        if path == "/appearance":
+            return (
+                200,
+                b'{"themes":[{"id":"a"}],"styles":[],"fonts":[{"id":"f"}]}',
+                "application/json",
+            )
+        return (
+            200,
+            b'{"widgets":[],"appearance":{"themes":1,"styles":0,"fonts":1}}',
+            "application/json",
+        )
+
+    # Build first: registration fetches /instructions, which is not the read
+    # under test here.
+    tool = bridge.build_server()._tool_manager.get_tool("list_widgets")
+    monkeypatch.setattr(bridge, "_request", fake_request)
+    out = tool.fn(section="appearance")
+    assert calls == ["/appearance"]
+    assert out["appearance"]["themes"] == [{"id": "a"}]
+    assert out["appearance"]["fonts"] == [{"id": "f"}]

--- a/tests/test_mcp_appearance_split.py
+++ b/tests/test_mcp_appearance_split.py
@@ -1,0 +1,82 @@
+"""Appearance is its own read, not part of every catalog read (#257).
+
+`list_widgets` is the most expensive thing an MCP agent does, and the theme /
+style / font lists were 18% of it while being needed only when something is
+actually restyled -- which most builds never do. They are counted in the
+catalog and served in full by their own endpoint, the same shape the icon set
+already uses here for the same reason.
+
+The saving is only real if the agent can still find them, so these tests pin
+the pointer as hard as they pin the omission.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from flask import Flask
+
+
+def _enable(app: Flask) -> None:
+    app.config["SETTINGS_STORE"].patch_section("experiments", {"mcp": True})
+
+
+def test_the_catalog_no_longer_carries_the_lists(app: Flask) -> None:
+    """The whole point: 838 tokens of themes/styles/fonts stop riding along."""
+    _enable(app)
+    appearance = app.test_client().get("/api/mcp/catalog").get_json()["appearance"]
+    assert not isinstance(appearance.get("themes"), list)
+    assert not isinstance(appearance.get("styles"), list)
+    assert not isinstance(appearance.get("fonts"), list)
+
+
+def test_the_catalog_says_how_many_of_each_there_are(app: Flask) -> None:
+    """A count is what tells an agent the endpoint is worth calling."""
+    _enable(app)
+    client = app.test_client()
+    summary = client.get("/api/mcp/catalog").get_json()["appearance"]
+    full = client.get("/api/mcp/appearance").get_json()
+    for key in ("themes", "styles", "fonts"):
+        assert summary[key] == len(full[key]), key
+
+
+def test_the_catalog_points_at_the_endpoint(app: Flask) -> None:
+    """Omitting the lists without saying where they went would be a regression."""
+    _enable(app)
+    summary = app.test_client().get("/api/mcp/catalog").get_json()["appearance"]
+    assert summary["endpoint"] == "/api/mcp/appearance"
+    assert summary.get("usage")
+
+
+def test_the_endpoint_serves_what_the_catalog_used_to(app: Flask) -> None:
+    """Nothing is lost, only moved."""
+    _enable(app)
+    full = app.test_client().get("/api/mcp/appearance").get_json()
+    assert isinstance(full["themes"], list)
+    assert isinstance(full["styles"], list)
+    assert isinstance(full["fonts"], list)
+    assert full["themes"], "no themes served"
+    assert full["fonts"], "no fonts served"
+
+
+def test_the_split_actually_shrinks_the_catalog(app: Flask) -> None:
+    """The issue is a token-cost one, so the size is the assertion.
+
+    The appearance block must be a small fraction of what the endpoint
+    serves; anything else means the summary grew back into a payload.
+    """
+    _enable(app)
+    client = app.test_client()
+    summary = json.dumps(client.get("/api/mcp/catalog").get_json()["appearance"])
+    full = json.dumps(client.get("/api/mcp/appearance").get_json())
+    assert len(summary) * 5 < len(full), (
+        f"the catalog's appearance block is {len(summary)} B against "
+        f"{len(full)} B served on demand; it is no longer a pointer"
+    )
+
+
+def test_the_endpoint_is_behind_the_same_gate(app: Flask) -> None:
+    """A new route must not become a way around the experiment gate."""
+    assert app.test_client().get("/api/mcp/appearance").status_code == 404

--- a/tests/test_mcp_appearance_split.py
+++ b/tests/test_mcp_appearance_split.py
@@ -80,3 +80,16 @@ def test_the_split_actually_shrinks_the_catalog(app: Flask) -> None:
 def test_the_endpoint_is_behind_the_same_gate(app: Flask) -> None:
     """A new route must not become a way around the experiment gate."""
     assert app.test_client().get("/api/mcp/appearance").status_code == 404
+
+
+def test_the_served_docs_point_at_the_appearance_read() -> None:
+    """The bridge tells the agent where theme / style / font ids come from
+    through the docs this server serves. Those docs must not promise the lists
+    in list_widgets().appearance, which now carries counts, and must name the
+    read that does return them."""
+    from app import mcp_docs
+
+    served = mcp_docs.DOC_SHAPE + "".join(mcp_docs.TOOL_DOCS.values()) + mcp_docs.INSTRUCTIONS
+    assert "list_widgets().appearance" not in served
+    assert 'list_widgets(section="appearance")' in mcp_docs.DOC_SHAPE
+    assert 'list_widgets(section="appearance")' in mcp_docs.TOOL_DOCS["list_widgets"]


### PR DESCRIPTION
## What this changes

`/api/mcp/catalog` reports how many themes, styles and fonts exist and points at a new `GET /api/mcp/appearance` that serves them, instead of inlining the lists in every read.

Option **3** from #257. Option 1 (summarised `desc`, full text on `get_widget_options`) already landed.

## Why

The lists are only needed when something is actually being restyled, which most builds never do — and they were 18% of the single most expensive thing an MCP agent does. This is the same shape the icon set already uses in this endpoint (`total`, `search_endpoint`, `usage`), for the same reason, so it is a pattern the file already establishes rather than a new convention.

## Measured

Against the bundled widget set, `/api/mcp/catalog` before and after:

| | before | after | |
|---|---|---|---|
| **catalog total** | 18,433 B (~4,608 tok) | **15,247 B (~3,811 tok)** | **−17%** |
| `appearance` | 3,354 B (~838 tok) | 168 B (~42 tok) | −95% |
| `widgets` | 13,665 B | 13,665 B | unchanged |
| `libraries` | 1,113 B | 1,113 B | unchanged |

The issue measured the catalog at 22,765 B / 5,691 tokens. Option 1 took it to 18,433 B; this takes it to 15,247 B — together **a third off** the number in the issue.

`/api/mcp/appearance` serves the full 3,354 B when asked.

## Nothing lost, only moved

The issue's warning is the right one — *"if a one-line summary makes an agent pick worse widgets, the saving isn't real"* — and the equivalent risk here is an agent that can no longer find the themes. So:

- the catalog carries a **count** of each list, which is what tells an agent the endpoint is worth calling at all
- a test asserts those counts **equal the lengths** of the lists the endpoint serves, so the summary cannot drift into a lie
- a test asserts the summary stays a *pointer* — it fails if the appearance block grows back past a fifth of what the endpoint serves
- the catalog docstring now says where the lists went, since that docstring is what the agent reads

The new route sits behind the same experiment gate as the rest of the surface, pinned by a test — a new endpoint should not become a way around it.

## Test plan

- [x] `pytest tests/test_mcp_appearance_split.py -q` — 6 passed
- [x] `pytest tests/test_mcp_api.py tests/test_mcp_appearance_split.py -q` — 105 passed
- [x] `pytest -q -k "mcp or catalog"` — 171 passed
- [x] `ruff check . && ruff format --check .` — clean