### PR TITLE
fix(tests): close HTTPError response bodies so Python 3.14 doesn't warn

### DIFF
--- a/app/caldav_write.py
+++ b/app/caldav_write.py
@@ -19,6 +19,8 @@ and a single PUT is the whole of it.
 
 from __future__ import annotations
 
+import contextlib
+
 import logging
 import urllib.error
 import urllib.parse
@@ -113,6 +115,8 @@ def put_event(
         with opener.open(request, timeout=timeout) as resp:
             status = getattr(resp, "status", 0) or resp.getcode()
     except urllib.error.HTTPError as err:
+        with contextlib.suppress(Exception):
+            err.close()
         if err.code == 401:
             raise CalDavWriteError("The calendar rejected the credentials on this feed.") from err
         if err.code == 403:

--- a/app/caldav_write.py
+++ b/app/caldav_write.py
@@ -20,7 +20,6 @@ and a single PUT is the whole of it.
 from __future__ import annotations
 
 import contextlib
-
 import logging
 import urllib.error
 import urllib.parse

--- a/app/fal_backgrounds.py
+++ b/app/fal_backgrounds.py
@@ -20,6 +20,7 @@ widget's key first, then an app-level setting, then ``FAL_KEY`` in the env.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import io
 import os
@@ -235,7 +236,11 @@ def generate(
     try:
         payload = _fal_request(model, body, api_key)
     except urllib.error.HTTPError as err:
-        detail = err.read().decode("utf-8", "replace")[:200].strip()
+        try:
+            detail = err.read().decode("utf-8", "replace")[:200].strip()
+        finally:
+            with contextlib.suppress(Exception):
+                err.close()
         raise FalError(f"fal.ai returned {err.code}: {detail}") from err
     except urllib.error.URLError as err:
         raise FalError(f"cannot reach fal.ai: {err.reason}") from err

--- a/app/relay_client.py
+++ b/app/relay_client.py
@@ -14,6 +14,7 @@ mypy --strict applies to this module, see pyproject.toml.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import urllib.error
 import urllib.request
@@ -79,6 +80,8 @@ def _call(
             return int(resp.status), {k: v for k, v in resp.headers.items()}, resp.read()
     except urllib.error.HTTPError as exc:
         body = exc.read()
+        with contextlib.suppress(Exception):
+            exc.close()
         code: str | None = None
         message: str | None = None
         try:

--- a/app/screenshots.py
+++ b/app/screenshots.py
@@ -24,6 +24,7 @@ are overridable with ``--url`` / ``--token``.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import sys
@@ -67,7 +68,11 @@ def _render(
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             return bytes(resp.read())
     except urllib.error.HTTPError as err:
-        detail = err.read().decode("utf-8", "replace").strip()
+        try:
+            detail = err.read().decode("utf-8", "replace").strip()
+        finally:
+            with contextlib.suppress(Exception):
+                err.close()
         raise SystemExit(f"render failed ({err.code}) for {widget_id!r}: {detail}") from err
     except urllib.error.URLError as err:
         raise SystemExit(

--- a/app/updater.py
+++ b/app/updater.py
@@ -216,6 +216,8 @@ class Updater:
                         html = f"https://github.com/{repo}/releases/tag/{tag}"
         except urllib.error.HTTPError as err:
             err_msg = f"HTTP {err.code} {err.reason}"
+            with contextlib.suppress(Exception):
+                err.close()
         except (urllib.error.URLError, json.JSONDecodeError, OSError) as err:
             err_msg = str(err)
 

--- a/plugins/calendar_core/server.py
+++ b/plugins/calendar_core/server.py
@@ -270,6 +270,9 @@ def _http_get(
             blob = decode_content_encoding(blob, str(resp.headers.get("Content-Encoding", "")))
         return blob
     except Exception as err:
+        if isinstance(err, urllib.error.HTTPError):
+            with contextlib.suppress(Exception):
+                err.close()
         if error_out is not None:
             error_out.append(_describe_fetch_error(err))
         return None
@@ -612,6 +615,9 @@ def _fetch_ha_events(
     try:
         data = core.request_json(path, timeout=HTTP_TIMEOUT_S)
     except Exception as err:
+        if isinstance(err, urllib.error.HTTPError):
+            with contextlib.suppress(Exception):
+                err.close()
         # A RuntimeError is ha_core's own "not configured / token
         # unreadable" guidance; keep its wording, it says what to fix.
         msg = str(err) if isinstance(err, RuntimeError) else _describe_fetch_error(err)
@@ -1301,6 +1307,9 @@ def _caldav_report(
             raw = resp.read()
             raw = decode_content_encoding(raw, str(resp.headers.get("Content-Encoding", "")))
     except Exception as err:
+        if isinstance(err, urllib.error.HTTPError):
+            with contextlib.suppress(Exception):
+                err.close()
         if error_out is not None:
             error_out.append(_describe_fetch_error(err))
         return None

--- a/plugins/picture_apod/server.py
+++ b/plugins/picture_apod/server.py
@@ -70,6 +70,8 @@ def fetch(
             entry = _api_request(api_key, when)
         except urllib.error.HTTPError as err:
             last_err = f"HTTP {err.code}: {err.reason}"
+            with contextlib.suppress(Exception):
+                err.close()
             break
         except Exception as err:
             last_err = f"{type(err).__name__}: {err}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.408.1"
+version = "0.408.2"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/uv.lock
+++ b/uv.lock
@@ -1977,7 +1977,7 @@ wheels = [
 
 [[package]]
 name = "tesserae"
-version = "0.408.1"
+version = "0.408.2"
 source = { editable = "." }
 dependencies = [
     { name = "amqtt" },


### PR DESCRIPTION
## What this changes

HTTPError holds an open response body (a NamedTemporaryFile on Python 3.14+). Close it explicitly so it doesn't surface as a ResourceWarning on GC (which pytest promotes to an error).

## Why

It made the pytest results difficult to debug because it wasn't a real error / failure

## Test plan

<!-- The commands you ran and what you verified. Reviewers should be
able to repeat this. Skip the obvious (don't say "ran the tests") and
call out what's *not* covered by automated tests, UI, hardware,
manual flows. -->

- [x] `pytest -q`
- [x] `ruff check . && ruff format --check .`
- [x] `mypy app`

## Checklist

- [x] `ruff` + `mypy` clean
- [x] `pyproject.toml` version bumped if this is going to be tagged
