### PR TITLE
fix(rest): clear the scheduler tick when waking a device for a lineup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Fixed
 
+- A sleeping REST device woken for a daily lineup no longer collects the
+  previous day's frame. The device was told to poll 20 s after the lineup's
+  target, but the scheduler fires on a 30 s tick and renders each due lineup
+  in turn, so most mornings the poll landed before the new frame existed. The
+  miss then stuck: the projection reported the lineup as due now, a
+  fraction of a second in the past once truncated to the second, and the
+  poll path skipped it as stale and sent the device to sleep for its whole
+  interval on the old frame. The scheduler margin is now 70 s, and a change
+  overdue by less than a tick means "poll again after the margin".
+
 - The Location picker on the weather, sky, and sunrise widgets now accepts a
   pasted `lat, lon` pair. It only ever asked the city name search, which
   returned "No matches." for coordinates, so a spot with no nearby town could

--- a/app/rest_api.py
+++ b/app/rest_api.py
@@ -531,13 +531,24 @@ def _configured_poll_s(device: Device) -> int:
     return 60
 
 
-# Seconds to add to a projected content change before telling the client to
-# poll. The scheduler fires at the projected instant and the render itself is
-# a browser compose plus a quantize, so a client polling at exactly that
-# moment races the render and collects the *previous* frame. A margin costs
-# nothing (the device is asleep for it) and turns a guaranteed miss into a
-# hit.
+# Seconds to add to a widget's declared change before telling the client to
+# poll. The render is a browser compose plus a quantize, so a client polling
+# at exactly that moment races it and collects the *previous* frame. A margin
+# costs nothing (the device is asleep for it) and turns a guaranteed miss
+# into a hit. ``/frame`` also re-renders on demand once a declared change has
+# passed, so this only needs to cover the render itself.
 _CONTENT_POLL_MARGIN_S: int = 20
+
+# Seconds to add to a *scheduler-projected* change. The scheduler does not
+# fire at the projected instant: it wakes every ``tick_seconds`` (30 s, on a
+# phase set by when the process started), fires everything due in ascending
+# priority order, and each fire renders in turn, so a lineup due at 06:00:00
+# lands anywhere up to ~40 s later on a busy tick. A device told to come back
+# at 06:00:20 polled before the frame existed, collected yesterday's, and
+# slept its whole configured interval on it. The margin has to clear a full
+# tick plus the renders that share it.
+_SCHEDULER_TICK_S: int = 30
+_PROJECTED_POLL_MARGIN_S: int = _SCHEDULER_TICK_S + 2 * _CONTENT_POLL_MARGIN_S
 
 # Never ask a client to poll faster than this, however close the next change
 # is. Itself clamped by the configured interval below, so a deliberately
@@ -591,9 +602,16 @@ def _projected_poll_s(device: Device, configured_s: int) -> int | None:
         if event.certainty not in _WAKE_WORTHY_CERTAINTIES:
             continue
         delta = (event.scheduled_at - now).total_seconds()
-        if delta < 0:
+        # A record whose target has passed but which has not fired yet is
+        # projected at "now" (the next tick fires it). It reaches here a
+        # fraction of a second in the past, because ``scheduled_at`` is
+        # truncated to whole seconds, and used to be skipped as stale, so a
+        # device that polled a moment before the tick was told to sleep its
+        # whole interval on the old frame. Anything overdue by less than a
+        # tick is imminent: poll again after the margin.
+        if delta < -_SCHEDULER_TICK_S:
             continue
-        return int(delta) + _CONTENT_POLL_MARGIN_S
+        return max(0, int(delta)) + _PROJECTED_POLL_MARGIN_S
     return None
 
 

--- a/docs/dev/client-protocol.md
+++ b/docs/dev/client-protocol.md
@@ -1556,7 +1556,13 @@ the next poll earlier.
   against the next projected content change**. If a bound schedule or
   rotation step is due in 2 minutes and the configured interval is 15,
   you're told to come back in about 2 minutes, so you see the change on
-  the wake it happens rather than up to 15 minutes later.
+  the wake it happens rather than up to 15 minutes later. A margin of
+  70 s is added on top: the scheduler fires on a 30 s tick and each fire
+  renders in turn, so a poll landing exactly on the target would collect
+  the previous frame. A change the next tick is about to fire (its target
+  has just passed) is reported as due now, so a device that arrives a
+  moment early is told to poll again after the margin rather than sleep
+  its whole interval on the old frame.
 - The configured interval remains the ceiling. It's never extended,
   because manual Send, webhooks, Home Assistant events and data-change
   refreshes have no schedule to project, and a device sleeping past its
@@ -1571,7 +1577,8 @@ the next poll earlier.
   zero. A widget's `fetch()` may return `next_change_at` (ISO 8601 or a
   unix timestamp) meaning "what I just produced becomes wrong then". The
   soonest such value across the page feeds `next_poll_s` alongside the
-  schedule projection, under the same ceiling, floor and margin. Nothing
+  schedule projection, under the same ceiling and floor, with a shorter
+  20 s margin (there is no tick to clear, only the render). Nothing
   changes for a widget that doesn't return it.
 - **The frame is re-rendered when that moment has passed.** Waking at the
   right instant would otherwise achieve nothing, because `/frame` returns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.408.1"
+version = "0.408.2"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -2329,13 +2329,14 @@ def _set_sleep_interval(app: Flask, device_id: str, seconds: int) -> None:
 
 def test_next_poll_s_pulls_forward_to_a_projected_content_change(app: Flask) -> None:
     """#241: a dashboard change 120 s out beats the 900 s configured grid,
-    plus the render margin so the client doesn't race the compose."""
+    plus the scheduler margin so the client doesn't race the tick and the
+    compose."""
     client, token = _paired_client(app)
     _set_sleep_interval(app, "poll_panel", 900)
     app.config["SCHEDULER"] = _StubScheduler([_StubEvent(in_seconds=120)])
 
     poll = _poll_after_status(app, client, token)
-    assert 130 <= poll <= 141  # 120 + 20 margin, minus a second of test latency
+    assert 188 <= poll <= 190  # 120 + 70 margin, minus a second or two of test latency
 
 
 def test_next_poll_s_never_exceeds_the_configured_interval(app: Flask) -> None:
@@ -2431,18 +2432,44 @@ def test_next_poll_s_takes_the_first_wake_worthy_event(app: Flask) -> None:
         ],
     )
 
-    assert 210 <= _poll_after_status(app, client, token) <= 221
+    assert 268 <= _poll_after_status(app, client, token) <= 270  # 200 + 70 margin
 
 
 def test_next_poll_s_floors_an_imminent_change(app: Flask) -> None:
-    """A change one second away lands at the render margin, never below
+    """A change one second away lands at the scheduler margin, never below
     the content floor."""
     client, token = _paired_client(app)
     _set_sleep_interval(app, "poll_panel", 900)
     app.config["SCHEDULER"] = _StubScheduler([_StubEvent(in_seconds=1)])
 
     poll = _poll_after_status(app, client, token)
-    assert 20 <= poll <= 21  # ~1 s out + 20 s render margin
+    assert 70 <= poll <= 71  # ~1 s out + 70 s scheduler margin
+
+
+def test_next_poll_s_retries_a_change_the_next_tick_will_fire(app: Flask) -> None:
+    """A daily lineup whose target has just passed but which the 30 s tick
+    has not fired yet is projected at "now", which lands here a fraction of
+    a second in the past once ``scheduled_at`` is truncated to the second.
+    It used to be skipped as stale, so a device that polled a moment before
+    the tick (its own wake was projected from the same target) was told to
+    sleep its whole interval on the old frame. It is imminent: poll again
+    after the margin."""
+    client, token = _paired_client(app)
+    _set_sleep_interval(app, "poll_panel", 21600)
+    app.config["SCHEDULER"] = _StubScheduler([_StubEvent(in_seconds=-0.5)])
+
+    poll = _poll_after_status(app, client, token)
+    assert 69 <= poll <= 70  # overdue clamps to 0 + 70 s scheduler margin
+
+
+def test_next_poll_s_still_ignores_a_stale_projection(app: Flask) -> None:
+    """Overdue by more than a tick is not "about to fire", it is a
+    projection the engine has moved past; the configured interval stands."""
+    client, token = _paired_client(app)
+    _set_sleep_interval(app, "poll_panel", 900)
+    app.config["SCHEDULER"] = _StubScheduler([_StubEvent(in_seconds=-120)])
+
+    assert _poll_after_status(app, client, token) == 900
 
 
 def test_next_poll_s_floor_never_slows_a_hot_polling_panel(app: Flask) -> None:
@@ -2472,23 +2499,25 @@ def test_next_poll_s_floor_does_not_hold_back_an_always_on_panel(app: Flask) -> 
     deliver."""
     client, token = _paired_client(app)
     _set_always_on(app, "poll_panel", 60)
-    app.config["SCHEDULER"] = _StubScheduler([_StubEvent(in_seconds=1)])
+    app.config["SCHEDULER"] = None
+    _set_widget_change(app, "poll_panel", time.time() + 1)
 
     poll = _poll_after_status(app, client, token)
-    # An imminent change resolves to the render margin (~20 s). The old floor
-    # would have rounded that up to 30; the awake floor leaves it alone.
+    # An imminent widget change resolves to the render margin (~20 s). The
+    # old floor would have rounded that up to 30; the awake floor leaves it
+    # alone.
     assert AWAKE_POLL_MIN_S <= poll < 30
 
 
 def test_next_poll_s_still_pulls_forward_for_an_always_on_panel(app: Flask) -> None:
     """Pull-forward survives the floor change: a change 25 s out beats the
-    60 s awake cadence rather than being rounded up to it."""
+    120 s awake cadence rather than being rounded up to it."""
     client, token = _paired_client(app)
-    _set_always_on(app, "poll_panel", 60)
+    _set_always_on(app, "poll_panel", 120)
     app.config["SCHEDULER"] = _StubScheduler([_StubEvent(in_seconds=25)])
 
     poll = _poll_after_status(app, client, token)
-    assert 35 <= poll <= 46  # 25 + 20 margin, capped by the 60 s cadence
+    assert 94 <= poll <= 95  # 25 + 70 margin, under the 120 s cadence
 
 
 def test_next_poll_s_falls_back_when_the_projection_raises(app: Flask) -> None:
@@ -2568,7 +2597,7 @@ def test_schedule_still_wins_when_it_is_sooner(app: Flask) -> None:
     app.config["SCHEDULER"] = _StubScheduler([_StubEvent(in_seconds=100)])
     _set_widget_change(app, "poll_panel", time.time() + 2000)
 
-    assert 110 <= _poll_after_status(app, client, token) <= 121
+    assert 169 <= _poll_after_status(app, client, token) <= 171
 
 
 def test_a_broken_projection_does_not_lose_the_widget_hint(app: Flask) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1977,7 +1977,7 @@ wheels = [
 
 [[package]]
 name = "tesserae"
-version = "0.408.1"
+version = "0.408.2"
 source = { editable = "." }
 dependencies = [
     { name = "amqtt" },


### PR DESCRIPTION
## What this changes

`next_poll_s` for a scheduler-projected change now carries a 70 s margin instead of 20 s, and a change overdue by less than a scheduler tick is treated as imminent ("poll again after the margin") instead of being skipped as stale. The 20 s widget-hint margin is unchanged, since `/frame` already re-renders on demand for those.

## Why

A sleeping REST device woken for a daily lineup collected the *previous* day's frame most mornings.

- `/status` told the device to come back 20 s after the lineup's target. But the scheduler fires on a 30 s tick whose phase is set by process start, then renders each due lineup in turn, so the new frame landed anywhere up to ~40 s after the target. The poll arrived before it existed.
- The miss then stuck. On that early poll the projection correctly reported the lineup as "due now" (the next tick fires it), but `scheduled_at` is truncated to whole seconds, so it reached `_projected_poll_s` a fraction of a second in the past, tripped `if delta < 0: continue`, and the device was told to sleep its whole configured interval on the old frame.

Observed on an Inkplate 10 (`esp32_bw_client`, 6 h `sleep_interval_s`, daily lineup at 06:00 Europe/London) over four mornings, from the battery history (every heartbeat) and the event log (every fire):

| Day | Device polled | Lineup rendered | Result |
|---|---|---|---|
| Mon | 06:00:22 | 06:00:24 | miss, fixed by button press |
| Tue | 06:00:26 | 06:00:14 | hit |
| Wed | 06:00:21 | 06:00:36 | miss, fixed by button press |
| Thu | 06:00:22 | 06:00:37 | miss, fixed by button press |

Each morning the device first woke at ~05:58 (its 6 h grid pulled forward), was told `next_poll_s` ≈ 110 (target + 20 s), came back at 06:00:2x, and then slept 21 600 s.

## Test plan

- [x] `pytest -q tests/test_rest_api.py tests/test_rest_always_on.py tests/test_wake_alignment.py tests/test_device_upcoming.py`
- [x] `ruff check . && ruff format --check .`
- [x] `mypy app`
- [x] New tests: an event 0.5 s overdue yields the margin rather than the configured interval; an event 120 s overdue is still ignored. Existing margin-pinned assertions updated from 20 to 70; the always-on floor test now exercises the widget-hint path, which is where the 20 s case still lives.
- [ ] Manually verified: deployed to the home server above. The real check is the Inkplate's next 06:00 wake landing on the fresh frame without a button press; not yet observed at the time of opening this PR.

Not covered by automated tests: the end-to-end timing against a real scheduler thread, which is what the hardware check above is for.

## Checklist

- [x] Tests added for new behaviour
- [x] `ruff` + `mypy` clean
- [x] User-facing changes documented (`docs/dev/client-protocol.md`, projection section)
- [x] CHANGELOG entry added under `## [Unreleased]`
- [x] `pyproject.toml` version bumped (0.408.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
