### PR TITLE
feat(i18n): translate weather_hourly to French

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Added
 
+- The weather_hourly widget's panel text (the icon-strip tooltips, the
+  Temperature/Rain %/Now legend, and the NOW chip) is now available in
+  French, following the same `locales` contract as weather_now and the
+  calendar_* widget family.
 - The Dashboards page has Active and Archived tabs. Archive parks a dashboard
   you're not using without deleting it: it keeps its layout, device links,
   and history, but leaves the "go to page" and lineup pickers, drops its

--- a/plugins/weather_hourly/client.js
+++ b/plugins/weather_hourly/client.js
@@ -38,6 +38,27 @@ const COND_ACCENT = {
   fog: "var(--text-muted)",
 };
 
+// Semantic icon name → strings/<locale>.json key for the icon strip's
+// tooltip (title attr). server.py's _icon_name() only exposes the
+// coarse icon name in the structured hoursArr (not the WMO code), so
+// this is icon-grained rather than per-code like weather_now's
+// COND_KEY_BY_CODE — sun/moon share "Clear", partly/partly-night share
+// "Partly cloudy". Same vocabulary as weather_now for consistency.
+const ICON_COND_KEY = {
+  sun: "cond_clear",
+  moon: "cond_clear",
+  cloud: "cond_overcast",
+  partly: "cond_partly_cloudy",
+  "partly-night": "cond_partly_cloudy",
+  drizzle: "cond_drizzle",
+  rain: "cond_rain",
+  "rain-heavy": "cond_rain_heavy",
+  showers: "cond_showers",
+  snow: "cond_snow",
+  storm: "cond_thunderstorm",
+  fog: "cond_fog",
+};
+
 function escapeHtml(s) {
   return String(s ?? "").replace(/[&<>"']/g, (c) => ({
     "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
@@ -134,13 +155,14 @@ function nightBandsPlugin(nightFlags, color) {
 
 export default function render(shadow, ctx) {
   const data = ctx?.data ?? {};
+  const t = ctx?.t || ((key, fallback) => fallback ?? key);
   const css = `<link rel="stylesheet" href="/static/style/spectra-widgets.css">`;
 
   if (data.error) {
     shadow.innerHTML = `
       ${css}
       <div class="w" data-widget="weather_hourly">
-        <div class="w-title"><i class="ph-bold ph-warning-circle"></i><h3>Hourly</h3></div>
+        <div class="w-title"><i class="ph-bold ph-warning-circle"></i><h3>${escapeHtml(t("hourly", "Hourly"))}</h3></div>
         <div class="w-body"><p class="u-muted">${escapeHtml(data.error)}</p></div>
       </div>`;
     return;
@@ -202,7 +224,9 @@ export default function render(shadow, ctx) {
           const ph = PH_BY_NAME[name] || "ph-cloud";
           const accent = COND_ACCENT[name] || "var(--text-secondary)";
           const isNow = i === 0;
-          return `<i class="ph-bold ${ph}" style="color:${isNow ? "var(--accent-1)" : accent}" title="${escapeHtml(name)}"></i>`;
+          const condKey = ICON_COND_KEY[name];
+          const condLabel = condKey ? t(condKey, name) : name;
+          return `<i class="ph-bold ${ph}" style="color:${isNow ? "var(--accent-1)" : accent}" title="${escapeHtml(condLabel)}"></i>`;
         }).join("")}
       </div>`
     : "";
@@ -211,9 +235,9 @@ export default function render(shadow, ctx) {
   const legend = showLegend
     ? `
       <div class="hr-legend">
-        <span class="hr-key"><span class="dot dot--temp"></span>Temperature</span>
-        ${hasRain ? '<span class="hr-key"><span class="dot dot--rain"></span>Rain %</span>' : ""}
-        <span class="hr-key"><i class="ph-bold ph-circle-fill hr-now-dot"></i>Now</span>
+        <span class="hr-key"><span class="dot dot--temp"></span>${escapeHtml(t("legend_temperature", "Temperature"))}</span>
+        ${hasRain ? `<span class="hr-key"><span class="dot dot--rain"></span>${escapeHtml(t("legend_rain", "Rain %"))}</span>` : ""}
+        <span class="hr-key"><i class="ph-bold ph-circle-fill hr-now-dot"></i>${escapeHtml(t("legend_now", "Now"))}</span>
       </div>`
     : "";
 
@@ -292,7 +316,7 @@ export default function render(shadow, ctx) {
   const rangeChip = (hi != null || lo != null || now != null)
     ? `
       <span class="hr-range">
-        ${now != null ? `<span class="now">${escapeHtml(fmtTemp(now))} NOW</span>` : ""}
+        ${now != null ? `<span class="now">${escapeHtml(fmtTemp(now))} ${escapeHtml(t("now_suffix", "NOW"))}</span>` : ""}
         ${hi != null && lo != null ? `<span class="sep">·</span><span class="hi">${escapeHtml(fmtTemp(hi))}</span><span class="sep">/</span><span class="lo">${escapeHtml(fmtTemp(lo))}</span>` : ""}
       </span>`
     : "";
@@ -316,7 +340,7 @@ export default function render(shadow, ctx) {
       ${css}
       <style>${layout}.hr-body{padding:var(--space-2)}.hr-chart{flex:1;min-height:0;height:100%;position:relative}</style>
       <div class="w" data-widget="weather_hourly"><div class="w-body hr-body">
-        <div class="hr-chart">${hasData ? '<canvas></canvas>' : '<p class="u-muted">No hourly data.</p>'}</div>
+        <div class="hr-chart">${hasData ? '<canvas></canvas>' : `<p class="u-muted">${escapeHtml(t("no_hourly_data", "No hourly data."))}</p>`}</div>
       </div></div>`;
   } else {
     shadow.innerHTML = `
@@ -325,13 +349,13 @@ export default function render(shadow, ctx) {
       <div class="w" data-widget="weather_hourly">
         <div class="w-title">
           <i class="ph-bold ph-clock" style="color:var(--accent-4)"></i>
-          <h3>${escapeHtml(label || "Hourly")}</h3>
+          <h3>${escapeHtml(label || t("hourly", "Hourly"))}</h3>
           ${rangeChip}
         </div>
         <div class="w-body hr-body">
           ${iconStrip}
           <div class="hr-chart">
-            ${hasData ? '<canvas></canvas>' : '<p class="u-muted">No hourly data.</p>'}
+            ${hasData ? '<canvas></canvas>' : `<p class="u-muted">${escapeHtml(t("no_hourly_data", "No hourly data."))}</p>`}
           </div>
           ${legend}
         </div>
@@ -341,7 +365,7 @@ export default function render(shadow, ctx) {
   if (!hasData) return;
   const canvas = shadow.querySelector("canvas");
   if (!canvas || !window.Chart) return;
-  const t = tokens(shadow.host);
+  const tok = tokens(shadow.host);
 
   // Warm-to-cool vertical gradient for both the line stroke and the
   // area fill. The gradient mirrors actual temperature intuition: the
@@ -353,11 +377,11 @@ export default function render(shadow, ctx) {
     return (ctxArg) => {
       const chart = ctxArg.chart;
       const area = chart.chartArea;
-      if (!area) return withAlpha(t.accent1, alpha);
+      if (!area) return withAlpha(tok.accent1, alpha);
       const g = chart.ctx.createLinearGradient(0, area.top, 0, area.bottom);
-      g.addColorStop(0, withAlpha(t.accent1, alpha));
-      g.addColorStop(0.55, withAlpha(t.accent2, alpha));
-      g.addColorStop(1, withAlpha(t.accent5, alpha));
+      g.addColorStop(0, withAlpha(tok.accent1, alpha));
+      g.addColorStop(0.55, withAlpha(tok.accent2, alpha));
+      g.addColorStop(1, withAlpha(tok.accent5, alpha));
       return g;
     };
   }
@@ -368,7 +392,7 @@ export default function render(shadow, ctx) {
       type: "bar",
       label: "Rain",
       data: rainValues,
-      backgroundColor: withAlpha(t.accent4, 0.35),
+      backgroundColor: withAlpha(tok.accent4, 0.35),
       borderWidth: 0,
       borderRadius: 0,
       categoryPercentage: 0.95,
@@ -396,10 +420,10 @@ export default function render(shadow, ctx) {
   // every other point (matches existing widget behaviour).
   datasets[datasets.length - 1].pointRadius = values.map((_, i) => (i === 0 ? 5 : 0));
   datasets[datasets.length - 1].pointBackgroundColor = values.map((_, i) =>
-    i === 0 ? t.accent1 : "transparent"
+    i === 0 ? tok.accent1 : "transparent"
   );
   datasets[datasets.length - 1].pointBorderColor = values.map((_, i) =>
-    i === 0 ? t.accent1 : "transparent"
+    i === 0 ? tok.accent1 : "transparent"
   );
 
   // Axis tick size, clamp against cqmin so wide cells get legible 16-
@@ -420,8 +444,8 @@ export default function render(shadow, ctx) {
       scales: {
         x: {
           ticks: {
-            color: t.textSecondary,
-            font: { family: t.fontFamily, weight: 700, size: tickFontSize },
+            color: tok.textSecondary,
+            font: { family: tok.fontFamily, weight: 700, size: tickFontSize },
             autoSkip: true,
             maxRotation: 0,
             autoSkipPadding: 8,
@@ -453,7 +477,7 @@ export default function render(shadow, ctx) {
       },
     },
     plugins: [
-      nightBandsPlugin(nightFlags, withAlpha(t.textPrimary, 0.07)),
+      nightBandsPlugin(nightFlags, withAlpha(tok.textPrimary, 0.07)),
     ],
   });
   canvas._chart = chart;

--- a/plugins/weather_hourly/plugin.json
+++ b/plugins/weather_hourly/plugin.json
@@ -5,6 +5,7 @@
   "kind": "widget",
   "description": "Hourly temperature line with a shaded area + condition-icon strip across the top. Defaults to the next 12 hours; configurable to 24 or 48. Data from Open-Meteo (no API key).",
   "icon": "ph-chart-line",
+  "locales": ["en", "fr"],
   "supports": {
     "sizes": [
       "xs",

--- a/plugins/weather_hourly/strings/en.json
+++ b/plugins/weather_hourly/strings/en.json
@@ -1,0 +1,18 @@
+{
+  "hourly": "Hourly",
+  "legend_temperature": "Temperature",
+  "legend_rain": "Rain %",
+  "legend_now": "Now",
+  "now_suffix": "NOW",
+  "no_hourly_data": "No hourly data.",
+  "cond_clear": "Clear",
+  "cond_overcast": "Overcast",
+  "cond_partly_cloudy": "Partly cloudy",
+  "cond_drizzle": "Drizzle",
+  "cond_rain": "Rain",
+  "cond_rain_heavy": "Heavy rain",
+  "cond_showers": "Showers",
+  "cond_snow": "Snow",
+  "cond_thunderstorm": "Thunderstorm",
+  "cond_fog": "Fog"
+}

--- a/plugins/weather_hourly/strings/fr.json
+++ b/plugins/weather_hourly/strings/fr.json
@@ -1,0 +1,18 @@
+{
+  "hourly": "Horaire",
+  "legend_temperature": "Température",
+  "legend_rain": "Pluie %",
+  "legend_now": "Maintenant",
+  "now_suffix": "ACTUEL",
+  "no_hourly_data": "Aucune donnée horaire.",
+  "cond_clear": "Dégagé",
+  "cond_overcast": "Couvert",
+  "cond_partly_cloudy": "Partiellement nuageux",
+  "cond_drizzle": "Bruine",
+  "cond_rain": "Pluie",
+  "cond_rain_heavy": "Pluie forte",
+  "cond_showers": "Averses",
+  "cond_snow": "Neige",
+  "cond_thunderstorm": "Orage",
+  "cond_fog": "Brouillard"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.408.1"
+version = "0.409.0"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/tests/test_weather_hourly_i18n.py
+++ b/tests/test_weather_hourly_i18n.py
@@ -1,0 +1,186 @@
+"""Locales contract for weather_hourly (docs/widgets.md#locales-strings).
+
+weather_hourly's translation was wired in 5e131171: title, legend, empty
+state, and the icon-strip condition tooltips (``ICON_COND_KEY`` in
+client.js). Before that commit the tooltips leaked raw semantic icon
+names ("rain-heavy") instead of the translated ``cond_*`` strings -- a
+typo in that mapping (or a key present in one locale file but not the
+other) would silently regress to the same thing and nothing would fail.
+These tests pin the static contract (en/fr key parity, every key
+client.js actually references exists in both files) plus one real
+end-to-end render proving the French strings reach the DOM, mirroring
+test_composer_locale.py's calendar_day pilot test.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+
+from app import plugin_loader
+from app.main import REPO_ROOT, create_app
+
+PLUGIN_DIR = REPO_ROOT / "plugins" / "weather_hourly"
+CLIENT_JS = (PLUGIN_DIR / "client.js").read_text(encoding="utf-8")
+
+
+def _strings(locale: str) -> dict[str, str]:
+    return json.loads((PLUGIN_DIR / "strings" / f"{locale}.json").read_text(encoding="utf-8"))
+
+
+def _manifest() -> dict:
+    return json.loads((PLUGIN_DIR / "plugin.json").read_text(encoding="utf-8"))
+
+
+# -- static contract: the strings/*.json files themselves ---------------
+
+
+def test_locales_declared_in_manifest_match_shipped_strings_files() -> None:
+    declared = set(_manifest()["locales"])
+    shipped = {p.stem for p in (PLUGIN_DIR / "strings").glob("*.json")}
+    assert declared == shipped
+
+
+def test_en_and_fr_strings_have_identical_key_sets() -> None:
+    """A key present in one locale but not the other resolves silently
+    (strings_for falls back to English, or the key just goes missing) --
+    this is the actual shape of the bug fixed on this branch, so pin
+    it as an equality check rather than a one-way subset."""
+    en_keys = set(_strings("en"))
+    fr_keys = set(_strings("fr"))
+    assert en_keys == fr_keys
+
+
+@pytest.mark.parametrize("locale", ["en", "fr"])
+def test_no_blank_translations(locale: str) -> None:
+    blanks = [k for k, v in _strings(locale).items() if not str(v).strip()]
+    assert blanks == [], f"blank {locale} translation(s): {blanks}"
+
+
+# -- client.js only asks for keys that actually exist --------------------
+
+# Literal ``t("key", "fallback text")`` calls -- excludes the one dynamic
+# call (``t(condKey, name)``), which is covered separately below via the
+# ICON_COND_KEY mapping it reads ``condKey`` from.
+_LITERAL_T_CALLS = re.compile(r't\("([a-zA-Z0-9_]+)",\s*"([^"]*)"\)')
+
+
+def test_every_literal_t_call_key_exists_in_both_locales() -> None:
+    calls = _LITERAL_T_CALLS.findall(CLIENT_JS)
+    assert calls, "no literal t(key, fallback) calls found -- did client.js change shape?"
+    en, fr = _strings("en"), _strings("fr")
+    for key, _fallback in calls:
+        assert key in en, f"t({key!r}, ...) has no strings/en.json entry"
+        assert key in fr, f"t({key!r}, ...) has no strings/fr.json entry"
+
+
+def test_literal_t_call_fallback_text_matches_shipped_english() -> None:
+    """The JS fallback (used when ctx.t is absent, e.g. an untranslated
+    embed) should read the same as the shipped English string, so the
+    two don't drift apart over time."""
+    en = _strings("en")
+    for key, fallback in _LITERAL_T_CALLS.findall(CLIENT_JS):
+        assert en[key] == fallback, (
+            f"t({key!r}, {fallback!r}) fallback text no longer matches "
+            f"strings/en.json ({en[key]!r})"
+        )
+
+
+def test_icon_condition_tooltip_keys_exist_in_both_locales() -> None:
+    """ICON_COND_KEY maps each icon name to a ``cond_*`` strings key,
+    read dynamically (``t(condKey, name)``) so the literal-call regex
+    above can't see it. This is exactly the mapping the fixed bug lived
+    in: a missing/mistyped cond_* key here degrades the icon-strip
+    tooltip to the raw icon name instead of translated text."""
+    block = re.search(r"const ICON_COND_KEY = \{(.*?)\};", CLIENT_JS, re.DOTALL)
+    assert block is not None, "ICON_COND_KEY mapping not found -- did client.js change shape?"
+    cond_keys = set(re.findall(r':\s*"([a-zA-Z0-9_]+)"', block.group(1)))
+    assert cond_keys, "no cond_* keys parsed out of ICON_COND_KEY"
+    en, fr = _strings("en"), _strings("fr")
+    for key in cond_keys:
+        assert key in en, f"ICON_COND_KEY value {key!r} has no strings/en.json entry"
+        assert key in fr, f"ICON_COND_KEY value {key!r} has no strings/fr.json entry"
+
+
+def test_every_icon_name_has_a_condition_key() -> None:
+    """PH_BY_NAME enumerates every icon name the icon strip can render;
+    every one of them must resolve to a tooltip key so none silently
+    falls back to showing the raw semantic name (the pre-fix bug)."""
+    ph_block = re.search(r"const PH_BY_NAME = \{(.*?)\};", CLIENT_JS, re.DOTALL)
+    cond_block = re.search(r"const ICON_COND_KEY = \{(.*?)\};", CLIENT_JS, re.DOTALL)
+    assert ph_block is not None and cond_block is not None
+    icon_names = set(re.findall(r'^\s*"?([a-zA-Z0-9_-]+)"?\s*:', ph_block.group(1), re.MULTILINE))
+    cond_names = set(re.findall(r'^\s*"?([a-zA-Z0-9_-]+)"?\s*:', cond_block.group(1), re.MULTILINE))
+    assert icon_names == cond_names
+
+
+# -- discovery: the real plugin loads clean with these strings files -----
+
+
+def test_weather_hourly_discovers_without_errors_and_resolves_french() -> None:
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        registry = plugin_loader.discover(
+            REPO_ROOT / "plugins",
+            schema_path=REPO_ROOT / "schema" / "plugin.schema.json",
+            data_root=Path(tmp),
+        )
+    assert not any(err.plugin_id == "weather_hourly" for err in registry.errors)
+    plugin = registry.plugins["weather_hourly"]
+    assert plugin.strings_for("fr") == _strings("fr")
+    assert plugin.strings_for("en") == _strings("en")
+    # An unshipped regional tag falls back to the base language.
+    assert plugin.strings_for("fr-CA") == _strings("fr")
+
+
+# -- end-to-end: the real composer pipeline, mirroring calendar_day's ----
+# pilot test in test_composer_locale.py.
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> Flask:
+    return create_app(testing=True, data_root=tmp_path, plugins_dir=REPO_ROOT / "plugins")
+
+
+@pytest.fixture
+def client(app: Flask) -> FlaskClient:
+    return app.test_client()
+
+
+def _cell_dataset(html: str, attr: str) -> str:
+    marker = f"data-{attr}="
+    idx = html.index(marker) + len(marker)
+    quote = html[idx]
+    start = idx + 1
+    end = html.index(quote, start)
+    return html[start:end]
+
+
+def test_weather_hourly_receives_its_real_french_strings(client: FlaskClient, app: Flask) -> None:
+    """No location is configured for this cell, so server.py's fetch()
+    returns its friendly {"error": ...} payload without touching the
+    network -- the render still carries the widget's full resolved
+    strings map regardless of whether the fetch succeeded."""
+    app.config["SETTINGS_STORE"].patch_section("app", {"locale": "fr"})
+    resp = client.get("/_test/render?plugin=weather_hourly&size=md")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert _cell_dataset(body, "locale") == "fr"
+    assert json.loads(_cell_dataset(body, "strings")) == _strings("fr")
+
+
+def test_weather_hourly_falls_back_to_english_by_default(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("LC_ALL", raising=False)
+    monkeypatch.delenv("LANG", raising=False)
+    resp = client.get("/_test/render?plugin=weather_hourly&size=md")
+    body = resp.get_data(as_text=True)
+    assert _cell_dataset(body, "locale") == "en"
+    assert json.loads(_cell_dataset(body, "strings")) == _strings("en")

--- a/uv.lock
+++ b/uv.lock
@@ -1977,7 +1977,7 @@ wheels = [
 
 [[package]]
 name = "tesserae"
-version = "0.408.1"
+version = "0.409.0"
 source = { editable = "." }
 dependencies = [
     { name = "amqtt" },


### PR DESCRIPTION
## What this changes

Translates the weather_hourly widget to french

## Why

Make the widget accessible to french speaking users

refs #279

## Test plan

<!-- The commands you ran and what you verified. Reviewers should be
able to repeat this. Skip the obvious (don't say "ran the tests") and
call out what's *not* covered by automated tests, UI, hardware,
manual flows. -->

- [x] `pytest -q`
- [x] `ruff check . && ruff format --check .`
- [x] `mypy app`
- [x] Manually verified: translations are accurate

## Checklist

- [x] Tests added for new behaviour (or note why none made sense)
- [x] `ruff` + `mypy` clean
- [x] CHANGELOG entry added under `## [Unreleased]` if user-facing
- [x] `pyproject.toml` version bumped if this is going to be tagged
