### PR TITLE
feat(hardware): add Pimoroni Inky Frame 7.3" SKUs, both panel revisions

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -101,6 +101,8 @@ Runs the [Tesserae-native firmware](https://github.com/dmellok/tesserae-device-f
 
 | SKU | Panel | Gamut | Protocol / Renderer | Kind id |
 |---|---|---|---|---|
+| [Pimoroni Inky Frame 7.3" (Spectra 6)](https://shop.pimoroni.com/products/inky-frame-7-3) | 800×480 | `spectra_6` | `pico_bin_client` (inherit) | `pimoroni_inky_frame_73` |
+| [Pimoroni Inky Frame 7.3" (7-colour ACeP)](https://shop.pimoroni.com/products/inky-frame-7-3) | 800×480 | `inky_7colour` | `pico_bin_client` (inherit) | `pimoroni_inky_frame_73_acep` |
 | [Pimoroni Inky Impression 4"](https://shop.pimoroni.com/products/inky-impression) | 600×400 | `spectra_6` | `pi_bin_client` (inherit) | `pimoroni_inky_4` |
 | [Pimoroni Inky Impression 4" (ACeP, 640x400, legacy)](https://shop.pimoroni.com/products/inky-impression) | 640×400 | `acep_7colour` | `pi_bin_client` (inherit) | `pimoroni_inky_4_acep` |
 

--- a/hardware/pimoroni/inky_frame_73.json
+++ b/hardware/pimoroni/inky_frame_73.json
@@ -1,0 +1,22 @@
+{
+  "tesserae_compat": "1.x",
+  "id": "pimoroni_inky_frame_73",
+  "name": "Pimoroni Inky Frame 7.3\" (Spectra 6)",
+  "vendor": "Pimoroni",
+  "url": "https://shop.pimoroni.com/products/inky-frame-7-3",
+  "icon": "monitor",
+  "description": "7.3 inch 800x480 Inky Frame (Pico 2 W aboard) with the Spectra 6 E673 panel shipped from September 2025. Driven by the tesserae-inkyframe Pico SDK firmware (built with PANEL_VARIANT=PANEL_SPECTRA) over the REST device API. Owners of the earlier 7-colour ACeP revision should use pimoroni_inky_frame_73_acep.",
+  "protocol": "pico_bin_client",
+  "panel": {
+    "w": 800,
+    "h": 480,
+    "orientation": "landscape",
+    "name": "Inky Frame 7.3\" (Spectra 6, 800x480)",
+    "gamut": "spectra_6",
+    "native_w": 800,
+    "native_h": 480
+  },
+  "refresh_floor_s": 30,
+  "image_format": "bin",
+  "notes_md": "Community firmware by [partridgeworks/tesserae.inkyframe](https://github.com/partridgeworks/tesserae.inkyframe). Untested on hardware at the time of writing (the firmware author owns the ACeP revision); the panel driver follows Pimoroni's inky_e673 sequence."
+}

--- a/hardware/pimoroni/inky_frame_73_acep.json
+++ b/hardware/pimoroni/inky_frame_73_acep.json
@@ -1,0 +1,22 @@
+{
+  "tesserae_compat": "1.x",
+  "id": "pimoroni_inky_frame_73_acep",
+  "name": "Pimoroni Inky Frame 7.3\" (7-colour ACeP)",
+  "vendor": "Pimoroni",
+  "url": "https://shop.pimoroni.com/products/inky-frame-7-3",
+  "icon": "monitor",
+  "description": "7.3 inch 800x480 Inky Frame (Pico W / Pico 2 W aboard) with the original 7-colour ACeP panel (AC073TC1A), the revision sold before September 2025. Driven by the tesserae-inkyframe Pico SDK firmware over the REST device API: the pico_bin renderer's landscape 4-bpp buffer streams straight into the panel. Units shipped from September 2025 have a Spectra 6 panel; use pimoroni_inky_frame_73 for those.",
+  "protocol": "pico_bin_client",
+  "panel": {
+    "w": 800,
+    "h": 480,
+    "orientation": "landscape",
+    "name": "Inky Frame 7.3\" (7-colour ACeP, 800x480)",
+    "gamut": "inky_7colour",
+    "native_w": 800,
+    "native_h": 480
+  },
+  "refresh_floor_s": 30,
+  "image_format": "bin",
+  "notes_md": "Community firmware by [partridgeworks/tesserae.inkyframe](https://github.com/partridgeworks/tesserae.inkyframe), confirmed on real hardware by the author. Full refresh takes about 30 s. The firmware announces this kind on `/discover`; if the entry is missing it falls back to the stock `pico_bin_client` kind, whose 1600x1200 default panel produces frames the firmware refuses, so install this file before clicking Register."
+}


### PR DESCRIPTION
## What this changes

Community contribution from https://github.com/partridgeworks, as the server-side half of tesserae.inkyframe, an open-source Tesserae client firmware for the Pimoroni Inky Frame 7.3":

  https://github.com/partridgeworks/tesserae.inkyframe

## Why

The firmware is C against the Raspberry Pi Pico SDK and runs the frame as a battery-powered pico_bin_client thin client: an RTC alarm wakes the board, it joins Wi-Fi, does an ETag-conditional GET /frame, streams the 4-bpp buffer Tesserae packed straight to the glass with no decode, quantise or rotate on device, reports battery and RSSI to /status, then drops VSYS and sits at about 20 uA until the next refresh. The five front buttons raise Tesserae button events, with their LEDs as the linger-window feedback.

Because every frame is packed server-side, the panel is only correct if the server knows its real geometry. Without a kind of its own the firmware's /discover announcement resolves to nothing and it falls back to the stock pico_bin_client kind, whose 1600x1200 default panel yields frames an 800x480 device can only refuse. Hence a SKU, not a preset.

Two SKUs because Pimoroni shipped the 7.3" on identical pins with two different panels: the original 7-colour ACeP (AC073TC1A, inky_7colour) sold before September 2025, and the Spectra 6 (E673, spectra_6) from September 2025 on. They differ only in gamut and in the panel command sequence the firmware uses, so the operator picks the matching kind and flashes the matching build. The ACeP entry is confirmed on the author's own hardware; the Spectra 6 entry is untested, and its notes_md says so.


## Notes

There is an issue to be aware of for the ACeP panel, reported separately in the pull request: the existing palette profiles permute inky_7colour frames, because PaletteProfile.as_tuples() emits the Spectra 6 slot order (black, white, yellow, red, blue, green) while the inky_7colour gamut's nibble LUT runs black, white, green, blue, red, yellow. Nothing in this diff depends on that, and the fix belongs in the palette-profile code rather than here.
