### PR TITLE
fix(quantizer): clamp diffused error so Jarvis and Stucki stop flooding flat regions

### DIFF
--- a/app/quantizer.py
+++ b/app/quantizer.py
@@ -1365,6 +1365,28 @@ def _error_diffusion(
             r = buf_r[idx]
             g = buf_g[idx]
             b = buf_b[idx]
+            # Clamp the diffused value to the displayable range before
+            # matching, as Pillow's Floyd-Steinberg does (CLIP8). Without
+            # this a flat field the palette cannot reach (white above the
+            # calibrated white, a saturated tone past the panel's hull)
+            # banks the same residual on every pixel; the wide kernels
+            # (Jarvis, Stucki) propagate all of it, so the running value
+            # climbs into the thousands and dumps into the next region as
+            # a wave-shaped swathe of solid black or white. Clamping bounds
+            # the error at +-255 per channel so it can only ever nudge a
+            # neighbour, never overwhelm it.
+            if r < 0.0:
+                r = 0.0
+            elif r > 255.0:
+                r = 255.0
+            if g < 0.0:
+                g = 0.0
+            elif g > 255.0:
+                g = 255.0
+            if b < 0.0:
+                b = 0.0
+            elif b > 255.0:
+                b = 255.0
             if use_lab:
                 # LAB nearest-palette. chroma_weight (2.0 for chroma-
                 # aware, 1.0 for plain LAB) biases towards preserving

--- a/tests/test_quantizer.py
+++ b/tests/test_quantizer.py
@@ -790,3 +790,33 @@ def test_circuitpython_guard_keeps_the_palette_attached() -> None:
     assert palette is not None
     flat = img.getpalette()[: len(palette) * 3]
     assert flat == [channel for entry in palette for channel in entry]
+
+
+@pytest.mark.parametrize("dither", ["jarvis", "stucki", "atkinson"])
+def test_error_diffusion_clamps_accumulated_error(dither: str) -> None:
+    """A flat region the palette cannot reach must not act as an error
+    reservoir. Before the clamp, every pixel of a 255-white field dithered
+    against a palette whose white is 200 banked +55 per channel with nowhere
+    to spend it; Jarvis and Stucki propagate all of it, so the running value
+    climbed into the thousands and then dumped into whatever came next,
+    painting a mid-grey strip solid white in a wave-shaped swathe. Pillow's
+    Floyd-Steinberg clips the pixel to 0-255 before matching (CLIP8), which
+    bounds the error by construction; the numpy loop now does the same."""
+    from app.quantizer import (
+        _ATKINSON_WEIGHTS,
+        _JJN_WEIGHTS,
+        _STUCKI_WEIGHTS,
+        _error_diffusion,
+    )
+
+    weights = {"jarvis": _JJN_WEIGHTS, "stucki": _STUCKI_WEIGHTS, "atkinson": _ATKINSON_WEIGHTS}
+    w, h, split = 200, 100, 60
+    arr = np.full((h, w, 3), 255, dtype=np.uint8)
+    arr[split:, :, :] = 100  # mid-grey strip under an out-of-gamut white field
+    palette = np.array([[0, 0, 0], [200, 200, 200]], dtype=np.float32)
+    raw = _error_diffusion(Image.fromarray(arr), palette, weights[dither])
+    out = np.frombuffer(raw, dtype=np.uint8).reshape(h, w)
+    # 100 sits at 50% of the 0..200 range, so the strip should come out
+    # roughly half black; the failure mode is a strip that is almost all white.
+    black_fraction = float((out[split:, :] == 0).mean())
+    assert 0.35 < black_fraction < 0.65, black_fraction


### PR DESCRIPTION
## Problem

Selecting **Jarvis-Judice-Ninke** (or **Stucki**) on a colour panel produces large flat swathes of a single colour, with the real image surviving only in pockets bounded by wave-shaped edges. Seen on an Inky Frame 7.3 (`inky_7colour`, `pico_bin` renderer) with a calibrated palette profile and the default-ish saturation/contrast boost; reproduced locally with the same settings against `upstream/main`:

![Jarvis and Stucki before and after the clamp, with a Floyd-Steinberg reference](https://raw.githubusercontent.com/partridgeworks/tesserae/a312bf36743aa6600b865824aa7f27d4fc5cb9c1/jarvis-clamp-before-after.png)

## Cause

The numpy error-diffusion loop in `_error_diffusion` never bounds the value a pixel has accumulated from its neighbours. A flat field the palette cannot reach (white above the calibrated white, a saturated sky or lawn outside the panel's hull, both routine once saturation and contrast run after the calibrated range squeeze) banks the same residual on every pixel with nowhere to spend it. Jarvis and Stucki propagate 100% of the error over a wide kernel, so the running value climbs into the thousands across an 800x480 frame (measured max |value| ≈ 2700 to 2900 on a 0 to 255 scale, with 40 to 60% of pixels far out of range) and then dumps into the next region as a solid swathe.

Atkinson discards a quarter of its error so it was only mildly affected. Pillow's Floyd-Steinberg clips each pixel to 0 to 255 before matching (`CLIP8`), which is why it never showed the problem.

## Fix

Clamp the diffused r/g/b to 0 to 255 after reading them and before the palette match and the error computation, the same way Pillow does. Bounded at ±255 per channel, error can only nudge a neighbour, never overwhelm it. Jarvis and Stucki now produce the same colour balance as Floyd-Steinberg on real content; the hot loop's cost is unchanged (≈1.8 s at 800x480 before and after).

Atkinson's output shifts very slightly as well, since its error also drifted a little past the displayable range; on the same test images it is visually indistinguishable.

## Tests

- New `test_error_diffusion_clamps_accumulated_error`, parametrised over jarvis / stucki / atkinson: a mid-grey strip under an out-of-gamut white field must dither to roughly half black. Fails on `main` for jarvis and stucki, passes for atkinson.
- `tests/test_quantizer.py`, `tests/test_bwry_calibration.py` and the bin renderer suites pass; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)