### PR TITLE
feat(hardware): add reMarkable 2, reMarkable 1 and Paper Pro catalog entries

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -115,6 +115,16 @@ Open-hardware e-paper picture frames (ESP32-C6, NiMH cells) that run the [Tesser
 | [Pimoroni Inky Impression 4"](https://shop.pimoroni.com/products/inky-impression) | 600×400 | `spectra_6` | `pi_bin_client` (inherit) | `pimoroni_inky_4` |
 | [Pimoroni Inky Impression 4" (ACeP, 640x400, legacy)](https://shop.pimoroni.com/products/inky-impression) | 640×400 | `acep_7colour` | `pi_bin_client` (inherit) | `pimoroni_inky_4_acep` |
 
+### [reMarkable](https://remarkable.com/)
+
+E-ink writing tablets running the [tesserae.remarkable](https://github.com/partridgeworks/tesserae.remarkable) client, an AppLoad app that lives inside the tablet's own interface (Developer Mode plus the XOVI/AppLoad runtime required). It speaks the v1 REST device API, paints the server-dithered frame through the tablet's display stack, and deep-sleeps between polls on an RTC alarm. The reMarkable 2 is confirmed on hardware; the reMarkable 1 and Paper Pro entries are built but not yet confirmed.
+
+| SKU | Panel | Gamut | Protocol / Renderer | Kind id |
+|---|---|---|---|---|
+| [reMarkable Paper Pro](https://remarkable.com/products/remarkable-paper/pro) | 1620×2160 portrait | `rgb24` | `esp32_client` <br> `circuitpython_png` | `remarkable_paper_pro` |
+| [reMarkable 1](https://remarkable.com) | 1404×1872 portrait | `gray_16` | `esp32_client` <br> `esp32_gray_bin` | `remarkable_1` |
+| [reMarkable 2](https://remarkable.com/products/remarkable-2) | 1404×1872 portrait | `gray_16` | `esp32_client` <br> `esp32_gray_bin` | `remarkable_2` |
+
 ### [TRMNL](https://usetrmnl.com/)
 
 | SKU | Panel | Gamut | Protocol / Renderer | Kind id |

--- a/hardware/remarkable/paper_pro.json
+++ b/hardware/remarkable/paper_pro.json
@@ -1,0 +1,25 @@
+{
+  "tesserae_compat": "1.x",
+  "id": "remarkable_paper_pro",
+  "name": "reMarkable Paper Pro",
+  "vendor": "reMarkable",
+  "url": "https://remarkable.com/products/remarkable-paper/pro",
+  "icon": "device-tablet",
+  "description": "11.8 inch Canvas Color e-paper tablet (E Ink Gallery 3 class), 1620x2160 portrait, 229 ppi, colour, with a front light. Runs the tesserae-remarkable AppLoad app (https://github.com/partridgeworks/tesserae.remarkable), which speaks the v1 REST device API and paints a full-colour PNG (circuitpython_png with the rgb24 gamut, no server-side quantisation) through the tablet's own colour pipeline.",
+  "protocol": "esp32_client",
+  "renderers": [
+    "circuitpython_png"
+  ],
+  "panel": {
+    "w": 1620,
+    "h": 2160,
+    "orientation": "portrait",
+    "name": "11.8 inch Canvas Color (1620x2160)",
+    "gamut": "rgb24",
+    "native_w": 1620,
+    "native_h": 2160
+  },
+  "refresh_floor_s": 60,
+  "image_format": "png",
+  "notes_md": "Client app and install guide: https://github.com/partridgeworks/tesserae.remarkable. Needs Developer Mode plus the XOVI/AppLoad runtime. The panel reproduces a limited, muted colour set, so dashboards with strong flat colours read best; the client can optionally dither to a six-colour palette on the device. Not yet confirmed on hardware by the app author (the reMarkable 2 is). Pairs by zero-touch discover (Wi-Fi MAC) or a 6-digit code typed into the app's Settings."
+}

--- a/hardware/remarkable/remarkable_1.json
+++ b/hardware/remarkable/remarkable_1.json
@@ -1,0 +1,25 @@
+{
+  "tesserae_compat": "1.x",
+  "id": "remarkable_1",
+  "name": "reMarkable 1",
+  "vendor": "reMarkable",
+  "url": "https://remarkable.com",
+  "icon": "device-tablet",
+  "description": "10.3 inch monochrome E Ink Carta tablet, 1404x1872 portrait, 226 ppi, 16-level greyscale, three physical buttons, no front light. Runs the tesserae-remarkable AppLoad app (https://github.com/partridgeworks/tesserae.remarkable) over the v1 REST device API and paints the 4-bpp 16-grey buffer from esp32_gray_bin, dithered server-side.",
+  "protocol": "esp32_client",
+  "renderers": [
+    "esp32_gray_bin"
+  ],
+  "panel": {
+    "w": 1404,
+    "h": 1872,
+    "orientation": "portrait",
+    "name": "10.3 inch monochrome E Ink (1404x1872, 16 greys)",
+    "gamut": "gray_16",
+    "native_w": 1404,
+    "native_h": 1872
+  },
+  "refresh_floor_s": 30,
+  "image_format": "bin",
+  "notes_md": "Client app and install guide: https://github.com/partridgeworks/tesserae.remarkable. Same panel and wire format as the reMarkable 2 entry (1314144 bytes, high nibble = left pixel, 0x0 black .. 0xF white). Not yet confirmed on hardware by the app author; the app installs on it through the same AppLoad runtime. The physical buttons are not reported to Tesserae yet."
+}

--- a/hardware/remarkable/remarkable_2.json
+++ b/hardware/remarkable/remarkable_2.json
@@ -1,0 +1,25 @@
+{
+  "tesserae_compat": "1.x",
+  "id": "remarkable_2",
+  "name": "reMarkable 2",
+  "vendor": "reMarkable",
+  "url": "https://remarkable.com/products/remarkable-2",
+  "icon": "device-tablet",
+  "description": "10.3 inch monochrome E Ink Carta tablet, 1404x1872 portrait, 226 ppi, 16-level greyscale, no front light. Runs the tesserae-remarkable AppLoad app (https://github.com/partridgeworks/tesserae.remarkable), which speaks the v1 REST device API and paints the 4-bpp 16-grey buffer from esp32_gray_bin, dithered server-side, through the tablet's own display stack. The tablet deep-sleeps between polls and wakes on its RTC.",
+  "protocol": "esp32_client",
+  "renderers": [
+    "esp32_gray_bin"
+  ],
+  "panel": {
+    "w": 1404,
+    "h": 1872,
+    "orientation": "portrait",
+    "name": "10.3 inch monochrome E Ink (1404x1872, 16 greys)",
+    "gamut": "gray_16",
+    "native_w": 1404,
+    "native_h": 1872
+  },
+  "refresh_floor_s": 30,
+  "image_format": "bin",
+  "notes_md": "Client app and install guide: https://github.com/partridgeworks/tesserae.remarkable. Needs Developer Mode plus the XOVI/AppLoad runtime on the tablet. Wire format is exactly 1314144 bytes (1404*1872/2), row-major from the top-left of the portrait panel, high nibble = left pixel, 0x0 = black .. 0xF = white; the client unpacks it to an 8-bit grey image. Pick the dither on the device card: Floyd-Steinberg suits photos, none suits flat UI. Pairs by zero-touch discover (Wi-Fi MAC) or a 6-digit code typed into the app's Settings. Advertises `can_stay_awake` only while charging, so `always_on` is offered when it is honest."
+}

--- a/scripts/gen_compatibility.py
+++ b/scripts/gen_compatibility.py
@@ -35,6 +35,7 @@ VENDOR_ORDER: list[tuple[str, str]] = [
     ("m5stack", "M5Stack"),
     ("paperlesspaper", "paperlesspaper"),
     ("pimoroni", "Pimoroni"),
+    ("remarkable", "reMarkable"),
     ("trmnl", "TRMNL"),
     ("waveshare", "Waveshare"),
     ("xteink", "Xteink"),
@@ -64,6 +65,7 @@ VENDOR_URL: dict[str, str] = {
     "m5stack": "https://m5stack.com/",
     "paperlesspaper": "https://paperlesspaper.de/en",
     "pimoroni": "https://shop.pimoroni.com/",
+    "remarkable": "https://remarkable.com/",
     "trmnl": "https://usetrmnl.com/",
     "waveshare": "https://www.waveshare.com/",
     "xteink": "https://www.xteink.com/",
@@ -101,6 +103,16 @@ VENDOR_INTRO: dict[str, str] = {
         "up the flash first if you may want the vendor service back. The "
         "OpenPaper 7 is on the bench; the OpenPaper L build has not met its "
         "hardware yet."
+    ),
+    "remarkable": (
+        "E-ink writing tablets running the "
+        "[tesserae.remarkable](https://github.com/partridgeworks/tesserae.remarkable) "
+        "client, an AppLoad app that lives inside the tablet's own interface "
+        "(Developer Mode plus the XOVI/AppLoad runtime required). It speaks the "
+        "v1 REST device API, paints the server-dithered frame through the "
+        "tablet's display stack, and deep-sleeps between polls on an RTC "
+        "alarm. The reMarkable 2 is confirmed on hardware; the reMarkable 1 "
+        "and Paper Pro entries are built but not yet confirmed."
     ),
     "xteink": (
         "E-readers rather than dedicated dashboard panels. These run "


### PR DESCRIPTION
## What this changes

Community contribution from https://github.com/partridgeworks, as the server-side half of **tesserae.remarkable**, an open-source Tesserae client for reMarkable tablets:

  https://github.com/partridgeworks/tesserae.remarkable

Adds `hardware/remarkable/remarkable_2.json`, `remarkable_1.json` and `paper_pro.json`, registers the vendor in `scripts/gen_compatibility.py`, and regenerates `docs/compatibility.md` (the only change in the generated file is the new reMarkable section).

## How the hardware is supported

The client is an AppLoad app (Go backend plus QML frontend) that runs inside the tablet's own interface; it needs Developer Mode and the XOVI/AppLoad runtime. It pairs through the v1 REST discover flow (MAC auto-claim, or a 6-digit code), does an ETag-conditional `GET /frame`, reports battery, RSSI, IP and MAC on `/status`, and honours `next_poll_s` and `wake_at`: after each refresh it arms the tablet's RTC alarm and suspends via `systemctl`, then wakes, reconnects Wi-Fi and polls again. It advertises `can_stay_awake` only while charging, so `always_on` is only offered when it is honest.

The tablet cannot drive its panel directly: the app hands an image to the reMarkable display stack, which quantises it. So the useful wire format is one the tablet shows well without its own dither pass:

- **reMarkable 1 and 2** (1404x1872 portrait, 16-level greyscale): `esp32_client` protocol with the `esp32_gray_bin` renderer override, the same 4-bpp buffer the Seeed reTerminal E1003 takes on the same glass class, dithered server-side with the algorithm chosen on the device card.
- **reMarkable Paper Pro** (1620x2160 portrait, colour): `esp32_client` with `circuitpython_png` and the `rgb24` gamut, so a plain 24-bit PNG reaches the tablet's own colour pipeline.

Without a kind of its own the app falls back to the stock `esp32_client` kind and converts its Spectra 6 buffer to grey, then announces the real kind on every wake so the server heals the instance once the entry is installed. Hence a SKU per model.

## Hardware status

- reMarkable 2: confirmed on hardware (OS 3.27.3.0, Tesserae 0.392.0): pairing, 16-grey frames, 304 on unchanged content, and the suspend/RTC-wake loop.
- reMarkable 1 and Paper Pro: built from the same code paths, not yet confirmed; their `notes_md` say so.

Each entry's `notes_md` links to the client and its install guide. `tests/test_hardware_catalog.py` passes and the three files validate against `schema/hardware.schema.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
