### PR TITLE
feat(i18n): weather_now_scenic widget french translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to Tesserae are recorded here. Format loosely follows
 
 ### Added
 
+- The weather_now_scenic widget's panel text (the current-conditions label
+  and the error-state title) is now available in French, following the same
+  `locales` / `ctx.t()` contract as weather_now and the calendar_* widget
+  family (docs/widgets.md#locales-strings).
 - The Dashboards page has Active and Archived tabs. Archive parks a dashboard
   you're not using without deleting it: it keeps its layout, device links,
   and history, but leaves the "go to page" and lineup pickers, drops its

--- a/plugins/weather_now_scenic/client.js
+++ b/plugins/weather_now_scenic/client.js
@@ -133,6 +133,34 @@ const PRESETS = {
 
 const FALLBACK = PRESETS.cloudy_day;
 
+// WMO weather code → strings/<locale>.json key, mirrors server.py's
+// _WMO table 1:1 so a translated condition matches the exact English
+// text (``data.cond``) it replaces rather than a coarser icon-grouped
+// approximation. Keep in sync if server.py's _WMO table changes.
+const COND_KEY_BY_CODE = {
+  0: "cond_sunny",
+  1: "cond_mostly_clear",
+  2: "cond_partly_cloudy",
+  3: "cond_cloudy",
+  45: "cond_fog",
+  48: "cond_fog",
+  51: "cond_drizzle",
+  53: "cond_drizzle",
+  55: "cond_drizzle",
+  61: "cond_rain",
+  63: "cond_rain",
+  65: "cond_rain_heavy",
+  71: "cond_snow",
+  73: "cond_snow",
+  75: "cond_snow_heavy",
+  80: "cond_showers",
+  81: "cond_showers",
+  82: "cond_showers",
+  95: "cond_storm",
+  96: "cond_storm",
+  99: "cond_storm",
+};
+
 // --- scene builders -------------------------------------------------
 // Each returns an HTML fragment that renders inside .scene (absolutely
 // positioned behind the .content layer). Use inline SVG + CSS shapes
@@ -284,11 +312,12 @@ function sceneStorm() {
 
 export default function render(shadow, ctx) {
   const data = ctx?.data ?? {};
+  const t = ctx?.t || ((key, fallback) => fallback ?? key);
   if (data.error) {
     shadow.innerHTML = `
       <link rel="stylesheet" href="/static/style/spectra-widgets.css">
       <div class="w">
-        <div class="w-title"><i class="ph-bold ph-warning-circle"></i><h3>Weather</h3></div>
+        <div class="w-title"><i class="ph-bold ph-warning-circle"></i><h3>${escapeHtml(t("weather", "Weather"))}</h3></div>
         <div class="w-body"><p class="u-muted">${escapeHtml(data.error)}</p></div>
       </div>`;
     return;
@@ -297,7 +326,8 @@ export default function render(shadow, ctx) {
   const presetName = PRESETS[data.preset] ? data.preset : "cloudy_day";
   const preset = PRESETS[presetName] || FALLBACK;
   const temp = fmtTemp(data.temp);
-  const cond = data.cond || "";
+  const condKey = COND_KEY_BY_CODE[data.code];
+  const cond = condKey ? t(condKey, data.cond || "") : (data.cond || "");
   const label = data.label || "";
   const time = fmtTime();
   const date = fmtDate();

--- a/plugins/weather_now_scenic/plugin.json
+++ b/plugins/weather_now_scenic/plugin.json
@@ -5,6 +5,7 @@
   "kind": "widget",
   "description": "Current weather as a pill card with weather-and-time-of-day theming. Uses the extended palette opt-in so soft gradients (sunset, night sky) render on 7-colour e-ink panels via the renderer's dither pass. Data from Open-Meteo (no API key).",
   "icon": "ph-cloud-sun",
+  "locales": ["en", "fr"],
   "supports": {
     "sizes": [
       "sm",

--- a/plugins/weather_now_scenic/strings/en.json
+++ b/plugins/weather_now_scenic/strings/en.json
@@ -1,0 +1,15 @@
+{
+  "weather": "Weather",
+  "cond_sunny": "Sunny",
+  "cond_mostly_clear": "Mostly clear",
+  "cond_partly_cloudy": "Partly cloudy",
+  "cond_cloudy": "Cloudy",
+  "cond_fog": "Fog",
+  "cond_drizzle": "Drizzle",
+  "cond_rain": "Rain",
+  "cond_rain_heavy": "Heavy Rain",
+  "cond_snow": "Snow",
+  "cond_snow_heavy": "Heavy Snow",
+  "cond_showers": "Showers",
+  "cond_storm": "Storm"
+}

--- a/plugins/weather_now_scenic/strings/fr.json
+++ b/plugins/weather_now_scenic/strings/fr.json
@@ -1,0 +1,15 @@
+{
+  "weather": "Météo",
+  "cond_sunny": "Ensoleillé",
+  "cond_mostly_clear": "Généralement dégagé",
+  "cond_partly_cloudy": "Partiellement nuageux",
+  "cond_cloudy": "Nuageux",
+  "cond_fog": "Brouillard",
+  "cond_drizzle": "Bruine",
+  "cond_rain": "Pluie",
+  "cond_rain_heavy": "Pluie forte",
+  "cond_snow": "Neige",
+  "cond_snow_heavy": "Neige forte",
+  "cond_showers": "Averses",
+  "cond_storm": "Orage"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tesserae"
-version = "0.408.1"
+version = "0.409.0"
 description = "E-ink dashboard companion. Compose tile-based dashboards, render headless, push frames over MQTT."
 requires-python = ">=3.11"
 license = { text = "AGPL-3.0-or-later" }

--- a/tests/test_weather_now_scenic_i18n.py
+++ b/tests/test_weather_now_scenic_i18n.py
@@ -1,0 +1,198 @@
+"""Locales contract for weather_now_scenic (docs/widgets.md#locales-strings).
+
+weather_now_scenic's translation was wired in f045cc75: the error-state
+title and the WMO condition text (``COND_KEY_BY_CODE``), same idiom as
+weather_now (test_weather_now_i18n.py). Its own comment says so too:
+"mirrors server.py's _WMO table 1:1 ... keep in sync" -- a code added
+to (or removed from) server.py's ``_WMO`` table without a matching
+client.js entry would silently render server.py's untranslated English
+condition text in every non-English locale, with nothing to notice.
+
+These tests pin that mirror against server.py's real source (via
+``ast``, not string matching), plus the static en/fr contract and one
+real end-to-end render, mirroring test_composer_locale.py's
+calendar_day pilot and the other weather_* i18n test files.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+from pathlib import Path
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+
+from app import plugin_loader
+from app.main import REPO_ROOT, create_app
+
+PLUGIN_DIR = REPO_ROOT / "plugins" / "weather_now_scenic"
+CLIENT_JS = (PLUGIN_DIR / "client.js").read_text(encoding="utf-8")
+SERVER_AST = ast.parse((PLUGIN_DIR / "server.py").read_text(encoding="utf-8"))
+
+
+def _strings(locale: str) -> dict[str, str]:
+    return json.loads((PLUGIN_DIR / "strings" / f"{locale}.json").read_text(encoding="utf-8"))
+
+
+def _manifest() -> dict:
+    return json.loads((PLUGIN_DIR / "plugin.json").read_text(encoding="utf-8"))
+
+
+def _cond_key_by_code() -> dict[int, str]:
+    m = re.search(r"const COND_KEY_BY_CODE = \{(.*?)\};", CLIENT_JS, re.DOTALL)
+    assert m is not None, "COND_KEY_BY_CODE mapping not found -- did client.js change shape?"
+    pairs = re.findall(r"(\d+):\s*\"([a-zA-Z0-9_]+)\"", m.group(1))
+    assert pairs, "no entries parsed out of COND_KEY_BY_CODE"
+    return {int(code): key for code, key in pairs}
+
+
+def _server_wmo_codes() -> set[int]:
+    """The real ``_WMO`` dict's keys, read via ast so this can't drift
+    from a regex's idea of the table's shape. ``_WMO`` carries a type
+    annotation (``dict[int, tuple[str, str, str]]``), so it's an
+    ``AnnAssign`` node, not a plain ``Assign``."""
+    for node in ast.walk(SERVER_AST):
+        is_wmo_target = (
+            isinstance(node, ast.Assign)
+            and any(isinstance(t, ast.Name) and t.id == "_WMO" for t in node.targets)
+        ) or (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "_WMO"
+        )
+        if is_wmo_target and node.value is not None:
+            assert isinstance(node.value, ast.Dict)
+            return {k.value for k in node.value.keys if isinstance(k, ast.Constant)}
+    raise AssertionError("_WMO dict not found in server.py -- did it get renamed/moved?")
+
+
+# -- static contract: the strings/*.json files themselves ---------------
+
+
+def test_locales_declared_in_manifest_match_shipped_strings_files() -> None:
+    declared = set(_manifest()["locales"])
+    shipped = {p.stem for p in (PLUGIN_DIR / "strings").glob("*.json")}
+    assert declared == shipped
+
+
+def test_en_and_fr_strings_have_identical_key_sets() -> None:
+    en_keys = set(_strings("en"))
+    fr_keys = set(_strings("fr"))
+    assert en_keys == fr_keys
+
+
+@pytest.mark.parametrize("locale", ["en", "fr"])
+def test_no_blank_translations(locale: str) -> None:
+    blanks = [k for k, v in _strings(locale).items() if not str(v).strip()]
+    assert blanks == [], f"blank {locale} translation(s): {blanks}"
+
+
+# -- client.js only asks for keys that actually exist --------------------
+
+# Literal ``t("key", "fallback text")`` calls -- excludes the one dynamic
+# call (``t(condKey, ...)``), covered separately below via
+# COND_KEY_BY_CODE, the mapping ``condKey`` is read from.
+_LITERAL_T_CALLS = re.compile(r't\("([a-zA-Z0-9_]+)",\s*"([^"]*)"\)')
+
+
+def test_every_literal_t_call_key_exists_in_both_locales() -> None:
+    calls = _LITERAL_T_CALLS.findall(CLIENT_JS)
+    assert calls, "no literal t(key, fallback) calls found -- did client.js change shape?"
+    en, fr = _strings("en"), _strings("fr")
+    for key, _fallback in calls:
+        assert key in en, f"t({key!r}, ...) has no strings/en.json entry"
+        assert key in fr, f"t({key!r}, ...) has no strings/fr.json entry"
+
+
+def test_literal_t_call_fallback_text_matches_shipped_english() -> None:
+    en = _strings("en")
+    for key, fallback in _LITERAL_T_CALLS.findall(CLIENT_JS):
+        assert en[key] == fallback, (
+            f"t({key!r}, {fallback!r}) fallback text no longer matches "
+            f"strings/en.json ({en[key]!r})"
+        )
+
+
+def test_cond_key_by_code_values_exist_in_both_locales() -> None:
+    en, fr = _strings("en"), _strings("fr")
+    for code, key in _cond_key_by_code().items():
+        assert key in en, f"COND_KEY_BY_CODE[{code}] = {key!r} has no strings/en.json entry"
+        assert key in fr, f"COND_KEY_BY_CODE[{code}] = {key!r} has no strings/fr.json entry"
+
+
+def test_cond_key_by_code_covers_exactly_the_server_wmo_codes() -> None:
+    """The "keep in sync" comment above COND_KEY_BY_CODE, turned into
+    an assertion."""
+    assert set(_cond_key_by_code()) == _server_wmo_codes()
+
+
+# -- discovery: the real plugin loads clean with these strings files -----
+
+
+def test_weather_now_scenic_discovers_without_errors_and_resolves_french() -> None:
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        registry = plugin_loader.discover(
+            REPO_ROOT / "plugins",
+            schema_path=REPO_ROOT / "schema" / "plugin.schema.json",
+            data_root=Path(tmp),
+        )
+    assert not any(err.plugin_id == "weather_now_scenic" for err in registry.errors)
+    plugin = registry.plugins["weather_now_scenic"]
+    assert plugin.strings_for("fr") == _strings("fr")
+    assert plugin.strings_for("en") == _strings("en")
+    # An unshipped regional tag falls back to the base language.
+    assert plugin.strings_for("fr-CA") == _strings("fr")
+
+
+# -- end-to-end: the real composer pipeline, mirroring calendar_day's ----
+# pilot test in test_composer_locale.py.
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> Flask:
+    return create_app(testing=True, data_root=tmp_path, plugins_dir=REPO_ROOT / "plugins")
+
+
+@pytest.fixture
+def client(app: Flask) -> FlaskClient:
+    return app.test_client()
+
+
+def _cell_dataset(html: str, attr: str) -> str:
+    marker = f"data-{attr}="
+    idx = html.index(marker) + len(marker)
+    quote = html[idx]
+    start = idx + 1
+    end = html.index(quote, start)
+    return html[start:end]
+
+
+def test_weather_now_scenic_receives_its_real_french_strings(
+    client: FlaskClient, app: Flask
+) -> None:
+    """No location is configured for this cell, so server.py's fetch()
+    returns its friendly {"error": ...} payload without touching the
+    network -- the render still carries the widget's full resolved
+    strings map regardless of whether the fetch succeeded."""
+    app.config["SETTINGS_STORE"].patch_section("app", {"locale": "fr"})
+    resp = client.get("/_test/render?plugin=weather_now_scenic&size=md")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert _cell_dataset(body, "locale") == "fr"
+    assert json.loads(_cell_dataset(body, "strings")) == _strings("fr")
+
+
+def test_weather_now_scenic_falls_back_to_english_by_default(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("LC_ALL", raising=False)
+    monkeypatch.delenv("LANG", raising=False)
+    resp = client.get("/_test/render?plugin=weather_now_scenic&size=md")
+    body = resp.get_data(as_text=True)
+    assert _cell_dataset(body, "locale") == "en"
+    assert json.loads(_cell_dataset(body, "strings")) == _strings("en")

--- a/uv.lock
+++ b/uv.lock
@@ -1977,7 +1977,7 @@ wheels = [
 
 [[package]]
 name = "tesserae"
-version = "0.408.1"
+version = "0.409.0"
 source = { editable = "." }
 dependencies = [
     { name = "amqtt" },


### PR DESCRIPTION
## What this changes

Translates the weather_now_scenic widget to French

## Why

Make the widget accessible to french speaking users

refs #279

## Test plan

<!-- The commands you ran and what you verified. Reviewers should be
able to repeat this. Skip the obvious (don't say "ran the tests") and
call out what's *not* covered by automated tests, UI, hardware,
manual flows. -->

- [x] `pytest -q`
- [x] `ruff check . && ruff format --check .`
- [x] `mypy app`
- [x] Manually verified: translations are accurate

## Checklist

- [x] Tests added for new behaviour (or note why none made sense)
- [x] `ruff` + `mypy` clean
- [x] CHANGELOG entry added under `## [Unreleased]` if user-facing
- [x] `pyproject.toml` version bumped if this is going to be tagged