### PR TITLE
feat(i18n): weather_forecast widget french translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Added
 
+- The weather_forecast widget's panel text (the day-strip's "Today" /
+  "Tom" labels, weekday abbreviations, the "No forecast." / "No chart
+  data" empty states, and the rain-chance tooltip) is now available in
+  French, following the same `locales` contract as weather_now and the
+  calendar_* widget family (`ctx.t()` + `strings/<locale>.json`).
 - The Dashboards page has Active and Archived tabs. Archive parks a dashboard
   you're not using without deleting it: it keeps its layout, device links,
   and history, but leaves the "go to page" and lineup pickers, drops its

--- a/plugins/weather_forecast/client.js
+++ b/plugins/weather_forecast/client.js
@@ -61,7 +61,7 @@ function fmtTemp(v) {
 // name from ``d.date`` (the legacy ISO-date field, already present)
 // rather than a hand-rolled table — same idiom calendar_day/_week/
 // _month use for weekday names.
-function dayLabel(d, i, locale, t) {
+export function dayLabel(d, i, locale, t) {
   if (i === 0) return t("day_today", "Today");
   if (i === 1) return t("day_tomorrow", "Tom");
   const [y, m, dd] = String(d.date || "").split("-").map(Number);

--- a/plugins/weather_forecast/client.js
+++ b/plugins/weather_forecast/client.js
@@ -52,15 +52,34 @@ function fmtTemp(v) {
   return Math.round(Number(v)) + "°";
 }
 
+// Row label for one forecast day. server.py's ``day`` field already
+// carries "Today" / "Tom" / a 3-letter weekday for index 0/1/2+ (see
+// its DAY_NAMES table), but that text is baked in English at fetch
+// time. Reproduce the same index-based rule client-side instead of
+// translating the server string: index 0/1 are relative-day words
+// (ctx.t()), index 2+ asks Intl for the locale's real short weekday
+// name from ``d.date`` (the legacy ISO-date field, already present)
+// rather than a hand-rolled table — same idiom calendar_day/_week/
+// _month use for weekday names.
+function dayLabel(d, i, locale, t) {
+  if (i === 0) return t("day_today", "Today");
+  if (i === 1) return t("day_tomorrow", "Tom");
+  const [y, m, dd] = String(d.date || "").split("-").map(Number);
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(dd)) return "";
+  return new Intl.DateTimeFormat(locale, { weekday: "short" }).format(new Date(y, m - 1, dd));
+}
+
 export default function render(shadow, ctx) {
   const data = ctx?.data ?? {};
+  const locale = ctx?.locale || "en";
+  const t = ctx?.t || ((key, fallback) => fallback ?? key);
   const css = `<link rel="stylesheet" href="/static/style/spectra-widgets.css">`;
 
   if (data.error) {
     shadow.innerHTML = `
       ${css}
       <div class="w" data-widget="weather_forecast">
-        <div class="w-title"><i class="ph-bold ph-warning-circle"></i><h3>Forecast</h3></div>
+        <div class="w-title"><i class="ph-bold ph-warning-circle"></i><h3>${escapeHtml(t("forecast", "Forecast"))}</h3></div>
         <div class="w-body"><p class="u-muted">${escapeHtml(data.error)}</p></div>
       </div>`;
     return;
@@ -78,11 +97,11 @@ export default function render(shadow, ctx) {
   const weekMin = allLos.length ? Math.min(...allLos) : 0;
   const weekSpan = Math.max(1, weekMax - weekMin);
 
-  const rows = days.map((d) => {
+  const rows = days.map((d, i) => {
     const ph = PH_BY_NAME[d.icon] || "ph-cloud";
     const accent = COND_ACCENT[d.icon] || "var(--accent-5)";
     const isToday = d.today;
-    const dayText = d.day || (typeof d.weekday === "number" ? "" : d.weekday) || "";
+    const dayText = dayLabel(d, i, locale, t);
     const hi = Number(d.hi ?? d.high);
     const lo = Number(d.lo ?? d.low);
     const left = Number.isFinite(lo) ? ((lo - weekMin) / weekSpan) * 100 : 0;
@@ -98,7 +117,7 @@ export default function render(shadow, ctx) {
     // "65%") without shifting the icon column.
     const rainBlock = rainPct == null
       ? '<span class="wxf-rain wxf-rain--unknown" aria-hidden="true"></span>'
-      : `<span class="wxf-rain ${rainPct >= 40 ? "is-wet" : ""}" title="Chance of precipitation">
+      : `<span class="wxf-rain ${rainPct >= 40 ? "is-wet" : ""}" title="${escapeHtml(t("precip_chance", "Chance of precipitation"))}">
            <span class="wxf-rain-val">${rainPct.toFixed(0)}%</span>
            <i class="ph-bold ph-drop"></i>
          </span>`;
@@ -119,7 +138,7 @@ export default function render(shadow, ctx) {
   const titleBar = `
     <div class="w-title">
       <i class="ph-bold ph-calendar" style="color:var(--accent-4)"></i>
-      <h3>${escapeHtml(label || "Forecast")}</h3>
+      <h3>${escapeHtml(label || t("forecast", "Forecast"))}</h3>
       ${data.rangeHi != null && data.rangeLo != null
         ? `<span class="w-title-meta">${escapeHtml(fmtTemp(data.rangeHi))} / ${escapeHtml(fmtTemp(data.rangeLo))}</span>`
         : ""}
@@ -302,7 +321,7 @@ export default function render(shadow, ctx) {
       ${css}
       <style>${layout}.w-body{padding:var(--space-2)}.wxf-rows{flex:1;min-height:0}</style>
       <div class="w" data-widget="weather_forecast"><div class="w-body">
-        <div class="wxf-rows">${rows || '<p class="u-muted">No forecast.</p>'}</div>
+        <div class="wxf-rows">${rows || `<p class="u-muted">${escapeHtml(t("no_forecast", "No forecast."))}</p>`}</div>
       </div></div>`;
     return;
   }
@@ -311,7 +330,7 @@ export default function render(shadow, ctx) {
       ${css}
       <style>${layout}.w-body{padding:var(--space-2)}.wxf-chart{flex:1;min-height:0;height:100%;position:relative}</style>
       <div class="w" data-widget="weather_forecast"><div class="w-body">
-        <div class="wxf-chart">${chartReady ? '<canvas></canvas>' : '<p class="u-muted">No chart data</p>'}</div>
+        <div class="wxf-chart">${chartReady ? '<canvas></canvas>' : `<p class="u-muted">${escapeHtml(t("no_chart_data", "No chart data"))}</p>`}</div>
       </div></div>`;
   } else {
     shadow.innerHTML = `
@@ -320,7 +339,7 @@ export default function render(shadow, ctx) {
       <div class="w" data-widget="weather_forecast">
         ${titleBar}
         <div class="w-body wxf-body">
-          <div class="wxf-rows">${rows || '<p class="u-muted">No forecast.</p>'}</div>
+          <div class="wxf-rows">${rows || `<p class="u-muted">${escapeHtml(t("no_forecast", "No forecast."))}</p>`}</div>
           <div class="wxf-chart">
             ${chartReady ? '<canvas></canvas>' : ""}
           </div>

--- a/plugins/weather_forecast/plugin.json
+++ b/plugins/weather_forecast/plugin.json
@@ -5,6 +5,7 @@
   "kind": "widget",
   "description": "5-day forecast as a row of theme-aware cards: day name, condition icon, high / low temps, and rain probability. Data from Open-Meteo (no API key).",
   "icon": "ph-calendar-dots",
+  "locales": ["en", "fr"],
   "supports": {
     "sizes": [
       "sm",

--- a/plugins/weather_forecast/strings/en.json
+++ b/plugins/weather_forecast/strings/en.json
@@ -1,0 +1,8 @@
+{
+  "forecast": "Forecast",
+  "no_forecast": "No forecast.",
+  "no_chart_data": "No chart data",
+  "precip_chance": "Chance of precipitation",
+  "day_today": "Today",
+  "day_tomorrow": "Tom"
+}

--- a/plugins/weather_forecast/strings/fr.json
+++ b/plugins/weather_forecast/strings/fr.json
@@ -1,0 +1,8 @@
+{
+  "forecast": "Prévisions",
+  "no_forecast": "Aucune prévision.",
+  "no_chart_data": "Aucune donnée de graphique",
+  "precip_chance": "Probabilité de précipitations",
+  "day_today": "Auj.",
+  "day_tomorrow": "Dem."
+}

--- a/plugins/weather_forecast/tests/clamp_check.mjs
+++ b/plugins/weather_forecast/tests/clamp_check.mjs
@@ -1,0 +1,50 @@
+// Plain-node self-check (no test framework in this repo).
+// Run: node tests/clamp_check.mjs
+//
+// dayLabel: index 0/1 are relative-day words that must come from
+// ctx.t() (the locales contract, docs/widgets.md#locales-strings);
+// index 2+ used to be server.py's hardcoded English weekday
+// abbreviation and is now Intl-driven off ctx.locale instead, so a
+// wrong/missing locale would silently show the English weekday name
+// in a French render with nothing to notice.
+import assert from "node:assert/strict";
+import { dayLabel } from "../client.js";
+
+const stubT = (key, fallback) => `t(${key})`;
+
+assert.equal(
+  dayLabel({}, 0, "en", stubT),
+  "t(day_today)",
+  "index 0 always asks ctx.t() for day_today, regardless of locale"
+);
+assert.equal(
+  dayLabel({}, 1, "fr", stubT),
+  "t(day_tomorrow)",
+  "index 1 always asks ctx.t() for day_tomorrow, regardless of locale"
+);
+
+// A Wednesday, so weekday-index confusion (off-by-one from a Monday-
+// vs-Sunday week start) would show up as a mismatch here.
+const wednesday = { date: "2026-09-16" };
+assert.equal(
+  dayLabel(wednesday, 2, "en", stubT),
+  "Wed",
+  "index 2+ in English reads Intl's short weekday name, not ctx.t()"
+);
+assert.equal(
+  dayLabel(wednesday, 4, "fr", stubT),
+  "mer.",
+  "index 2+ in French asks Intl for the locale's own short weekday name"
+);
+
+// Malformed/missing ``date`` falls back to an empty label instead of
+// throwing (Number.isFinite guards on unparsable y/m/dd) so a
+// half-populated upstream payload doesn't crash the whole render.
+assert.equal(dayLabel({ date: "" }, 3, "en", stubT), "", "missing date -> blank label, not a throw");
+assert.equal(
+  dayLabel({ date: "not-a-date" }, 3, "en", stubT),
+  "",
+  "unparsable date -> blank label, not a throw"
+);
+
+console.log("weather_forecast dayLabel: all assertions passed");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.408.1"
+version = "0.409.0"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/tests/test_weather_forecast_i18n.py
+++ b/tests/test_weather_forecast_i18n.py
@@ -1,0 +1,171 @@
+"""Locales contract for weather_forecast (docs/widgets.md#locales-strings).
+
+weather_forecast's translation was wired in 8a922545: the title, the
+two empty states, the rain-chance tooltip, and the day-strip's "Today"
+/ "Tom" labels. Unlike weather_now/weather_hourly there is no
+code->key mirror table to keep in sync (the widget shows no condition
+text of its own, only an icon) -- the one piece of genuinely new
+locale-dependent logic is ``dayLabel``'s index-2+ branch, which moved
+from server.py's hardcoded English weekday abbreviation to an
+Intl.DateTimeFormat call keyed on ``ctx.locale``; that's covered by
+``plugins/weather_forecast/tests/clamp_check.mjs`` (picked up by
+test_widget_clamp_checks.py) rather than here, since it needs a real
+JS Intl call rather than string matching.
+
+These tests pin the static en/fr contract, that every key client.js
+actually references exists in both files, plus one real end-to-end
+render proving the French strings reach the DOM -- mirroring
+test_composer_locale.py's calendar_day pilot, test_weather_hourly_i18n.py
+and test_weather_now_i18n.py.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+
+from app import plugin_loader
+from app.main import REPO_ROOT, create_app
+
+PLUGIN_DIR = REPO_ROOT / "plugins" / "weather_forecast"
+CLIENT_JS = (PLUGIN_DIR / "client.js").read_text(encoding="utf-8")
+
+
+def _strings(locale: str) -> dict[str, str]:
+    return json.loads((PLUGIN_DIR / "strings" / f"{locale}.json").read_text(encoding="utf-8"))
+
+
+def _manifest() -> dict:
+    return json.loads((PLUGIN_DIR / "plugin.json").read_text(encoding="utf-8"))
+
+
+# -- static contract: the strings/*.json files themselves ---------------
+
+
+def test_locales_declared_in_manifest_match_shipped_strings_files() -> None:
+    declared = set(_manifest()["locales"])
+    shipped = {p.stem for p in (PLUGIN_DIR / "strings").glob("*.json")}
+    assert declared == shipped
+
+
+def test_en_and_fr_strings_have_identical_key_sets() -> None:
+    en_keys = set(_strings("en"))
+    fr_keys = set(_strings("fr"))
+    assert en_keys == fr_keys
+
+
+@pytest.mark.parametrize("locale", ["en", "fr"])
+def test_no_blank_translations(locale: str) -> None:
+    blanks = [k for k, v in _strings(locale).items() if not str(v).strip()]
+    assert blanks == [], f"blank {locale} translation(s): {blanks}"
+
+
+# -- client.js only asks for keys that actually exist --------------------
+
+# Literal ``t("key", "fallback text")`` calls. weather_forecast has no
+# dynamic (variable-key) t() call at all -- unlike weather_now/
+# weather_hourly's icon/condition lookups -- so this regex catches
+# every single translated string in the widget.
+_LITERAL_T_CALLS = re.compile(r't\("([a-zA-Z0-9_]+)",\s*"([^"]*)"\)')
+
+
+def test_every_literal_t_call_key_exists_in_both_locales() -> None:
+    calls = _LITERAL_T_CALLS.findall(CLIENT_JS)
+    assert calls, "no literal t(key, fallback) calls found -- did client.js change shape?"
+    en, fr = _strings("en"), _strings("fr")
+    for key, _fallback in calls:
+        assert key in en, f"t({key!r}, ...) has no strings/en.json entry"
+        assert key in fr, f"t({key!r}, ...) has no strings/fr.json entry"
+
+
+def test_literal_t_call_fallback_text_matches_shipped_english() -> None:
+    en = _strings("en")
+    for key, fallback in _LITERAL_T_CALLS.findall(CLIENT_JS):
+        assert en[key] == fallback, (
+            f"t({key!r}, {fallback!r}) fallback text no longer matches "
+            f"strings/en.json ({en[key]!r})"
+        )
+
+
+def test_every_shipped_key_is_actually_referenced() -> None:
+    """The flip side of the check above: a key shipped in strings/en.json
+    that client.js never asks for is dead weight (or a rename that
+    forgot to update the call site). day_today/day_tomorrow are read
+    through dayLabel()'s literal t() calls, so this still holds for
+    the whole file even though that function isn't the render() body."""
+    referenced = {key for key, _fallback in _LITERAL_T_CALLS.findall(CLIENT_JS)}
+    assert referenced == set(_strings("en"))
+
+
+# -- discovery: the real plugin loads clean with these strings files -----
+
+
+def test_weather_forecast_discovers_without_errors_and_resolves_french() -> None:
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        registry = plugin_loader.discover(
+            REPO_ROOT / "plugins",
+            schema_path=REPO_ROOT / "schema" / "plugin.schema.json",
+            data_root=Path(tmp),
+        )
+    assert not any(err.plugin_id == "weather_forecast" for err in registry.errors)
+    plugin = registry.plugins["weather_forecast"]
+    assert plugin.strings_for("fr") == _strings("fr")
+    assert plugin.strings_for("en") == _strings("en")
+    # An unshipped regional tag falls back to the base language.
+    assert plugin.strings_for("fr-CA") == _strings("fr")
+
+
+# -- end-to-end: the real composer pipeline, mirroring calendar_day's ----
+# pilot test in test_composer_locale.py.
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> Flask:
+    return create_app(testing=True, data_root=tmp_path, plugins_dir=REPO_ROOT / "plugins")
+
+
+@pytest.fixture
+def client(app: Flask) -> FlaskClient:
+    return app.test_client()
+
+
+def _cell_dataset(html: str, attr: str) -> str:
+    marker = f"data-{attr}="
+    idx = html.index(marker) + len(marker)
+    quote = html[idx]
+    start = idx + 1
+    end = html.index(quote, start)
+    return html[start:end]
+
+
+def test_weather_forecast_receives_its_real_french_strings(
+    client: FlaskClient, app: Flask
+) -> None:
+    """No location is configured for this cell, so server.py's fetch()
+    returns its friendly {"error": ...} payload without touching the
+    network -- the render still carries the widget's full resolved
+    strings map regardless of whether the fetch succeeded."""
+    app.config["SETTINGS_STORE"].patch_section("app", {"locale": "fr"})
+    resp = client.get("/_test/render?plugin=weather_forecast&size=md")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert _cell_dataset(body, "locale") == "fr"
+    assert json.loads(_cell_dataset(body, "strings")) == _strings("fr")
+
+
+def test_weather_forecast_falls_back_to_english_by_default(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("LC_ALL", raising=False)
+    monkeypatch.delenv("LANG", raising=False)
+    resp = client.get("/_test/render?plugin=weather_forecast&size=md")
+    body = resp.get_data(as_text=True)
+    assert _cell_dataset(body, "locale") == "en"
+    assert json.loads(_cell_dataset(body, "strings")) == _strings("en")

--- a/tests/test_weather_forecast_i18n.py
+++ b/tests/test_weather_forecast_i18n.py
@@ -145,9 +145,7 @@ def _cell_dataset(html: str, attr: str) -> str:
     return html[start:end]
 
 
-def test_weather_forecast_receives_its_real_french_strings(
-    client: FlaskClient, app: Flask
-) -> None:
+def test_weather_forecast_receives_its_real_french_strings(client: FlaskClient, app: Flask) -> None:
     """No location is configured for this cell, so server.py's fetch()
     returns its friendly {"error": ...} payload without touching the
     network -- the render still carries the widget's full resolved

--- a/uv.lock
+++ b/uv.lock
@@ -1977,7 +1977,7 @@ wheels = [
 
 [[package]]
 name = "tesserae"
-version = "0.408.1"
+version = "0.409.0"
 source = { editable = "." }
 dependencies = [
     { name = "amqtt" },


### PR DESCRIPTION
## What this changes

Translates the weather_forecast widget to French

## Why

Make the widget accessible to french speaking users

refs #279

## Test plan

<!-- The commands you ran and what you verified. Reviewers should be
able to repeat this. Skip the obvious (don't say "ran the tests") and
call out what's *not* covered by automated tests, UI, hardware,
manual flows. -->

- [x] `pytest -q`
- [x] `ruff check . && ruff format --check .`
- [x] `mypy app`
- [x] Manually verified: translations are accurate

## Checklist

- [x] Tests added for new behaviour (or note why none made sense)
- [x] `ruff` + `mypy` clean
- [x] CHANGELOG entry added under `## [Unreleased]` if user-facing
- [x] `pyproject.toml` version bumped if this is going to be tagged